### PR TITLE
docs: Fix typo and broken nested list in kernel/README.md

### DIFF
--- a/kernel/README.md
+++ b/kernel/README.md
@@ -1,6 +1,6 @@
 # Containerization Kernel Configuration
 
-This directory includes an optimized kernel configuration to produce a fast and light weight kernel for container use.
+This directory includes an optimized kernel configuration to produce a fast and lightweight kernel for container use.
 
 
 - `config-arm64` includes the kernel `CONFIG_` options.
@@ -12,8 +12,11 @@ This directory includes an optimized kernel configuration to produce a fast and 
 
 1. Build the `Containerization` project by running `make` in the root of the repository.
 2. Place a kernel you want to use in `bin/vmlinux` directory of the repository.
+
     a. This kernel will be used to launch the build container.
+
     b. To fetch a default kernel run `make fetch-default-kernel` in the root of the repository.
 4. Run `make` in the `/kernel` directory. 
 
 A `kernel/vmlinux` will be the result of the build.
+


### PR DESCRIPTION
This change fixes a broken nested list and updates the phrase "light weight" for consistency with https://github.com/apple/containerization/pull/50.