### PR TITLE
fix: `structure` in createOCILayoutStructure

### DIFF
--- a/Sources/Containerization/Image/ImageStore/ImageStore+OCILayout.swift
+++ b/Sources/Containerization/Image/ImageStore/ImageStore+OCILayout.swift
@@ -62,7 +62,7 @@ extension ImageStore {
             client.setImageReferenceAnnotation(descriptor: &descriptor, reference: image.reference)
             saved.append(descriptor)
         }
-        try client.createOCILayoutStructre(directory: out, manifests: saved)
+        try client.createOCILayoutStructure(directory: out, manifests: saved)
     }
 
     /// Imports one or more images and their associated layers from an OCI Image Layout directory.

--- a/Sources/ContainerizationOCI/Client/LocalOCILayoutClient.swift
+++ b/Sources/ContainerizationOCI/Client/LocalOCILayoutClient.swift
@@ -132,7 +132,7 @@ extension LocalOCILayoutClient {
         return index
     }
 
-    package func createOCILayoutStructre(directory: URL, manifests: [Descriptor]) throws {
+    package func createOCILayoutStructure(directory: URL, manifests: [Descriptor]) throws {
         let fm = FileManager.default
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.withoutEscapingSlashes]


### PR DESCRIPTION
Both the callee and caller names have been corrected.

Since this is a package func, I haven’t soft-deprecated it (unlike what I did in [this PR](https://github.com/apple/containerization/pull/92)).
Please let me know if `deprecation` is still recommended in this case.

Thanks!