### PR TITLE
LCShim: Add CZ prefixes/pidfd wrappers

### DIFF
--- a/vminitd/Sources/LCShim/include/syscall.h
+++ b/vminitd/Sources/LCShim/include/syscall.h
@@ -14,14 +14,25 @@
  * limitations under the License.
  */
 
-#include <sys/prctl.h>
-#include <sys/syscall.h>
-#include <unistd.h>
+#ifndef __SYSCALL_H
+#define __SYSCALL_H
 
-#include "syscall2.h"
+#include <sys/types.h>
 
-int syscall2(long number, void *arg1, void *arg2) {
-  return syscall(number, arg1, arg2);
-}
+int CZ_pivot_root(const char *new_root, const char *put_old);
 
-int set_sub_reaper() { return prctl(PR_SET_CHILD_SUBREAPER, 1); }
+int CZ_set_sub_reaper();
+
+#ifndef SYS_pidfd_open
+#define SYS_pidfd_open 434
+#endif
+
+int CZ_pidfd_open(pid_t pid, unsigned int flags);
+
+#ifndef SYS_pidfd_getfd
+#define SYS_pidfd_getfd 438
+#endif
+
+int CZ_pidfd_getfd(int pidfd, int targetfd, unsigned int flags);
+
+#endif

--- a/vminitd/Sources/LCShim/syscall.c
+++ b/vminitd/Sources/LCShim/syscall.c
@@ -14,13 +14,24 @@
  * limitations under the License.
  */
 
-//
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
 
-#ifndef __SYSCALL2_H
-#define __SYSCALL2_H
+#include "syscall.h"
 
-int syscall2(long number, void *arg1, void *arg2);
+int CZ_pivot_root(const char *new_root, const char *put_old) {
+  return syscall(SYS_pivot_root, new_root, put_old);
+}
 
-int set_sub_reaper();
+int CZ_set_sub_reaper() { return prctl(PR_SET_CHILD_SUBREAPER, 1); }
 
-#endif
+int CZ_pidfd_open(pid_t pid, unsigned int flags) {
+  // Musl doesn't have pidfd_open.
+  return syscall(SYS_pidfd_open, pid, flags);
+}
+
+int CZ_pidfd_getfd(int pidfd, int targetfd, unsigned int flags) {
+  // Musl doesn't have pidfd_getfd.
+  return syscall(SYS_pidfd_getfd, pidfd, targetfd, flags);
+}

--- a/vminitd/Sources/vmexec/RunCommand.swift
+++ b/vminitd/Sources/vmexec/RunCommand.swift
@@ -228,7 +228,7 @@ struct RunCommand: ParsableCommand {
         guard fchdir(newRoot) == 0 else {
             throw App.Errno(stage: "fchdir(newroot)")
         }
-        guard syscall2(Int(SYS_pivot_root), toCString("."), toCString(".")) == 0 else {
+        guard CZ_pivot_root(toCString("."), toCString(".")) == 0 else {
             throw App.Errno(stage: "pivot_root()")
         }
         // change cwd to the old root

--- a/vminitd/Sources/vminitd/Application.swift
+++ b/vminitd/Sources/vminitd/Application.swift
@@ -88,7 +88,7 @@ struct Application {
         // since we are not running as pid1 in this mode we must set ourselves
         // as a subpreaper so that all child processes are reaped by us and not
         // passed onto our parent.
-        set_sub_reaper()
+        CZ_set_sub_reaper()
         #endif
 
         signal(SIGPIPE, SIG_IGN)


### PR DESCRIPTION
We should namespace these a bit, and we need pidfd for some upcoming terminal work. This also just gets rid of syscall2 and replaces with a pivot_root wrapper.