### PR TITLE
Fix compiler warning in LocalOCILayoutClient

### DIFF
--- a/Sources/ContainerizationOCI/Client/LocalOCILayoutClient.swift
+++ b/Sources/ContainerizationOCI/Client/LocalOCILayoutClient.swift
@@ -72,7 +72,8 @@ package final class LocalOCILayoutClient: ContentClient {
     ) async throws where T.Element == ByteBuffer {
         let input = try streamGenerator()
 
-        try await self.cs.ingest { dir in
+        let (id, dir) = try await self.cs.newIngestSession()
+        do {
             let into = dir.appendingPathComponent(descriptor.digest.trimmingDigestPrefix)
             guard FileManager.default.createFile(atPath: into.path, contents: nil) else {
                 throw Error.cannotCreateFile
@@ -95,6 +96,9 @@ package final class LocalOCILayoutClient: ContentClient {
                     }
                 }
             }
+            try await self.cs.completeIngestSession(id)
+        } catch {
+            try await self.cs.cancelIngestSession(id)
         }
     }
 }


### PR DESCRIPTION
Resolves warning
```
LocalOCILayoutClient.swift:87:37: warning: capture of non-sendable type 'T.AsyncIterator.Type' in an isolated closure
 85 |             var hasher = SHA256()
 86 | 
 87 |             for try await buffer in input {
    |                                     `- warning: capture of non-sendable type 'T.AsyncIterator.Type' in an isolated closure
 88 |                 wrote += buffer.readableBytes
 89 |                 try buffer.withUnsafeReadableBytes { pointer in
```