### PR TITLE
Pin Swift 6.2 version and Linux SDK

### DIFF
--- a/.swift-version
+++ b/.swift-version
@@ -1,1 +1,1 @@
-6.2-snapshot
+6.2-snapshot-2025-06-25

--- a/vminitd/Makefile
+++ b/vminitd/Makefile
@@ -15,8 +15,8 @@
 BUILD_CONFIGURATION := debug
 SWIFT_CONFIGURATION := --swift-sdk aarch64-swift-linux-musl
 
-SWIFT_VERSION = 6.2-snapshot
-SWIFT_SDK_URL = https://download.swift.org/swift-6.2-branch/static-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-06-17-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-06-17-a_static-linux-0.0.1.artifactbundle.tar.gz
+SWIFT_VERSION = 6.2-snapshot-2025-06-25
+SWIFT_SDK_URL = https://download.swift.org/swift-6.2-branch/static-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-06-25-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-06-25-a_static-linux-0.0.1.artifactbundle.tar.gz
 SWIFT_SDK_PATH = /tmp/$(notdir $(SWIFT_SDK_URL))
 
 SWIFTLY_URL := https://download.swift.org/swiftly/darwin/swiftly.pkg


### PR DESCRIPTION
Until 6.2 officially releases lets pin to a static version of the 6.2 snapshots. The Linux SDK and swift version must be aligned so this should be less fickle than using `6.2-snapshot` as this is a friendly identifier to choose the latest uploaded snapshot.