### PR TITLE
update SPI manifest to build on 6.2 only

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,3 +2,4 @@ version: 1
 builder:
   configs:
     - documentation_targets: [Containerization, ContainerizationEXT4, ContainerizationOS, ContainerizationOCI, ContainerizationNetlink, ContainerizationIO, ContainerizationExtras, ContainerizationArchive, SendableProperty]
+      swift_version: '6.2'


### PR DESCRIPTION
adds configuration to SwiftPackageIndex manifest to request builds happen explicitly on Swift 6.2 vs whatever the current default it