### PR TITLE
Makefile: Fix `all` not building with local changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ include Protobuf.Makefile
 .DEFAULT_GOAL := all
 
 .PHONY: all
+all: swift-build
 all: containerization
 all: init
 


### PR DESCRIPTION
We need to run the source build phase, otherwise we can have scenarios where a user has local changes and `make` reports:

```
make: Nothing to be done for `all'.
```