### PR TITLE
Update `swift-docc-plugin` to fix a non-sendable warning

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "944785f35daba39211e1c0033414cff9c136956de50baf611c6220a3ae0fa5bd",
+  "originHash" : "25d5d51d209538c87dc4d10dfb4a86bcaea48115381c502d5b148608a8edecf2",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
-        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
-        "version" : "1.4.3"
+        "revision" : "d1691545d53581400b1de9b0472d45eb25c19fed",
+        "version" : "1.4.4"
       }
     },
     {


### PR DESCRIPTION
This PR resolves warnings:
```
…/.build/checkouts/swift-docc-plugin/Plugins/Swift-DocC Preview/Symbolic Links/SwiftDocCPluginUtilities/BuildGraph/DocumentationBuildGraph.swift:106:17: warning: capture of non-sendable type 'Target.Type' in an isolated closure
104 |             // Copy the closure and the target into a block operation object
105 |             let new = BlockOperation { [work, task] in
106 |                 work(task)
    |                 `- warning: capture of non-sendable type 'Target.Type' in an isolated closure
107 |             }
108 |             operationsByID[task.id] = new

…/.build/checkouts/swift-docc-plugin/Plugins/Swift-DocC Preview/Symbolic Links/SwiftDocCPluginUtilities/BuildGraph/DocumentationBuildGraph.swift:105:41: warning: capture of non-sendable type 'Target.Type' in an isolated closure
103 |             }
104 |             // Copy the closure and the target into a block operation object
105 |             let new = BlockOperation { [work, task] in
    |                                         `- warning: capture of non-sendable type 'Target.Type' in an isolated closure
106 |                 work(task)
107 |             }
```