### PR TITLE
Updated documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ make serve-docs
 Preview the documentation by running in another terminal:
 
 ```bash
-open http://localhost:8000/documentation/
+open http://localhost:8000/containerization/documentation/
 ```
 
 ## Contributing


### PR DESCRIPTION
## Description of Change

- I updated the documentation link in the README: [Documentation Tab](https://github.com/apple/containerization?tab=readme-ov-file#documentation)
- The original link (`open http://localhost:8000/documentation/`) was returning a **404 error**, as shown in the screenshot below.
- I fixed the issue by updating the link to: `open http://127.0.0.1:8000/containerization/documentation/`, which works correctly.

## Screenshot of the 404 Error and the Fix

Here’s the screenshot showing the error and the fix:

![404 Error Shown and 200 Fix](https://github.com/user-attachments/assets/4198d381-80de-4bca-a9f4-5455eee887f6)
