### PR TITLE
docs: Avoid using Latin abbreviations in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ for the squashed commit. Think of it as the single, definitive description of yo
 Before merging, we'll review the pull request title and body to ensure it:
 
 * Clearly and concisely describes the changes.
-* Uses the imperative mood (e.g., "Add feature," "Fix bug").
+* Uses the imperative mood (for example, "Add feature," "Fix bug").
 * Provides enough context for future developers to understand the purpose of the change.
 
 The pull request description should be concise and accurately describe the *what* and *why* of your changes.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,6 @@ Contributions to Containerization are welcomed and encouraged. Please see [CONTR
 
 Version 0.1.0 is the first official release of Containerization. Earlier versions have no source stability guarantees.
 
-Because the Containerization library is under active development, source stability is only guaranteed within minor versions (e.g. between 0.1.1 and 0.1.2). If you don't want potentially source-breaking package updates, you can specify your package dependency using .upToNextMinorVersion(from: "0.1.0") instead.
+Because the Containerization library is under active development, source stability is only guaranteed within minor versions (for example, between 0.1.1 and 0.1.2). If you don't want potentially source-breaking package updates, you can specify your package dependency using .upToNextMinorVersion(from: "0.1.0") instead.
 
 Future minor versions of the package may introduce changes to these rules as needed.


### PR DESCRIPTION
Remove Latin abbreviations from the documentation in accordance with the [Apple Style Guide](https://help.apple.com/applestyleguide/). This change does not impact any abbreviations used in code comments since those are not covered by the style guide.