### PR TITLE
Fix compilation warnings

### DIFF
--- a/Tests/SendablePropertyMacrosTests/SendablePropertyMacrosTests.swift
+++ b/Tests/SendablePropertyMacrosTests/SendablePropertyMacrosTests.swift
@@ -25,8 +25,7 @@ import XCTest
 #if canImport(SendablePropertyMacros)
 import SendablePropertyMacros
 
-// testMacros is thread-safe.
-nonisolated(unsafe) let testMacros: [String: Macro.Type] = [
+let testMacros: [String: Macro.Type] = [
     "SendableProperty": SendablePropertyMacro.self
 ]
 #endif


### PR DESCRIPTION
This PR fixes compilation warnings observed in:
```
swift -v --version
Apple Swift version 6.2-dev (LLVM 5fbc818cf26c90b, Swift 2e1897356956e43)
Target: arm64-apple-macosx26.0
/Users/Dmitry/Library/Developer/Toolchains/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-06-17-a.xctoolchain/usr/bin/swift-frontend --version
Apple Swift version 6.2-dev (LLVM 5fbc818cf26c90b, Swift 2e1897356956e43)
Target: arm64-apple-macosx26.0
Build config: +assertions
```