### PR TITLE
Fix: `extended` in throughout the code

### DIFF
--- a/Sources/ContainerizationEXT4/EXT4+Export.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Export.swift
@@ -165,7 +165,12 @@ extension EXT4.EXT4Reader {
         try writer.finishEncoding()
     }
 
+    @available(*, deprecated, renamed: "readInlineExtendedAttributes(from:)")
     public static func readInlineExtenedAttributes(from buffer: [UInt8]) throws -> [EXT4.ExtendedAttribute] {
+        try readInlineExtendedAttributes(from: buffer)
+    }
+
+    public static func readInlineExtendedAttributes(from buffer: [UInt8]) throws -> [EXT4.ExtendedAttribute] {
         let header = UInt32(littleEndian: buffer[0...4].withUnsafeBytes { $0.load(as: UInt32.self) })
         if header != EXT4.XAttrHeaderMagic {
             throw EXT4.FileXattrsState.Error.missingXAttrHeader
@@ -173,7 +178,12 @@ extension EXT4.EXT4Reader {
         return try EXT4.FileXattrsState.read(buffer: buffer, start: 4, offset: 4)
     }
 
+    @available(*, deprecated, renamed: "readBlockExtendedAttributes(from:)")
     public static func readBlockExtenedAttributes(from buffer: [UInt8]) throws -> [EXT4.ExtendedAttribute] {
+        try readBlockExtendedAttributes(from: buffer)
+    }
+
+    public static func readBlockExtendedAttributes(from buffer: [UInt8]) throws -> [EXT4.ExtendedAttribute] {
         let header = UInt32(littleEndian: buffer[0...4].withUnsafeBytes { $0.load(as: UInt32.self) })
         if header != EXT4.XAttrHeaderMagic {
             throw EXT4.FileXattrsState.Error.missingXAttrHeader

--- a/Sources/ContainerizationEXT4/EXT4+Export.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Export.swift
@@ -50,7 +50,7 @@ extension EXT4.EXT4Reader {
             var attributes: [EXT4.ExtendedAttribute] = []
             let buffer: [UInt8] = EXT4.tupleToArray(inode.inlineXattrs)
             if !buffer.allZeros {
-                try attributes.append(contentsOf: Self.readInlineExtenedAttributes(from: buffer))
+                try attributes.append(contentsOf: Self.readInlineExtendedAttributes(from: buffer))
             }
             if inode.xattrBlockLow != 0 {
                 let block = inode.xattrBlockLow
@@ -58,7 +58,7 @@ extension EXT4.EXT4Reader {
                 guard let buffer = try self.handle.read(upToCount: Int(self.blockSize)) else {
                     throw EXT4.Error.couldNotReadBlock(block)
                 }
-                try attributes.append(contentsOf: Self.readBlockExtenedAttributes(from: [UInt8](buffer)))
+                try attributes.append(contentsOf: Self.readBlockExtendedAttributes(from: [UInt8](buffer)))
             }
 
             var xattrs: [String: Data] = [:]

--- a/Tests/ContainerizationEXT4Tests/TestEXT4ExtendedAttributes.swift
+++ b/Tests/ContainerizationEXT4Tests/TestEXT4ExtendedAttributes.swift
@@ -75,8 +75,8 @@ struct TestEXT4ExtendedAttribute {
         var blockAttrBuffer: [UInt8] = .init(repeating: 0, count: blockSize)
         try! state.writeInlineAttributes(buffer: &inlineAttrBuffer)
         try! state.writeBlockAttributes(buffer: &blockAttrBuffer)
-        let gotInlineXattrs = try! EXT4.EXT4Reader.readInlineExtenedAttributes(from: inlineAttrBuffer)
-        let gotBlockXattrs = try! EXT4.EXT4Reader.readBlockExtenedAttributes(from: blockAttrBuffer)
+        let gotInlineXattrs = try! EXT4.EXT4Reader.readInlineExtendedAttributes(from: inlineAttrBuffer)
+        let gotBlockXattrs = try! EXT4.EXT4Reader.readBlockExtendedAttributes(from: blockAttrBuffer)
 
         var gotXattrs: [String: Data] = [:]
         for attr in gotBlockXattrs + gotInlineXattrs {

--- a/Tests/ContainerizationEXT4Tests/TestFormatterUnpack.swift
+++ b/Tests/ContainerizationEXT4Tests/TestFormatterUnpack.swift
@@ -165,11 +165,11 @@ extension EXT4.EXT4Reader {
     fileprivate func getXattrsForInode(inode: EXT4.Inode) throws -> [String: Data] {
         var attributes: [EXT4.ExtendedAttribute] = []
         let buffer: [UInt8] = EXT4.tupleToArray(inode.inlineXattrs)
-        try attributes.append(contentsOf: Self.readInlineExtenedAttributes(from: buffer))
+        try attributes.append(contentsOf: Self.readInlineExtendedAttributes(from: buffer))
         let block = inode.xattrBlockLow
         try self.seek(block: block)
         let buf = try self.handle.read(upToCount: Int(self.blockSize))!
-        try attributes.append(contentsOf: Self.readBlockExtenedAttributes(from: [UInt8](buf)))
+        try attributes.append(contentsOf: Self.readBlockExtendedAttributes(from: [UInt8](buf)))
         var xattrs: [String: Data] = [:]
         for attribute in attributes {
             guard attribute.fullName != "system.data" else {


### PR DESCRIPTION
 - Corrected the typo in the method name (`Extened` → `Extended`)
 - Updated all references to reflect the corrected spelling
 - Introduced a `@available(*, deprecated)` alias for the original method to maintain backward compatibility, as it was part of the public API