### PR TITLE
UnixSocketConfiguration: Change from/to to source/destination

### DIFF
--- a/Sources/Containerization/Agent/Vminitd+SocketRelay.swift
+++ b/Sources/Containerization/Agent/Vminitd+SocketRelay.swift
@@ -28,10 +28,10 @@ extension Vminitd: SocketRelayAgent {
 
             switch configuration.direction {
             case .into:
-                $0.guestPath = configuration.to.path
+                $0.guestPath = configuration.destination.path
                 $0.action = .into
             case .outOf:
-                $0.guestPath = configuration.from.path
+                $0.guestPath = configuration.source.path
                 $0.action = .outOf
             }
         }

--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -738,9 +738,9 @@ extension LinuxContainer {
         let rootInGuest = URL(filePath: self.root)
 
         if socket.direction == .into {
-            socket.to = rootInGuest.appending(path: socket.to.path)
+            socket.destination = rootInGuest.appending(path: socket.destination.path)
         } else {
-            socket.from = rootInGuest.appending(path: socket.from.path)
+            socket.source = rootInGuest.appending(path: socket.source.path)
         }
 
         let port = self.hostVsockPorts.wrappingAdd(1, ordering: .relaxed).oldValue

--- a/Sources/Containerization/UnixSocketConfiguration.swift
+++ b/Sources/Containerization/UnixSocketConfiguration.swift
@@ -31,12 +31,12 @@ public struct UnixSocketConfiguration: Sendable {
     /// direction this should be the path on the host to a unix socket.
     /// For direction .outOf this should be the path in the container/guest
     /// to a unix socket.
-    public var from: URL
+    public var source: URL
 
     /// The path you'd like the socket to be relayed to. For .into
-    /// direction this should be ther path in the container/guest. For
+    /// direction this should be the path in the container/guest. For
     /// direction .outOf this should be the path on your host.
-    public var to: URL
+    public var destination: URL
 
     /// What to set the file permissions of the unix socket being created
     /// to. For .into direction this will be the socket in the guest. For
@@ -57,13 +57,13 @@ public struct UnixSocketConfiguration: Sendable {
     }
 
     public init(
-        host: URL,
+        source: URL,
         destination: URL,
         permissions: FilePermissions? = nil,
         direction: Direction = .into
     ) {
-        self.from = host
-        self.to = destination
+        self.source = source
+        self.destination = destination
         self.permissions = permissions
         self.direction = direction
     }

--- a/Sources/Containerization/UnixSocketRelay.swift
+++ b/Sources/Containerization/UnixSocketRelay.swift
@@ -144,14 +144,14 @@ extension SocketRelay {
         case .outOf:
             // If we created the host conn, lets unlink it also. It's possible it was
             // already unlinked if the relay failed earlier.
-            try? FileManager.default.removeItem(at: self.configuration.to)
+            try? FileManager.default.removeItem(at: self.configuration.destination)
         case .into:
             try self.vm.stopListen(self.port)
         }
     }
 
     private func setupHostVsockDial() async throws {
-        let hostConn = self.configuration.to
+        let hostConn = self.configuration.destination
 
         let socketType = try UnixType(
             path: hostConn.path,
@@ -181,7 +181,7 @@ extension SocketRelay {
     }
 
     private func setupHostVsockListener() throws {
-        let hostPath = self.configuration.from
+        let hostPath = self.configuration.source
         let port = self.port
         let log = self.log
 


### PR DESCRIPTION
This is something I forgot to update ages ago. The field names, while they do make sense, were different than the constructor names that eventually set the fields themselves. This is kind of awkward, and I'd much rather fix this now while it's much easier.

We'll need to update `container` after this