### PR TITLE
Add a `com.apple.containerization.index.indirect` annotation to distinguish synthesized index

### DIFF
--- a/Sources/Containerization/Image/ImageStore/ImageStore+Import.swift
+++ b/Sources/Containerization/Image/ImageStore/ImageStore+Import.swift
@@ -211,10 +211,12 @@ extension ImageStore {
                 let platform = supportedPlatforms.first!
                 var root = root
                 root.platform = platform
-                let index = ContainerizationOCI.Index(schemaVersion: 2, manifests: [root], annotations: [
-                    // indicate that this is a synthesized index which is not directly user facing
-                    AnnotationKeys.containerizationIndexIndirect: "true"
-                ])
+                let index = ContainerizationOCI.Index(
+                    schemaVersion: 2, manifests: [root],
+                    annotations: [
+                        // indicate that this is a synthesized index which is not directly user facing
+                        AnnotationKeys.containerizationIndexIndirect: "true"
+                    ])
                 return index
             default:
                 throw ContainerizationError(.internalError, message: "Failed to create index for descriptor \(root.digest), media type \(root.mediaType)")

--- a/Sources/Containerization/Image/ImageStore/ImageStore+Import.swift
+++ b/Sources/Containerization/Image/ImageStore/ImageStore+Import.swift
@@ -211,7 +211,10 @@ extension ImageStore {
                 let platform = supportedPlatforms.first!
                 var root = root
                 root.platform = platform
-                let index = ContainerizationOCI.Index(schemaVersion: 2, manifests: [root])
+                let index = ContainerizationOCI.Index(schemaVersion: 2, manifests: [root], annotations: [
+                    // indicate that this is a synthesized index which is not directly user facing
+                    "com.apple.containerization.index.indirect" : "true"
+                ])
                 return index
             default:
                 throw ContainerizationError(.internalError, message: "Failed to create index for descriptor \(root.digest), media type \(root.mediaType)")

--- a/Sources/Containerization/Image/ImageStore/ImageStore+Import.swift
+++ b/Sources/Containerization/Image/ImageStore/ImageStore+Import.swift
@@ -213,7 +213,7 @@ extension ImageStore {
                 root.platform = platform
                 let index = ContainerizationOCI.Index(schemaVersion: 2, manifests: [root], annotations: [
                     // indicate that this is a synthesized index which is not directly user facing
-                    "com.apple.containerization.index.indirect" : "true"
+                    AnnotationKeys.containerizationIndexIndirect: "true"
                 ])
                 return index
             default:

--- a/Sources/ContainerizationOCI/AnnotationKeys.swift
+++ b/Sources/ContainerizationOCI/AnnotationKeys.swift
@@ -17,6 +17,7 @@
 /// AnnotationKeys contains a subset of "dictionary keys" for commonly used annotations in an OCI Image Descriptor
 /// https://github.com/opencontainers/image-spec/blob/main/annotations.md
 public struct AnnotationKeys: Codable, Sendable {
+    public static let containerizationIndexIndirect = "com.apple.containerization.index.indirect"
     public static let containerizationImageName = "com.apple.containerization.image.name"
     public static let containerdImageName = "io.containerd.image.name"
     public static let openContainersImageName = "org.opencontainers.image.ref.name"


### PR DESCRIPTION
In general I believe it's clever to synthesize an index for single-platform image manifest, but we still need a way to distinguish it. Add a dedicated annotation is the slightest change I've come up with, and it's also OCI compliant. With this change come in, we can work around https://github.com/apple/container/issues/212 and imitate the behavior of other runtime with `container`.

Note that since `cctl` is meant to be a dedicated tool for inspecting the Containerization framework itself, I didn't apply the indirection for it, and it will be as-is with the genuine storage.