### PR TITLE
Makefile: Make target deps more explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ containerization:
 	@codesign --force --sign - --timestamp=none --entitlements=signing/vz.entitlements bin/containerization-integration
 
 .PHONY: init
-init: vminitd
+init: containerization vminitd
 	@echo Creating init.ext4...
 	@rm -f bin/init.rootfs.tar.gz bin/init.block
 	@./bin/cctl rootfs create --vminitd vminitd/bin/vminitd --labels org.opencontainers.image.source=https://github.com/apple/containerization --vmexec vminitd/bin/vmexec bin/init.rootfs.tar.gz vminit:latest
@@ -82,7 +82,7 @@ test:
 	@echo Testing all test targets...
 	@$(SWIFT) test --enable-code-coverage
 
-.PHONY: integration
+.PHONY: init integration
 integration:
 ifeq (,$(wildcard bin/vmlinux))
 	@echo No bin/vmlinux kernel found. See fetch-default-kernel target.

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {


### PR DESCRIPTION
Fixes #165

Some of the targets rely on others but weren't actually listed:
- `init` relies on `containerization` as it invokes `cctl`.
- `integration` relies on `init` as it needs the rootfs with vminitd inside.