### PR TITLE
Fix grammar: "speed of which" → "speed at which" in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Anything else that could enhance the project!
 
 To file a bug or feature request, use [GitHub issues](https://github.com/apple/containerization/issues/new).
 
-🚧 For unexpected behavior or usability limitations, detailed instructions on how to reproduce the issue are appreciated. This will greatly help the priority setting and speed of which maintainers can get to your issue.
+🚧 For unexpected behavior or usability limitations, detailed instructions on how to reproduce the issue are appreciated. This will greatly help the priority setting and speed at which maintainers can get to your issue.
 
 ### Pull Requests
 


### PR DESCRIPTION
## Summary
Corrects a grammatical error in CONTRIBUTING.md line 36.

## Change
**Line 36**: `speed of which` → `speed at which`

The preposition "of" is incorrect when connecting the noun "speed" with the relative pronoun "which". Standard English requires "at" (e.g., "the speed at which", "the rate at which").

**Before:**
```
This will greatly help the priority setting and speed of which maintainers can get to your issue.
```

**After:**
```
This will greatly help the priority setting and speed at which maintainers can get to your issue.
```