### PR TITLE
More informative errors from RegistryClient

### DIFF
--- a/Sources/ContainerizationOCI/Client/RegistryClient+Fetch.swift
+++ b/Sources/ContainerizationOCI/Client/RegistryClient+Fetch.swift
@@ -49,7 +49,8 @@ extension RegistryClient {
         return try await request(components: components, method: .HEAD, headers: headers) { response in
             guard response.status == .ok else {
                 let url = components.url?.absoluteString ?? "unknown"
-                throw Error.invalidStatus(url: url, response.status)
+                let reason = await ErrorResponse.fromResponseBody(response.body)?.jsonString
+                throw Error.invalidStatus(url: url, response.status, reason: reason)
             }
 
             guard let digest = response.headers.first(name: "Docker-Content-Digest") else {
@@ -150,7 +151,8 @@ extension RegistryClient {
         try await request(components: components, headers: headers) { response in
             guard response.status == .ok else {
                 let url = components.url?.absoluteString ?? "unknown"
-                throw Error.invalidStatus(url: url, response.status)
+                let reason = await ErrorResponse.fromResponseBody(response.body)?.jsonString
+                throw Error.invalidStatus(url: url, response.status, reason: reason)
             }
 
             // How many bytes to expect

--- a/Sources/ContainerizationOCI/Client/RegistryClient+Push.swift
+++ b/Sources/ContainerizationOCI/Client/RegistryClient+Push.swift
@@ -93,7 +93,8 @@ extension RegistryClient {
                 }
             } else if response.status != .notFound {
                 let url = components.url?.absoluteString ?? "unknown"
-                throw Error.invalidStatus(url: url, response.status)
+                let reason = await ErrorResponse.fromResponseBody(response.body)?.jsonString
+                throw Error.invalidStatus(url: url, response.status, reason: reason)
             }
         }
 
@@ -114,7 +115,8 @@ extension RegistryClient {
                     throw ContainerizationError(.exists, message: "Content already exists \(descriptor.digest)")
                 default:
                     let url = components.url?.absoluteString ?? "unknown"
-                    throw Error.invalidStatus(url: url, response.status)
+                    let reason = await ErrorResponse.fromResponseBody(response.body)?.jsonString
+                    throw Error.invalidStatus(url: url, response.status, reason: reason)
                 }
 
                 // Get the location to upload the blob.
@@ -149,7 +151,8 @@ extension RegistryClient {
                 break
             default:
                 let url = components.url?.absoluteString ?? "unknown"
-                throw Error.invalidStatus(url: url, response.status)
+                let reason = await ErrorResponse.fromResponseBody(response.body)?.jsonString
+                throw Error.invalidStatus(url: url, response.status, reason: reason)
             }
 
             guard descriptor.digest == response.headers.first(name: "Docker-Content-Digest") else {

--- a/Sources/ContainerizationOCI/Client/RegistryClient.swift
+++ b/Sources/ContainerizationOCI/Client/RegistryClient.swift
@@ -235,7 +235,8 @@ public final class RegistryClient: ContentClient {
         try await request(components: components, method: .GET, headers: headers) { response in
             guard response.status == .ok else {
                 let url = components.url?.absoluteString ?? "unknown"
-                throw Error.invalidStatus(url: url, response.status)
+                let reason = await ErrorResponse.fromResponseBody(response.body)?.jsonString
+                throw Error.invalidStatus(url: url, response.status, reason: reason)
             }
 
             var body = try await response.body.collect(upTo: self.bufferSize)
@@ -263,7 +264,8 @@ public final class RegistryClient: ContentClient {
         try await request(components: components) { response in
             guard response.status == .ok else {
                 let url = components.url?.absoluteString ?? "unknown"
-                throw Error.invalidStatus(url: url, response.status)
+                let reason = await ErrorResponse.fromResponseBody(response.body)?.jsonString
+                throw Error.invalidStatus(url: url, response.status, reason: reason)
             }
         }
     }


### PR DESCRIPTION
Also creates an `ErrorResponse` type to model the errors typically returned by a container registry. 

Reference: https://distribution.github.io/distribution/spec/api/#errors

Example error message:
```
Error: HTTP request to https://ghcr.io/token?client_id=containerization-registry-client&service=ghcr.io&scope=repository:user/image:pull failed with response: 403 Forbidden. Reason: {"errors":[{"message":"requested access to the resource is denied","code":"DENIED"}]}
```