### PR TITLE
Add links in README to the various products

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,13 @@ Containerization is written in [Swift](https://www.swift.org) and uses [Virtuali
 
 Containerization provides APIs to:
 
-- Manage OCI images.
-- Interact with remote registries.
-- Create and populate ext4 file systems.
-- Interact with the Netlink socket family.
-- Create an optimized Linux kernel for fast boot times.
-- Spawn lightweight virtual machines.
-- Manage the runtime environment of virtual machines.
-- Spawn and interact with containerized processes.
+- [Manage OCI images](./Sources/ContainerizationOCI/).
+- [Interact with remote registries](./Sources/ContainerizationOCI/Client/).
+- [Create and populate ext4 file systems](./Sources/ContainerizationEXT4/).
+- [Interact with the Netlink socket family](./Sources/ContainerizationNetlink/).
+- [Create an optimized Linux kernel for fast boot times](./kernel/).
+- [Spawn lightweight virtual machines and manage the runtime environment](./Sources/Containerization/LinuxContainer.swift).
+- [Spawn and interact with containerized processes](./Sources/Containerization/LinuxProcess.swift).
 - Use Rosetta 2 for executing x86_64 processes on Apple silicon.
 
 Please view the [API documentation](https://apple.github.io/containerization/documentation/) for information on the Swift packages that Containerization provides.


### PR DESCRIPTION
It'd be useful in the blurb about what APIs the project contains to link to where the source for these features live in the project.

I'm not too worried about link rot, as while the APIs in the packages may change over time, the package names I'd imagine will stay static. I've also left off a link for rosetta as we don't really have a central spot to toggle it, it's split across a couple files/packages.