### PR TITLE
Better parsing for www-authenticate headers

### DIFF
--- a/Sources/ContainerizationOCI/Client/RegistryClient+Token.swift
+++ b/Sources/ContainerizationOCI/Client/RegistryClient+Token.swift
@@ -108,7 +108,7 @@ struct TokenResponse: Codable, Hashable {
     }
 }
 
-struct AuthenticateChallenge {
+struct AuthenticateChallenge: Equatable {
     let type: String
     let realm: String?
     let service: String?
@@ -158,7 +158,7 @@ extension RegistryClient {
     }
 
     internal func createTokenRequest(parsing authenticateHeaders: [String]) throws -> TokenRequest {
-        let parsedHeaders = parseWWWAuthenticateHeaders(headers: authenticateHeaders)
+        let parsedHeaders = Self.parseWWWAuthenticateHeaders(headers: authenticateHeaders)
         let bearerChallenge = parsedHeaders.first { $0.type == "Bearer" }
         guard let bearerChallenge else {
             throw ContainerizationError(.invalidArgument, message: "Missing Bearer challenge in \(TokenRequest.authenticateHeaderName) header")
@@ -174,11 +174,11 @@ extension RegistryClient {
         return tokenRequest
     }
 
-    internal func parseWWWAuthenticateHeaders(headers: [String]) -> [AuthenticateChallenge] {
+    internal static func parseWWWAuthenticateHeaders(headers: [String]) -> [AuthenticateChallenge] {
         var parsed: [String: [String: String]] = [:]
         for challenge in headers {
             let trimmedChallenge = challenge.trimmingCharacters(in: .whitespacesAndNewlines)
-            let parts = trimmedChallenge.split(separator: " ", maxSplits: 2)
+            let parts = trimmedChallenge.split(separator: " ", maxSplits: 1)
             guard parts.count == 2 else {
                 continue
             }

--- a/Tests/ContainerizationOCITests/AuthChallengeTests.swift
+++ b/Tests/ContainerizationOCITests/AuthChallengeTests.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Containerization project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerizationOCI
+
+struct AuthChallengeTests {
+    internal struct TestCase: Sendable {
+        let input: String
+        let expected: AuthenticateChallenge
+    }
+
+    private static let testCases: [TestCase] = [
+        .init(
+            input: """
+                Bearer realm="https://domain.io/token",service="domain.io",scope="repository:user/image:pull"
+                """,
+            expected: .init(type: "Bearer", realm: "https://domain.io/token", service: "domain.io", scope: "repository:user/image:pull", error: nil)),
+        .init(
+            input: """
+                Bearer realm="https://foo-bar-registry.com/auth",service="Awesome Registry"
+                """,
+            expected: .init(type: "Bearer", realm: "https://foo-bar-registry.com/auth", service: "Awesome Registry", scope: nil, error: nil)),
+        .init(
+            input: """
+                Bearer realm="users.example.com", scope="create delete"
+                """,
+            expected: .init(type: "Bearer", realm: "users.example.com", service: nil, scope: "create delete", error: nil)),
+        .init(
+            input: """
+                Bearer realm="https://auth.server.io/token",service="registry.server.io"
+                """,
+            expected: .init(type: "Bearer", realm: "https://auth.server.io/token", service: "registry.server.io", scope: nil, error: nil)),
+
+    ]
+
+    @Test(arguments: testCases)
+    func parseAuthHeader(testCase: TestCase) throws {
+        let challenges = RegistryClient.parseWWWAuthenticateHeaders(headers: [testCase.input])
+        #expect(challenges.count == 1)
+        #expect(challenges[0] == testCase.expected)
+    }
+}

--- a/Tests/ContainerizationOCITests/RegistryClientTests.swift
+++ b/Tests/ContainerizationOCITests/RegistryClientTests.swift
@@ -72,8 +72,14 @@ struct OCIClientTests: ~Copyable {
         #expect(response.getToken() != nil)
     }
 
-    @Test func ping() async throws {
-        let client = RegistryClient(host: "registry-1.docker.io")
+    @Test(arguments: [
+        "registry-1.docker.io",
+        "public.ecr.aws",
+        "registry.k8s.io",
+        "mcr.microsoft.com",
+    ])
+    func ping(host: String) async throws {
+        let client = RegistryClient(host: host)
         try await client.ping()
     }
 


### PR DESCRIPTION
There was a bug where the `www-authenticate` header in the HTTP response from a registry would not be parsed accurately.

Specifically, if the header value had more than one `<space>` character, the entire header would be ignored. This PR fixes this bug and adds unit test to detect this in the future.


Fixes https://github.com/apple/container/issues/240
And most likely fixes https://github.com/apple/container/issues/237

