### PR TITLE
LinuxProcess: Resource adjustments

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -645,6 +645,9 @@ extension LinuxContainer {
             )
         }
 
+        // Lets free up the init procs resources, as this includes the open agent conn.
+        try? await startedState.process.delete()
+
         try await startedState.vm.stop()
         try state.stopped()
     }


### PR DESCRIPTION
- The kqueue handlers for stdio didn't have logic to exit on zero byte reads.
- The agent wasn't getting closed explicitly in .delete()
- In LinuxContainer we should call delete just for sanity, if for nothing more than ensuring the agent vsock fd is closed.