### PR TITLE
Fix `make release` goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_CONFIGURATION ?= debug
 # Commonly used locations
 SWIFT := "/usr/bin/swift"
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
-BUILD_BIN_DIR := $(shell $(SWIFT) build -c $(BUILD_CONFIGURATION) --show-bin-path)
+BUILD_BIN_DIR = $(shell $(SWIFT) build -c $(BUILD_CONFIGURATION) --show-bin-path)
 
 # Variables for libarchive integration
 LIBARCHIVE_UPSTREAM_REPO := https://github.com/libarchive/libarchive


### PR DESCRIPTION
We were using a := assignment for BUILD_BIN_DIR which evaluates any variables immediately. Our make release logic sets the envvar and then invokes `all` but at that point the value of BUILD_BIN_DIR has already been determined.