### PR TITLE
Remove image push tests

### DIFF
--- a/Tests/ContainerizationOCITests/RegistryClientTests.swift
+++ b/Tests/ContainerizationOCITests/RegistryClientTests.swift
@@ -166,7 +166,7 @@ struct OCIClientTests: ~Copyable {
         #expect(done)
     }
 
-    @Test(.enabled(if: hasRegistryCredentials))
+    @Test(.disabled("External users cannot push images, disable while we find a better solution"))
     func pushIndex() async throws {
         let client = RegistryClient(host: "ghcr.io", authentication: Self.authentication)
         let indexDescriptor = try await client.resolve(name: "apple/containerization/emptyimage", tag: "0.0.1")

--- a/Tests/ContainerizationTests/ImageTests/ImageStoreTests.swift
+++ b/Tests/ContainerizationTests/ImageTests/ImageStoreTests.swift
@@ -72,6 +72,14 @@ public class ImageStoreTests: ContainsAuth {
 
         let tempFile = self.dir.appending(path: "export.tar")
         try await self.store.save(references: [imageReference, expectedLoadedImage], out: tempFile)
+    }
+
+    @Test(.disabled("External users cannot push images, disable while we find a better solution"))
+    func testImageStorePush() async throws {
+        guard let authentication = Self.authentication else {
+            return
+        }
+        let imageReference = "ghcr.io/apple/containerization/dockermanifestimage:0.0.2"
 
         let remoteImageName = "ghcr.io/apple/test-images/image-push"
         let epoch = Int(Date().timeIntervalSince1970.description)


### PR DESCRIPTION
This removes two image push tests. We cannot have the CI push to our ghcr registry since external users do not have write access for pushing the image. We will explore a better solution. 