### PR TITLE
Containerization: Reduce allocations for image subsystems

### DIFF
--- a/Sources/ContainerizationArchive/Reader.swift
+++ b/Sources/ContainerizationArchive/Reader.swift
@@ -101,9 +101,9 @@ extension ArchiveReader: Sequence {
 
     internal func readDataForEntry(_ entry: WriteEntry) -> Data {
         let bufferSize = Int(Swift.min(entry.size ?? 4096, 4096))
-        var data = Data()
+        var entry = Data()
+        var part = Data(count: bufferSize)
         while true {
-            var part = Data(count: bufferSize)
             let c = part.withUnsafeMutableBytes { buffer in
                 guard let baseAddress = buffer.baseAddress else {
                     return 0
@@ -112,9 +112,9 @@ extension ArchiveReader: Sequence {
             }
             guard c > 0 else { break }
             part.count = c
-            data.append(part)
+            entry.append(part)
         }
-        return data
+        return entry
     }
 }
 

--- a/Sources/ContainerizationEXT4/EXT4Reader+Export.swift
+++ b/Sources/ContainerizationEXT4/EXT4Reader+Export.swift
@@ -130,14 +130,14 @@ extension EXT4.EXT4Reader {
                 entry.fileType = .symbolicLink
                 if size < 60 {
                     let linkBytes = EXT4.tupleToArray(inode.block)
-                    entry.symlinkTarget = String(data: Data(linkBytes), encoding: .utf8) ?? ""
+                    entry.symlinkTarget = String(bytes: linkBytes, encoding: .utf8) ?? ""
                 } else {
                     if let block = item.blocks {
                         try self.seek(block: block.start)
                         guard let linkBytes = try self.handle.read(upToCount: Int(size)) else {
                             throw EXT4.Error.couldNotReadBlock(block.start)
                         }
-                        entry.symlinkTarget = String(data: Data(linkBytes), encoding: .utf8) ?? ""
+                        entry.symlinkTarget = String(bytes: linkBytes, encoding: .utf8) ?? ""
                     }
                 }
                 try writer.writeEntry(entry: entry, data: nil)


### PR DESCRIPTION
Continue the allocations journey for anything that is in the codepaths for pulling images. This time there's a couple spots in archive and ext4 we can get rid of some copies.