### PR TITLE
Add module description for ContainerizationEXT4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -110,6 +110,10 @@ let package = Package(
                 .target(name: "ContainerizationArchive", condition: .when(platforms: [.macOS])),
                 .product(name: "SystemPackage", package: "swift-system"),
                 "ContainerizationOS",
+            ],
+            path: "Sources/ContainerizationEXT4",
+            exclude: [
+                "README.md"
             ]
         ),
         .testTarget(

--- a/Sources/ContainerizationEXT4/Documentation.docc/ext4.md
+++ b/Sources/ContainerizationEXT4/Documentation.docc/ext4.md
@@ -1,0 +1,4 @@
+# ``ContainerizationEXT4``
+
+`ContainerizationEXT4` provides functionality to read the superblock of an existing ext4 block device and format a new block device with
+the ext4 file system.

--- a/Sources/ContainerizationEXT4/README.md
+++ b/Sources/ContainerizationEXT4/README.md
@@ -1,0 +1,4 @@
+# ``ContainerizationEXT4``
+
+`ContainerizationEXT4` provides functionality to read the superblock of an existing ext4 block device and format a new block device with
+the ext4 file system.


### PR DESCRIPTION
<img width="890" alt="image" src="https://github.com/user-attachments/assets/e6453be9-c439-469c-88f4-1cd92ad1aa6d" />

Aside from the content -- is this a pattern that we are happy to use for the remaining modules? I think we can add more content as well for the modules that we think could have the highest utility for developers.