### PR TITLE
Add a way to detect if a process' io has completed

### DIFF
--- a/Sources/Containerization/LinuxProcess.swift
+++ b/Sources/Containerization/LinuxProcess.swift
@@ -339,7 +339,7 @@ extension LinuxProcess {
                 containerID: self.owningContainer,
                 timeoutInSeconds: timeoutInSeconds
             )
-            try await self.waitIoComplete()
+            await self.waitIoComplete()
             return code
         } catch {
             if error is ContainerizationError {
@@ -354,7 +354,7 @@ extension LinuxProcess {
     }
 
     /// Wait until the standard output and standard error streams for the process have concluded.
-    private func waitIoComplete() async throws {
+    private func waitIoComplete() async {
         let ioTracker = self.state.withLock { $0.ioTracker }
         guard let ioTracker else {
             return
@@ -370,8 +370,8 @@ extension LinuxProcess {
                     }
                 }
             }
-        } catch let err as CancellationError {
-            self.logger?.error("Timeout waiting for IO to complete for process \(id): \(err)")
+        } catch {
+            self.logger?.error("Timeout waiting for IO to complete for process \(id): \(error)")
         }
         self.state.withLock {
             $0.ioTracker = nil

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -200,7 +200,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             "process user": testProcessUser,
             "process home envvar": testProcessHomeEnvvar,
             "multiple concurrent processes": testMultipleConcurrentProcesses,
-            "multiple concurrent processes with output": testMultipleConcurrentProcessesOutput,
+            "multiple concurrent processes with output stress": testMultipleConcurrentProcessesOutputStress,
             "container hostname": testHostname,
             "container mount": testMounts,
             "nested virt": testNestedVirtualizationEnabled,

--- a/vminitd/Sources/vminitd/ProcessSupervisor.swift
+++ b/vminitd/Sources/vminitd/ProcessSupervisor.swift
@@ -98,7 +98,7 @@ actor ProcessSupervisor {
 
             return try process.start()
         } catch {
-            self.log?.error("process start failed \(error)")
+            self.log?.error("process \(process.id) start failed \(error)")
             throw error
         }
     }

--- a/vminitd/Sources/vminitd/ProcessSupervisor.swift
+++ b/vminitd/Sources/vminitd/ProcessSupervisor.swift
@@ -98,7 +98,7 @@ actor ProcessSupervisor {
 
             return try process.start()
         } catch {
-            self.log?.error("process \(process.id) start failed \(error)")
+            self.log?.error("process start failed \(error)", metadata: ["process-id": "\(process.id)"])
             throw error
         }
     }

--- a/vminitd/Sources/vminitd/StandardIO.swift
+++ b/vminitd/Sources/vminitd/StandardIO.swift
@@ -181,7 +181,10 @@ final class StandardIO: ManagedProcess.IO & Sendable {
         } catch {
             self.log?.error("failed to delete pipe fd from epoll \(readFd): \(error)")
         }
-        Foundation.close(writeFd)
+        if Foundation.close(writeFd) != 0 {
+            let err = POSIXError.fromErrno()
+            self.log?.error("failed to close write fd for StandardIO relay: \(String(describing:err))")
+        }
     }
 
     func close() throws {

--- a/vminitd/Sources/vminitd/StandardIO.swift
+++ b/vminitd/Sources/vminitd/StandardIO.swift
@@ -130,10 +130,9 @@ final class StandardIO: ManagedProcess.IO & Sendable {
 
         try ProcessSupervisor.default.poller.add(readFromFd, mask: EPOLLIN) { mask in
             if mask.isHangup && !mask.readyToRead {
-                self.cleanup(readFromFd, buffer: buf, log: self.log)
+                self.cleanupRelay(readFd: readFromFd, writeFd: writeToFd, buffer: buf, log: self.log)
                 return
             }
-
             // Loop so that in the case that someone wrote > buf.count down the pipe
             // we properly will drain it fully.
             while true {
@@ -147,7 +146,7 @@ final class StandardIO: ManagedProcess.IO & Sendable {
                     let w = writeTo.write(view)
                     if w.wrote != r.read {
                         self.log?.error("stopping relay: short write for stdio")
-                        self.cleanup(readFromFd, buffer: buf, log: self.log)
+                        self.cleanupRelay(readFd: readFromFd, writeFd: writeToFd, buffer: buf, log: self.log)
                         return
                     }
                 }
@@ -157,13 +156,13 @@ final class StandardIO: ManagedProcess.IO & Sendable {
                     self.log?.error("failed with errno \(errno) while reading for fd \(readFromFd)")
                     fallthrough
                 case .eof:
-                    self.cleanup(readFromFd, buffer: buf, log: self.log)
+                    self.cleanupRelay(readFd: readFromFd, writeFd: writeToFd, buffer: buf, log: self.log)
                     self.log?.debug("closing relay for \(readFromFd)")
                     return
                 case .again:
                     // We read all we could, exit.
                     if mask.isHangup {
-                        self.cleanup(readFromFd, buffer: buf, log: self.log)
+                        self.cleanupRelay(readFd: readFromFd, writeFd: writeToFd, buffer: buf, log: self.log)
                     }
                     return
                 default:
@@ -173,15 +172,16 @@ final class StandardIO: ManagedProcess.IO & Sendable {
         }
     }
 
-    func cleanup(_ fd: Int32, buffer: UnsafeMutableBufferPointer<UInt8>, log: Logger?) {
+    func cleanupRelay(readFd: Int32, writeFd: Int32, buffer: UnsafeMutableBufferPointer<UInt8>, log: Logger?) {
         do {
             // We could alternatively just allocate buffers in the constructor, and free them
             // on close().
             buffer.deallocate()
-            try ProcessSupervisor.default.poller.delete(fd)
+            try ProcessSupervisor.default.poller.delete(readFd)
         } catch {
-            self.log?.error("failed to delete pipe fd from epoll \(fd): \(error)")
+            self.log?.error("failed to delete pipe fd from epoll \(readFd): \(error)")
         }
+        Foundation.close(writeFd)
     }
 
     func close() throws {

--- a/vminitd/Sources/vminitd/TerminalIO.swift
+++ b/vminitd/Sources/vminitd/TerminalIO.swift
@@ -147,7 +147,10 @@ final class TerminalIO: ManagedProcess.IO & Sendable {
         } catch {
             self.log?.error("failed to delete pipe fd from epoll \(readFd): \(error)")
         }
-        Foundation.close(writeFd)
+        if Foundation.close(writeFd) != 0 {
+            let err = POSIXError.fromErrno()
+            self.log?.error("failed to close write fd for TerminalIO relay: \(String(describing:err))")
+        }
     }
 
     func close() throws {

--- a/vminitd/Sources/vminitd/TerminalIO.swift
+++ b/vminitd/Sources/vminitd/TerminalIO.swift
@@ -96,10 +96,9 @@ final class TerminalIO: ManagedProcess.IO & Sendable {
 
         try ProcessSupervisor.default.poller.add(readFromFd, mask: EPOLLIN) { mask in
             if mask.isHangup && !mask.readyToRead {
-                self.cleanup(readFromFd, buffer: buf, log: self.log)
+                self.cleanupRelay(readFd: readFromFd, writeFd: writeToFd, buffer: buf, log: self.log)
                 return
             }
-
             // Loop so that in the case that someone wrote > buf.count down the pipe
             // we properly will drain it fully.
             while true {
@@ -113,7 +112,7 @@ final class TerminalIO: ManagedProcess.IO & Sendable {
                     let w = writeTo.write(view)
                     if w.wrote != r.read {
                         self.log?.error("stopping relay: short write for stdio")
-                        self.cleanup(readFromFd, buffer: buf, log: self.log)
+                        self.cleanupRelay(readFd: readFromFd, writeFd: writeToFd, buffer: buf, log: self.log)
                         return
                     }
                 }
@@ -123,13 +122,13 @@ final class TerminalIO: ManagedProcess.IO & Sendable {
                     self.log?.error("failed with errno \(errno) while reading for fd \(readFromFd)")
                     fallthrough
                 case .eof:
-                    self.cleanup(readFromFd, buffer: buf, log: self.log)
+                    self.cleanupRelay(readFd: readFromFd, writeFd: writeToFd, buffer: buf, log: self.log)
                     self.log?.debug("closing relay for \(readFromFd)")
                     return
                 case .again:
                     // We read all we could, exit.
                     if mask.isHangup {
-                        self.cleanup(readFromFd, buffer: buf, log: self.log)
+                        self.cleanupRelay(readFd: readFromFd, writeFd: writeToFd, buffer: buf, log: self.log)
                     }
                     return
                 default:
@@ -139,15 +138,16 @@ final class TerminalIO: ManagedProcess.IO & Sendable {
         }
     }
 
-    func cleanup(_ fd: Int32, buffer: UnsafeMutableBufferPointer<UInt8>, log: Logger?) {
+    func cleanupRelay(readFd: Int32, writeFd: Int32, buffer: UnsafeMutableBufferPointer<UInt8>, log: Logger?) {
         do {
             // We could alternatively just allocate buffers in the constructor, and free them
             // on close().
             buffer.deallocate()
-            try ProcessSupervisor.default.poller.delete(fd)
+            try ProcessSupervisor.default.poller.delete(readFd)
         } catch {
-            self.log?.error("failed to delete pipe fd from epoll \(fd): \(error)")
+            self.log?.error("failed to delete pipe fd from epoll \(readFd): \(error)")
         }
+        Foundation.close(writeFd)
     }
 
     func close() throws {


### PR DESCRIPTION
This change adds a new private method  `waitIoComplete` on the `LinuxProcess` type.

This method is called internally when the user calls `wait` for a process - and it tries to give the IO streams some time to clear their buffers.

Internally, this method sets up an `AsyncStream` down which an item is sent when the vsock connection for either stdout/stderr is terminated.
We get this termination signal when the readability handler for the associated fd fires with a no available data.

Inside the guest - once we are done relaying the IO from the process into the socket connection, we close the socket fd which triggers the above.

All this logic is wrapped around a timeout of 3 seconds, just to ensure the method does not block forever.