### PR TITLE
gitignore: Remove editor specific git ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,6 @@ DerivedData/
 .swiftpm
 workdir/
 installer/
-.xcode/
-.vscode/
-.idea/
 .venv/
 test_results/
 *.pid

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,14 @@ Before merging, we'll review the pull request title and body to ensure it:
 
 The pull request description should be concise and accurately describe the *what* and *why* of your changes.
 
+#### .gitignore contributions
+
+We do not currently accept contributions to add editor specific additions to the root .gitignore. We urge contributors to make a global .gitignore file with their rulesets they may want to add instead. A global .gitignore file can be set like so:
+
+```bash
+git config --global core.excludesfile ~/.gitignore
+```
+
 #### Formatting Contributions
 
 Make sure your contributions are consistent with the rest of the project's formatting. You can do this using our Makefile:


### PR DESCRIPTION
These truthfully should be up to users to maintain, as trying to add everyones editor of choice config directories here isn't ideal.

This additionally adds a section in contributing on the new stance.