### PR TITLE
Containerization: Rename nat interfaces

### DIFF
--- a/Sources/Containerization/VMNetNATNetworkInterface.swift
+++ b/Sources/Containerization/VMNetNATNetworkInterface.swift
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Containerization project authors.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+#if os(macOS)
+
+import vmnet
+import Virtualization
+import ContainerizationError
+import Foundation
+import Synchronization
+
+/// A type that uses vmnet (https://developer.apple.com/documentation/vmnet)
+/// to provide a NAT interface for a given container/virtual machine.
+/// A `vmnet_network_ref` is provided to the type that should be pre-programmed
+/// by the client before passing to this class.
+@available(macOS 16, *)
+public final class VMNetNATNetworkInterface: Interface, Sendable {
+    public var address: String {
+        get { state.withLock { $0.address } }
+        set { state.withLock { $0.address = newValue } }
+    }
+
+    public var gateway: String {
+        get { state.withLock { $0.gateway } }
+        set { state.withLock { $0.gateway = newValue } }
+    }
+
+    public var macAddress: String? {
+        get { state.withLock { $0.macAddress } }
+        set { state.withLock { $0.macAddress = newValue } }
+    }
+
+    struct State {
+        var address: String
+        var gateway: String
+        var macAddress: String?
+        #if !CURRENT_SDK
+        var reference: vmnet_network_ref
+        #endif
+    }
+
+    #if !CURRENT_SDK
+    public var reference: vmnet_network_ref {
+        state.withLock { $0.reference }
+    }
+    #endif
+
+    private let state: Mutex<State>
+    #if !CURRENT_SDK
+    public init(
+        address: String,
+        gateway: String,
+        reference: sending vmnet_network_ref,
+        macAddress: String? = nil
+    ) {
+        self.state = .init(
+            .init(
+                address: address,
+                gateway: gateway,
+                macAddress: macAddress,
+                reference: reference
+            )
+        )
+    }
+    #else
+    public init(
+        address: String,
+        gateway: String,
+        macAddress: String? = nil
+    ) {
+        self.state = .init(
+            .init(
+                address: address,
+                gateway: gateway,
+                macAddress: macAddress
+            )
+        )
+    }
+    #endif
+}
+
+@available(macOS 16, *)
+extension VMNetNATNetworkInterface: VZInterface {
+    public func device() throws -> VZVirtioNetworkDeviceConfiguration {
+        let config = VZVirtioNetworkDeviceConfiguration()
+        if let macAddress = self.macAddress {
+            guard let mac = VZMACAddress(string: macAddress) else {
+                throw ContainerizationError(.invalidArgument, message: "invalid mac address \(macAddress)")
+            }
+            config.macAddress = mac
+        }
+
+        #if !CURRENT_SDK
+        config.attachment = VZVmnetNetworkDeviceAttachment(network: self.reference)
+        #else
+        config.attachment = VZNATNetworkDeviceAttachment()
+        #endif
+        return config
+    }
+}
+
+#endif

--- a/Sources/Containerization/VZInterface.swift
+++ b/Sources/Containerization/VZInterface.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Containerization project authors.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+#if os(macOS)
+import Virtualization
+
+/// A protocol to implement to convert your interface definition to
+/// Virtualization.framework's VZVirtioNetworkDeviceConfiguration.
+/// This is the definition Virtualization.framework uses to setup
+/// interfaces for virtual machines.
+public protocol VZInterface {
+    /// Return a valid `VZVirtioNetworkDeviceConfiguration`.
+    func device() throws -> VZVirtioNetworkDeviceConfiguration
+}
+
+#endif

--- a/Sources/Containerization/VZVirtualMachineInstance.swift
+++ b/Sources/Containerization/VZVirtualMachineInstance.swift
@@ -364,22 +364,4 @@ extension Kernel {
     }
 }
 
-public protocol VZInterface {
-    func device() throws -> VZVirtioNetworkDeviceConfiguration
-}
-
-extension NATInterface: VZInterface {
-    public func device() throws -> VZVirtioNetworkDeviceConfiguration {
-        let config = VZVirtioNetworkDeviceConfiguration()
-        if let macAddress = self.macAddress {
-            guard let mac = VZMACAddress(string: macAddress) else {
-                throw ContainerizationError(.invalidArgument, message: "invalid mac address \(macAddress)")
-            }
-            config.macAddress = mac
-        }
-        config.attachment = VZNATNetworkDeviceAttachment()
-        return config
-    }
-}
-
 #endif

--- a/Sources/cctl/RunCommand.swift
+++ b/Sources/cctl/RunCommand.swift
@@ -128,7 +128,7 @@ extension Application {
                 guard let gateway else {
                     throw ContainerizationError(.invalidArgument, message: "gateway must be specified")
                 }
-                container.interfaces.append(NATInterface(address: ip, gateway: gateway))
+                container.interfaces.append(VZNATInterface(address: ip, gateway: gateway))
                 container.dns = .init(nameservers: [gateway])
                 if nameservers.count > 0 {
                     container.dns = .init(nameservers: nameservers)


### PR DESCRIPTION
NOTE: This will be a breaking change and should be apart of a new 0.2.0 tag if we agree on this.

These were fairly generically named, and didn't give any hints to their ties to the various OS frameworks.