### PR TITLE
Containerization: Always set TERM

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ecb02e8bd5413f5287d7c7f236deef981e66bfaad51251787d448507e6ed2c17",
+  "originHash" : "de8e92cc53d3475bc48033bb3a62c1be5fff6cfaa8277de1d89f19524d834833",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -411,12 +411,15 @@ extension LinuxContainer {
         set { config.spec.process!.rlimits = newValue }
     }
 
-    /// Set a pty device as the container's stdio.
+    /// Set a pty device as the container's stdio. This additionally will
+    /// set the TERM=xterm environment variable, and the OCI runtime specs
+    /// `process.terminal` field to true.
     public var terminalDevice: Terminal? {
         get { config.terminal }
         set {
             config.spec.process!.terminal = newValue != nil ? true : false
             config.terminal = newValue
+            config.spec.process!.env.append("TERM=xterm")
             config.ioHandlers.stdin = newValue
             config.ioHandlers.stdout = newValue
             config.ioHandlers.stderr = nil
@@ -426,7 +429,10 @@ extension LinuxContainer {
     /// If the container has a pty allocated.
     public var terminal: Bool {
         get { config.spec.process!.terminal }
-        set { config.spec.process!.terminal = newValue }
+        set {
+            config.spec.process!.terminal = newValue
+            config.spec.process!.env.append("TERM=xterm")
+        }
     }
 
     /// Set the stdin stream for the initial process of the container.

--- a/Sources/Containerization/LinuxProcess.swift
+++ b/Sources/Containerization/LinuxProcess.swift
@@ -135,7 +135,12 @@ public final class LinuxProcess: Sendable {
     /// be attached to the Process's Standard I/O.
     public var terminal: Bool {
         get { state.withLock { $0.spec.process!.terminal } }
-        set { state.withLock { $0.spec.process!.terminal = newValue } }
+        set {
+            state.withLock {
+                $0.spec.process!.terminal = newValue
+                $0.spec.process!.env.append("TERM=xterm")
+            }
+        }
     }
 
     /// The User a Process should execute under.

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -200,6 +200,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             "process user": testProcessUser,
             "process home envvar": testProcessHomeEnvvar,
             "process custom home envvar": testProcessCustomHomeEnvvar,
+            "process tty ensure TERM": testProcessTtyEnvvar,
             "multiple concurrent processes": testMultipleConcurrentProcesses,
             "multiple concurrent processes with output stress": testMultipleConcurrentProcessesOutputStress,
             "container hostname": testHostname,

--- a/Sources/cctl/RunCommand.swift
+++ b/Sources/cctl/RunCommand.swift
@@ -100,7 +100,6 @@ extension Application {
 
             container.terminalDevice = current
             container.arguments = arguments
-            container.environment.append("TERM=xterm")
             container.workingDirectory = cwd
 
             for mount in self.mounts {

--- a/vminitd/Package.resolved
+++ b/vminitd/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e23def1de0482fe4a24b05d4808321638c41eab7d1ce2039d94cac24f8f4b2fc",
+  "originHash" : "ad8dec3662e872df8c3ddac4ec4c8531e98364117608a6d45321fb43e9d95a57",
   "pins" : [
     {
       "identity" : "async-http-client",

--- a/vminitd/Sources/vminitd/ManagedProcess.swift
+++ b/vminitd/Sources/vminitd/ManagedProcess.swift
@@ -104,7 +104,6 @@ final class ManagedProcess: Sendable {
             log.info("setting up terminal IO")
             let attrs = Command.Attrs(setsid: false, setctty: false)
             process.attrs = attrs
-            process.environment.append("TERM=xterm")
             io = try TerminalIO(
                 process: &process,
                 stdio: stdio,

--- a/vminitd/Sources/vminitd/Server+GRPC.swift
+++ b/vminitd/Sources/vminitd/Server+GRPC.swift
@@ -850,6 +850,15 @@ extension Initd {
             process.env.append("HOME=\(parsedUser.home)")
         }
 
+        // Defensive programming a tad, but ensure we have TERM set if
+        // the client requested a pty.
+        if process.terminal {
+            let termEnv = "TERM="
+            if !process.env.contains(where: { $0.hasPrefix(termEnv) }) {
+                process.env.append("TERM=xterm")
+            }
+        }
+
         ociSpec.process = process
     }
 }

--- a/vminitd/Sources/vminitd/TerminalIO.swift
+++ b/vminitd/Sources/vminitd/TerminalIO.swift
@@ -43,9 +43,12 @@ final class TerminalIO: ManagedProcess.IO & Sendable {
         self.log = log
 
         let ptyHandle = child.handle
-        process.stdin = stdio.stdin != nil ? ptyHandle : nil
+        let useHandles = stdio.stdin != nil || stdio.stdout != nil
+        // We currently set stdin to the controlling terminal always, so
+        // it must be a valid pty descriptor.
+        process.stdin = useHandles ? ptyHandle : nil
 
-        let stdoutHandle = stdio.stdout != nil ? ptyHandle : nil
+        let stdoutHandle = useHandles ? ptyHandle : nil
         process.stdout = stdoutHandle
         process.stderr = stdoutHandle
     }


### PR DESCRIPTION
Make sure we always set TERM for containers that ask for a tty. Right now this handling was spread around in a bunch of spots, but I'd wager setting it for the client on the host via LinuxContainer/Process is more sane and already what we do for a lot of the other fields.