### PR TITLE
Add branch protection to the test image build pipeline

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -32,31 +32,37 @@ jobs:
       contents: read
       packages: write 
     steps:
-    - name: Check inputs
-      run: |
-        if [ ${{ inputs.image }} == 'dockermanifestimage' ] && [ ${{ inputs.useBuildx }} == true ]; then
-          echo "dockermanifestimage cannot be built with buildx"
-          exit 1
-        fi 
+      - name: Check branch 
+        run: |
+          if [ '${{ github.ref }}' != 'refs/heads/main' ] && [[ '${{ github.ref }}' != 'refs/heads/release*' ]] && [ ${{ inputs.publish }} == true ]; then
+            echo "Cannot publish an image if we are not on main or a release branch."
+            exit 1
+          fi
+      - name: Check inputs
+        run: |
+          if [ ${{ inputs.image }} == 'dockermanifestimage' ] && [ ${{ inputs.useBuildx }} == true ]; then
+            echo "dockermanifestimage cannot be built with buildx"
+            exit 1
+          fi 
 
-        if [ ${{ inputs.image }} == 'emptyimage' ] && [ ${{ inputs.useBuildx}} != true ]; then
-          echo "emptyimage should be built with buildx"
-          exit 1
-        fi 
-    - name: Checkout repository
-      uses: actions/checkout@v4 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Set up Docker Buildx
-      if: ${{ inputs.useBuildx }} 
-      uses: docker/setup-buildx-action@v3
-    - name: Build dockerfile and push image
-      uses: docker/build-push-action@v6
-      with:
-        push: ${{ inputs.publish }}
-        context: Tests/TestImages/${{ inputs.image }}
-        tags: ghcr.io/apple/containerization/${{ inputs.image }}:${{ inputs.version }}
+          if [ ${{ inputs.image }} == 'emptyimage' ] && [ ${{ inputs.useBuildx}} != true ]; then
+            echo "emptyimage should be built with buildx"
+            exit 1
+          fi 
+      - name: Checkout repository
+        uses: actions/checkout@v4 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        if: ${{ inputs.useBuildx }} 
+        uses: docker/setup-buildx-action@v3
+      - name: Build dockerfile and push image
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ inputs.publish }}
+          context: Tests/TestImages/${{ inputs.image }}
+          tags: ghcr.io/apple/containerization/${{ inputs.image }}:${{ inputs.version }}

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -4,15 +4,10 @@ name: Deploy application website
 on: 
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-  pages: write
-
 jobs: 
   checkBranch:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'ref/heads/release')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')
     steps:
       - name: Branch validation 
         run: echo "Branch ${{ github.ref_name }} is allowed"
@@ -22,10 +17,18 @@ jobs:
     needs: checkBranch
     uses: ./.github/workflows/containerization-build-template.yml
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+      pages: write
 
   deployDocs:
     runs-on: ubuntu-latest
     needs: [checkBranch, buildSite]
+    permissions:
+      contents: read
+      packages: write
+      pages: write
 
     environment:
       name: github-pages


### PR DESCRIPTION
This adds branch protection to the workflow for building container test images. This PR additionally moves the permissions for docs deploying to be job level. 