### PR TITLE
Fix the Swiftly bin path

### DIFF
--- a/vminitd/Makefile
+++ b/vminitd/Makefile
@@ -41,7 +41,7 @@ all:
 	@install $(VMINITD_BIN_PATH)/vmexec ./bin/vmexec
 
 .PHONY: cross-prep
-cross-prep: swiftly swift linux-sdk macos-sdk
+cross-prep: linux-sdk macos-sdk
 
 .PHONY: swiftly
 swiftly:
@@ -56,12 +56,12 @@ swiftly:
 	fi
 	
 .PHONY: swift
-swift:
+swift: swiftly
 	@echo Installing Swift $(SWIFT_VERSION)...
 	@${SWIFTLY_BIN_DIR}/swiftly install $(SWIFT_VERSION)
 
 .PHONY: linux-sdk
-linux-sdk:
+linux-sdk: swift
 	@echo Installing Static Linux SDK...
 	@curl -L -o $(SWIFT_SDK_PATH) $(SWIFT_SDK_URL)
 	-@swift sdk install $(SWIFT_SDK_PATH)

--- a/vminitd/Makefile
+++ b/vminitd/Makefile
@@ -21,7 +21,7 @@ SWIFT_SDK_PATH = /tmp/$(notdir $(SWIFT_SDK_URL))
 
 SWIFTLY_URL := https://download.swift.org/swiftly/darwin/swiftly.pkg
 SWIFTLY_FILENAME = $(notdir $(SWIFTLY_URL))
-SWIFTLY_BIN_DIR ?= ~/.swiftly/bin/
+SWIFTLY_BIN_DIR ?= ~/.swiftly/bin
 VMINITD_BIN_PATH := $(shell swift build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --show-bin-path)
 
 MACOS_VERSION := $(shell sw_vers -productVersion)


### PR DESCRIPTION
This PR resolves the following error for new users:

```
% make cross-prep
Installing Swiftly...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 8549k  100 8549k    0     0  14.7M      0 --:--:-- --:--:-- --:--:-- 14.8M
installer: Package name is 
installer: Installing at base path /Users/Dmitry
installer: The install was successful.
Welcome to swiftly, the Swift toolchain manager for Linux and macOS!

Please read the following information carefully before proceeding with the installation. If you
wish to customize the steps performed during the installation process, refer to 'swiftly init -h'
for configuration options.

Swiftly installs files into the following locations:

/Users/Dmitry/.swiftly - Directory for configuration files
/Users/Dmitry/.swiftly/bin - Links to the binaries of the active toolchain
/Users/Dmitry/Library/Developer/Toolchains - Directory hosting installed toolchains

These locations can be changed by setting the environment variables
SWIFTLY_HOME_DIR, SWIFTLY_BIN_DIR, and SWIFTLY_TOOLCHAINS_DIR before running 'swiftly init' again.

For your convenience, swiftly will also attempt to modify your shell's profile file to make
installed items available in your environment upon login. This can be suppressed with the
'--no-modify-profile' option.

Proceed? (Y/n): 

Installing swiftly in /Users/Dmitry/.swiftly/bin/swiftly...
Error: The file “swiftly” couldn’t be opened because there is no such file.
make[1]: *** [swiftly] Error 1
make: *** [cross-prep] Error 2
```