### PR TITLE
mount /dev/console

### DIFF
--- a/vminitd/Sources/vmexec/RunCommand.swift
+++ b/vminitd/Sources/vmexec/RunCommand.swift
@@ -140,7 +140,7 @@ struct RunCommand: ParsableCommand {
             }
 
             var fdCopy = hostFd
-            var fdData = Data(bytes: &fdCopy, count: MemoryLayout.size(ofValue: fdCopy))
+            let fdData = Data(bytes: &fdCopy, count: MemoryLayout.size(ofValue: fdCopy))
             try childPipe.fileHandleForWriting.write(contentsOf: fdData)
             try childPipe.fileHandleForWriting.close()
 

--- a/vminitd/Sources/vmexec/RunCommand.swift
+++ b/vminitd/Sources/vmexec/RunCommand.swift
@@ -19,7 +19,6 @@ import ContainerizationOCI
 import Foundation
 import LCShim
 import Logging
-import Musl
 
 #if canImport(Musl)
 import Musl

--- a/vminitd/Sources/vminitd/ManagedProcess.swift
+++ b/vminitd/Sources/vminitd/ManagedProcess.swift
@@ -177,7 +177,7 @@ extension ManagedProcess {
                 guard fd != -1 else {
                     throw ContainerizationError(.internalError, message: "vmexec did not return pty fd")
                 }
-                try self.terminal.attach(pid: i, fd: fd)
+                try $0.io.attach(pid: i, fd: fd)
             }
 
             log.debug(

--- a/vminitd/Sources/vminitd/ManagedProcess.swift
+++ b/vminitd/Sources/vminitd/ManagedProcess.swift
@@ -128,6 +128,8 @@ final class ManagedProcess: Sendable {
 
         self.process = process
         self.lock = Mutex(State(io: io))
+
+        try io.start()
     }
 }
 
@@ -139,10 +141,6 @@ extension ManagedProcess {
                 metadata: [
                     "id": "\(id)"
                 ])
-
-            if !self.terminal {
-                try $0.io.start()
-            }
 
             // Start the underlying process.
             try process.start()

--- a/vminitd/Sources/vminitd/StandardIO.swift
+++ b/vminitd/Sources/vminitd/StandardIO.swift
@@ -120,6 +120,9 @@ final class StandardIO: ManagedProcess.IO & Sendable {
     }
 
     // NOP
+    func attach(pid: Int32, fd: Int32) throws {}
+
+    // NOP
     func resize(size: Terminal.Size) throws {}
 
     func relay(readFromFd: Int32, writeToFd: Int32) throws {

--- a/vminitd/Sources/vminitd/TerminalIO.swift
+++ b/vminitd/Sources/vminitd/TerminalIO.swift
@@ -16,6 +16,7 @@
 
 import ContainerizationOS
 import Foundation
+import LCShim
 import Logging
 import SendableProperty
 

--- a/vminitd/Sources/vminitd/TerminalIO.swift
+++ b/vminitd/Sources/vminitd/TerminalIO.swift
@@ -62,10 +62,12 @@ final class TerminalIO: ManagedProcess.IO & Sendable {
         let hostFd = CZ_pidfd_getfd(containerFd, fd, 0)
         guard Foundation.close(Int32(containerFd)) == 0 else {
             self.log?.error("failed to close pidfd: \(POSIXError.fromErrno())")
+            return
         }
 
         guard hostFd != -1 else {
             throw POSIXError.fromErrno()
+            return
         }
 
         let fdDup = Int32(hostFd)

--- a/vminitd/Sources/vminitd/TerminalIO.swift
+++ b/vminitd/Sources/vminitd/TerminalIO.swift
@@ -61,8 +61,7 @@ final class TerminalIO: ManagedProcess.IO & Sendable {
 
         let hostFd = CZ_pidfd_getfd(containerFd, fd, 0)
         guard Foundation.close(Int32(containerFd)) == 0 else {
-            self.log?.error("failed to close pidfd: \(POSIXError.fromErrno())")
-            return
+            throw POSIXError.fromErrno()
         }
 
         guard hostFd != -1 else {


### PR DESCRIPTION
fixes #145

this PR changes `configureConsole()` to bind mount `/dev/console` if `process.terminal` is true. I couldn't think of a better way to get the pty path so I used `readlink`. most OCI images don't have `/dev/console` because they don't have `mknod` and `devtmpfs` won't create `/dev/console` without a physical console in the namespace, so it also creates `/dev/console`

@dcantah 