### PR TITLE
limits buildAndTest to Apple repository

### DIFF
--- a/.github/workflows/containerization-build-template.yml
+++ b/.github/workflows/containerization-build-template.yml
@@ -15,6 +15,7 @@ on:
 jobs: 
   buildAndTest: 
     name: Build and Test repo
+    if: github.repository == 'apple/containerization'
     timeout-minutes: 60
     runs-on: [self-hosted, macos, sequoia, ARM64]
     permissions:


### PR DESCRIPTION
Constrains the buildAndTest job to only run on the `apple/containerization` repository due to Runner constraints.

Simplest solution - fixes #132 