### PR TITLE
Remove most uses of env variables for image registries

### DIFF
--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -59,16 +59,6 @@ struct IntegrationSuite: AsyncParsableCommand {
         try! LocalContentStore(path: appRoot.appending(path: "content"))
     }()
 
-    private static var authentication: Authentication? {
-        let env = ProcessInfo.processInfo.environment
-        guard let password = env["REGISTRY_TOKEN"],
-            let username = env["REGISTRY_USERNAME"]
-        else {
-            return nil
-        }
-        return BasicAuthentication(username: username, password: password)
-    }
-
     private static let _imageStore: ImageStore = {
         try! ImageStore(
             path: appRoot,
@@ -169,7 +159,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             return try await store.get(reference: reference)
         } catch let error as ContainerizationError {
             if error.code == .notFound {
-                return try await store.pull(reference: reference, auth: Self.authentication)
+                return try await store.pull(reference: reference)
             }
             throw error
         }

--- a/Tests/ContainerizationOCITests/RegistryClientTests.swift
+++ b/Tests/ContainerizationOCITests/RegistryClientTests.swift
@@ -94,18 +94,16 @@ struct OCIClientTests: ~Copyable {
         try await client.ping()
     }
 
-    @Test(.enabled(if: hasRegistryCredentials))
-    func resolve() async throws {
-        let client = RegistryClient(host: "ghcr.io", authentication: Self.authentication)
+    @Test func resolve() async throws {
+        let client = RegistryClient(host: "ghcr.io")
         let descriptor = try await client.resolve(name: "apple/containerization/dockermanifestimage", tag: "0.0.2")
         #expect(descriptor.mediaType == MediaTypes.dockerManifest)
         #expect(descriptor.size != 0)
         #expect(!descriptor.digest.isEmpty)
     }
 
-    @Test(.enabled(if: hasRegistryCredentials))
-    func resolveSha() async throws {
-        let client = RegistryClient(host: "ghcr.io", authentication: Self.authentication)
+    @Test func resolveSha() async throws {
+        let client = RegistryClient(host: "ghcr.io")
         let descriptor = try await client.resolve(
             name: "apple/containerization/dockermanifestimage", tag: "sha256:c8d344d228b7d9a702a95227438ec0d71f953a9a483e28ffabc5704f70d2b61e")
         let namedDescriptor = try await client.resolve(name: "apple/containerization/dockermanifestimage", tag: "0.0.2")
@@ -115,27 +113,24 @@ struct OCIClientTests: ~Copyable {
         #expect(!descriptor.digest.isEmpty)
     }
 
-    @Test(.enabled(if: hasRegistryCredentials))
-    func fetchManifest() async throws {
-        let client = RegistryClient(host: "ghcr.io", authentication: Self.authentication)
+    @Test func fetchManifest() async throws {
+        let client = RegistryClient(host: "ghcr.io")
         let descriptor = try await client.resolve(name: "apple/containerization/dockermanifestimage", tag: "0.0.2")
         let manifest: Manifest = try await client.fetch(name: "apple/containerization/dockermanifestimage", descriptor: descriptor)
         #expect(manifest.schemaVersion == 2)
         #expect(manifest.layers.count == 1)
     }
 
-    @Test(.enabled(if: hasRegistryCredentials))
-    func fetchManifestAsData() async throws {
-        let client = RegistryClient(host: "ghcr.io", authentication: Self.authentication)
+    @Test func fetchManifestAsData() async throws {
+        let client = RegistryClient(host: "ghcr.io")
         let descriptor = try await client.resolve(name: "apple/containerization/dockermanifestimage", tag: "0.0.2")
         let manifestData = try await client.fetchData(name: "apple/containerization/dockermanifestimage", descriptor: descriptor)
         let checksum = SHA256.hash(data: manifestData)
         #expect(descriptor.digest == checksum.digest)
     }
 
-    @Test(.enabled(if: hasRegistryCredentials))
-    func fetchConfig() async throws {
-        let client = RegistryClient(host: "ghcr.io", authentication: Self.authentication)
+    @Test func fetchConfig() async throws {
+        let client = RegistryClient(host: "ghcr.io")
         let descriptor = try await client.resolve(name: "apple/containerization/dockermanifestimage", tag: "0.0.2")
         let manifest: Manifest = try await client.fetch(name: "apple/containerization/dockermanifestimage", descriptor: descriptor)
         let image: Image = try await client.fetch(name: "apple/containerization/dockermanifestimage", descriptor: manifest.config)
@@ -144,9 +139,8 @@ struct OCIClientTests: ~Copyable {
         #expect(image.rootfs.diffIDs.count == 1)
     }
 
-    @Test(.enabled(if: hasRegistryCredentials))
-    func fetchBlob() async throws {
-        let client = RegistryClient(host: "ghcr.io", authentication: Self.authentication)
+    @Test func fetchBlob() async throws {
+        let client = RegistryClient(host: "ghcr.io")
         let descriptor = try await client.resolve(name: "apple/containerization/dockermanifestimage", tag: "0.0.2")
         let manifest: Manifest = try await client.fetch(name: "apple/containerization/dockermanifestimage", descriptor: descriptor)
         var called = false
@@ -275,12 +269,10 @@ struct OCIClientTests: ~Copyable {
         )
     }
 
-    @Test(.enabled(if: hasRegistryCredentials))
-    func resolveWithRetry() async throws {
+    @Test func resolveWithRetry() async throws {
         let counter = Mutex(0)
         let client = RegistryClient(
             host: "ghcr.io",
-            authentication: Self.authentication,
             retryOptions: RetryOptions(
                 maxRetries: 3,
                 retryInterval: 500_000_000,

--- a/Tests/ContainerizationTests/ImageTests/ImageStoreImagePullTests.swift
+++ b/Tests/ContainerizationTests/ImageTests/ImageStoreImagePullTests.swift
@@ -26,7 +26,7 @@ import Testing
 @testable import Containerization
 
 @Suite
-final class ImageStoreImagePullTests: ContainsAuth {
+final class ImageStoreImagePullTests {
     let store: ImageStore
     let dir: URL
     let contentStore: ContentStore
@@ -44,9 +44,8 @@ final class ImageStoreImagePullTests: ContainsAuth {
         try! FileManager.default.removeItem(at: self.dir)
     }
 
-    @Test(.enabled(if: hasRegistryCredentials))
-    func testPullImageWithoutIndex() async throws {
-        let img = try await self.store.pull(reference: "ghcr.io/apple/containerization/dockermanifestimage:0.0.2", auth: Self.authentication)
+    @Test func testPullImageWithoutIndex() async throws {
+        let img = try await self.store.pull(reference: "ghcr.io/apple/containerization/dockermanifestimage:0.0.2")
 
         let rootDescriptor = img.descriptor
         let index: ContainerizationOCI.Index = try await contentStore.get(digest: rootDescriptor.digest)!
@@ -65,14 +64,13 @@ final class ImageStoreImagePullTests: ContainsAuth {
     }
 
     @Test(
-        .enabled(if: hasRegistryCredentials),
         arguments: [
             (Platform(arch: "arm64", os: "linux", variant: "v8"), imagePullArm64Layers),
             (Platform(arch: "amd64", os: "linux"), imagePullAmd64Layers),
             (nil, imagePullTestAllLayers),
         ])
     func testPullSinglePlatform(platform: Platform?, expectLayers: [String]) async throws {
-        let img = try await self.store.pull(reference: "ghcr.io/linuxcontainers/alpine:3.20", platform: platform, auth: Self.authentication)
+        let img = try await self.store.pull(reference: "ghcr.io/linuxcontainers/alpine:3.20", platform: platform)
         let rootDescriptor = img.descriptor
         let index: ContainerizationOCI.Index = try await contentStore.get(digest: rootDescriptor.digest)!
         var foundMatch = false
@@ -99,11 +97,10 @@ final class ImageStoreImagePullTests: ContainsAuth {
         #expect(filesOnDisk == expectLayers)
     }
 
-    @Test(.enabled(if: hasRegistryCredentials))
-    func testPullWithSha() async throws {
+    @Test func testPullWithSha() async throws {
         let sha = "sha256:0a6a86d44d7f93c4f2b8dea7f0eee64e72cb98635398779f3610949632508d57"
         let r = "ghcr.io/linuxcontainers/alpine:3.20@\(sha)"
-        let img = try await self.store.pull(reference: r, platform: .current, auth: Self.authentication)
+        let img = try await self.store.pull(reference: r, platform: .current)
         #expect(img.descriptor.digest == sha)
     }
 }


### PR DESCRIPTION
When we were testing the repo, we added authentication to most of the registry tests so that we could access private images. Now that the images are public, this PR removes the use of REGISTRY_TOKEN and REGISTRY_USERNAME in tests that no longer require authenticating. 

Note: REGISTRY_TOKEN, REGISTRY_USERNAME, and REGISTRY_HOST are still required in the CI to push images and for a few registry tests. So the env variables are not completely removed. The variables are only used in the test tool cctl and in our swift tests. 