### PR TITLE
ContainerizationOCI: Add OCI prefix to types

### DIFF
--- a/Sources/Containerization/Agent/Vminitd.swift
+++ b/Sources/Containerization/Agent/Vminitd.swift
@@ -55,7 +55,7 @@ extension Vminitd: VirtualMachineAgent {
 
         try await setenv(key: "PATH", value: Self.defaultPath)
 
-        let mounts: [ContainerizationOCI.Mount] = [
+        let mounts: [OCIMount] = [
             .init(type: "sysfs", source: "sysfs", destination: "/sys"),
             .init(type: "tmpfs", source: "tmpfs", destination: "/tmp"),
             .init(type: "devpts", source: "devpts", destination: "/dev/pts", options: ["gid=5", "mode=620", "ptmxmode=666"]),
@@ -67,7 +67,7 @@ extension Vminitd: VirtualMachineAgent {
     }
 
     /// Mount a filesystem in the sandbox's environment.
-    public func mount(_ mount: ContainerizationOCI.Mount) async throws {
+    public func mount(_ mount: OCIMount) async throws {
         _ = try await client.mount(
             .with {
                 $0.type = mount.type
@@ -102,7 +102,7 @@ extension Vminitd: VirtualMachineAgent {
         stdinPort: UInt32?,
         stdoutPort: UInt32?,
         stderrPort: UInt32?,
-        configuration: ContainerizationOCI.Spec,
+        configuration: OCISpec,
         options: Data?
     ) async throws {
         let enc = JSONEncoder()

--- a/Sources/Containerization/Image/ImageStore/ImageStore+OCILayout.swift
+++ b/Sources/Containerization/Image/ImageStore/ImageStore+OCILayout.swift
@@ -30,7 +30,7 @@ extension ImageStore {
     ///   - platform: An optional parameter to indicate the platform to be saved for the images.
     ///               Defaults to `nil` signifying that layers for all supported platforms by the images will be saved.
     ///
-    public func save(references: [String], out: URL, platform: Platform? = nil) async throws {
+    public func save(references: [String], out: URL, platform: OCIPlatform? = nil) async throws {
         let matcher = createPlatformMatcher(for: platform)
         let fileManager = FileManager.default
         let tempDir = fileManager.uniqueTemporaryDirectory()
@@ -41,14 +41,14 @@ extension ImageStore {
         var toSave: [Image] = []
         for reference in references {
             let image = try await self.get(reference: reference)
-            let allowedMediaTypes = [MediaTypes.dockerManifestList, MediaTypes.index]
+            let allowedMediaTypes = [OCIMediaTypes.dockerManifestList, OCIMediaTypes.index]
             guard allowedMediaTypes.contains(image.mediaType) else {
                 throw ContainerizationError(.internalError, message: "Cannot save image \(image.reference) with Index media type \(image.mediaType)")
             }
             toSave.append(image)
         }
         let client = try LocalOCILayoutClient(root: out)
-        var saved: [Descriptor] = []
+        var saved: [OCIDescriptor] = []
 
         for image in toSave {
             let ref = try Reference.parse(image.reference)

--- a/Sources/Containerization/Image/ImageStore/ImageStore+ReferenceManager.swift
+++ b/Sources/Containerization/Image/ImageStore/ImageStore+ReferenceManager.swift
@@ -24,7 +24,7 @@ extension ImageStore {
     internal actor ReferenceManager: Sendable {
         private let path: URL
 
-        private typealias State = [String: Descriptor]
+        private typealias State = [String: OCIDescriptor]
         private var images: State
 
         public init(path: URL) throws {

--- a/Sources/Containerization/Image/ImageStore/ImageStore.swift
+++ b/Sources/Containerization/Image/ImageStore/ImageStore.swift
@@ -152,7 +152,7 @@ extension ImageStore {
     ///
     /// - Returns: A `Containerization.Image` object to the newly pulled image.
     public func pull(
-        reference: String, platform: Platform? = nil, insecure: Bool = false,
+        reference: String, platform: OCIPlatform? = nil, insecure: Bool = false,
         auth: Authentication? = nil, progress: ProgressHandler? = nil
     ) async throws -> Image {
 
@@ -196,10 +196,10 @@ extension ImageStore {
     ///           Defaults to `nil` meaning no additional credentials are added to any HTTP requests made to the registry.
     ///   - progress: An optional handler over which progress update events about the push operation can be received.
     ///
-    public func push(reference: String, platform: Platform? = nil, insecure: Bool = false, auth: Authentication? = nil, progress: ProgressHandler? = nil) async throws {
+    public func push(reference: String, platform: OCIPlatform? = nil, insecure: Bool = false, auth: Authentication? = nil, progress: ProgressHandler? = nil) async throws {
         let matcher = createPlatformMatcher(for: platform)
         let img = try await self.get(reference: reference)
-        let allowedMediaTypes = [MediaTypes.dockerManifestList, MediaTypes.index]
+        let allowedMediaTypes = [OCIMediaTypes.dockerManifestList, OCIMediaTypes.index]
         guard allowedMediaTypes.contains(img.mediaType) else {
             throw ContainerizationError(.internalError, message: "Cannot push image \(reference) with Index media type \(img.mediaType)")
         }

--- a/Sources/Containerization/Image/Unpacker/EXT4Unpacker.swift
+++ b/Sources/Containerization/Image/Unpacker/EXT4Unpacker.swift
@@ -32,7 +32,7 @@ public struct EXT4Unpacker: Unpacker {
         self.blockSizeInBytes = blockSizeInBytes
     }
 
-    public func unpack(_ image: Image, for platform: Platform, at path: URL, progress: ProgressHandler? = nil) async throws -> Mount {
+    public func unpack(_ image: Image, for platform: OCIPlatform, at path: URL, progress: ProgressHandler? = nil) async throws -> Mount {
         #if !os(macOS)
         throw ContainerizationError(.unsupported, message: "Cannot unpack an image on current platform")
         #else
@@ -47,9 +47,9 @@ public struct EXT4Unpacker: Unpacker {
 
             let compression: ContainerizationArchive.Filter
             switch layer.mediaType {
-            case MediaTypes.imageLayer, MediaTypes.dockerImageLayer:
+            case OCIMediaTypes.imageLayer, OCIMediaTypes.dockerImageLayer:
                 compression = .none
-            case MediaTypes.imageLayerGzip, MediaTypes.dockerImageLayerGzip:
+            case OCIMediaTypes.imageLayerGzip, OCIMediaTypes.dockerImageLayerGzip:
                 compression = .gzip
             default:
                 throw ContainerizationError(.unsupported, message: "Media type \(layer.mediaType) not supported.")

--- a/Sources/Containerization/Image/Unpacker/Unpacker.swift
+++ b/Sources/Containerization/Image/Unpacker/Unpacker.swift
@@ -35,6 +35,6 @@ public protocol Unpacker {
     /// or transformations during the unpacking.
     ///
     /// Progress updates can be observed via the optional `progress` handler.
-    func unpack(_ image: Image, for platform: Platform, at path: URL, progress: ProgressHandler?) async throws -> Mount
+    func unpack(_ image: Image, for platform: OCIPlatform, at path: URL, progress: ProgressHandler?) async throws -> Mount
 
 }

--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -41,7 +41,7 @@ public final class LinuxContainer: Container, Sendable {
     public let rootfs: Mount
 
     private struct Configuration {
-        var spec: Spec
+        var spec: OCISpec
         var cpus: Int = 4
         var memoryInBytes: UInt64 = 1024.mib()
         var interfaces: [any Interface] = []
@@ -243,7 +243,7 @@ public final class LinuxContainer: Container, Sendable {
         self.state = .initialized
     }
 
-    private static func createDefaultRuntimeSpec(_ id: String) -> Spec {
+    private static func createDefaultRuntimeSpec(_ id: String) -> OCISpec {
         .init(
             process: .init(
                 cwd: "/",
@@ -400,7 +400,7 @@ extension LinuxContainer {
     }
 
     /// The User the container should execute under.
-    public var user: ContainerizationOCI.User {
+    public var user: OCIUser {
         get {
             config.withLock { $0.spec.process!.user }
         }
@@ -430,7 +430,7 @@ extension LinuxContainer {
     }
 
     /// Rlimits for the container.
-    public var rlimits: [POSIXRlimit] {
+    public var rlimits: [OCIRlimit] {
         get {
             config.withLock { $0.spec.process!.rlimits }
         }
@@ -501,8 +501,8 @@ extension LinuxContainer {
         }
     }
 
-    public func setProcessConfig(from imageConfig: ImageConfig) {
-        let process = ContainerizationOCI.Process(from: imageConfig)
+    public func setProcessConfig(from imageConfig: OCIImageConfig) {
+        let process = OCIProcess(from: imageConfig)
         self.config.withLock { $0.spec.process = process }
     }
 
@@ -594,6 +594,46 @@ extension LinuxContainer {
             state.errored(error: error)
             throw error
         }
+    }
+
+    public func pause() async throws {
+        let vm = try state.setStarting()
+
+        let agent = try await vm.dialAgent()
+        do {
+            var specCopy = config.withLock { $0.spec }
+            // We don't need the rootfs, nor do OCI runtimes want it included.
+            specCopy.mounts = vm.mounts.dropFirst().map { $0.to }
+
+            let stdio = Self.setupIO(
+                portAllocator: self.hostVsockPorts,
+                stdin: self.stdin,
+                stdout: self.stdout,
+                stderr: self.stderr
+            )
+
+            let process = LinuxProcess(
+                self.id,
+                containerID: self.id,
+                spec: specCopy,
+                io: stdio,
+                agent: agent,
+                vm: vm,
+                logger: self.logger
+            )
+            try await process.start()
+
+            try state.setStarted(process: process)
+        } catch {
+            try? await agent.close()
+
+            state.errored(error: error)
+            throw error
+        }
+    }
+
+    public func resume() async throws {
+
     }
 
     private static func setupIO(
@@ -716,7 +756,7 @@ extension LinuxContainer {
     /// Execute a new process in the container.
     public func exec(
         _ id: String,
-        configuration: ContainerizationOCI.Process,
+        configuration: OCIProcess,
         stdin: ReaderStream? = nil,
         stdout: Writer? = nil,
         stderr: Writer? = nil
@@ -815,7 +855,7 @@ extension VirtualMachineInstance {
 }
 
 extension AttachedFilesystem {
-    fileprivate var to: ContainerizationOCI.Mount {
+    fileprivate var to: OCIMount {
         .init(
             type: self.type,
             source: self.source,

--- a/Sources/Containerization/LinuxProcess.swift
+++ b/Sources/Containerization/LinuxProcess.swift
@@ -90,7 +90,7 @@ public final class LinuxProcess: Sendable {
     }
 
     private struct State {
-        var spec: ContainerizationOCI.Spec
+        var spec: OCISpec
         var pid: Int32
         var stdio: StdioHandles
         var stdinRelay: Task<(), Never>?
@@ -144,13 +144,13 @@ public final class LinuxProcess: Sendable {
     }
 
     /// The User a Process should execute under.
-    public var user: ContainerizationOCI.User {
+    public var user: OCIUser {
         get { state.withLock { $0.spec.process!.user } }
         set { state.withLock { $0.spec.process!.user = newValue } }
     }
 
     /// Rlimits for the Process.
-    public var rlimits: [POSIXRlimit] {
+    public var rlimits: [OCIRlimit] {
         get { state.withLock { $0.spec.process!.rlimits } }
         set { state.withLock { $0.spec.process!.rlimits = newValue } }
     }
@@ -164,7 +164,7 @@ public final class LinuxProcess: Sendable {
     init(
         _ id: String,
         containerID: String? = nil,
-        spec: Spec,
+        spec: OCISpec,
         io: Stdio,
         agent: any VirtualMachineAgent,
         vm: any VirtualMachineInstance,

--- a/Sources/Containerization/SystemPlatform.swift
+++ b/Sources/Containerization/SystemPlatform.swift
@@ -32,8 +32,8 @@ public struct SystemPlatform: Sendable, Codable {
     }
     public let architecture: Architecture
 
-    public func ociPlatform() -> ContainerizationOCI.Platform {
-        ContainerizationOCI.Platform(arch: architecture.rawValue, os: os.rawValue)
+    public func ociPlatform() -> OCIPlatform {
+        OCIPlatform(arch: architecture.rawValue, os: os.rawValue)
     }
 
     public static var linuxArm: SystemPlatform { .init(os: .linux, architecture: .arm64) }

--- a/Sources/Containerization/VirtualMachineAgent.swift
+++ b/Sources/Containerization/VirtualMachineAgent.swift
@@ -31,7 +31,7 @@ public protocol VirtualMachineAgent: Sendable {
     // POSIX
     func getenv(key: String) async throws -> String
     func setenv(key: String, value: String) async throws
-    func mount(_ mount: ContainerizationOCI.Mount) async throws
+    func mount(_ mount: OCIMount) async throws
     func umount(path: String, flags: Int32) async throws
     func mkdir(path: String, all: Bool, perms: UInt32) async throws
     @discardableResult
@@ -44,7 +44,7 @@ public protocol VirtualMachineAgent: Sendable {
         stdinPort: UInt32?,
         stdoutPort: UInt32?,
         stderrPort: UInt32?,
-        configuration: ContainerizationOCI.Spec,
+        configuration: OCISpec,
         options: Data?
     ) async throws
     func startProcess(id: String, containerID: String?) async throws -> Int32

--- a/Sources/ContainerizationOCI/AnnotationKeys.swift
+++ b/Sources/ContainerizationOCI/AnnotationKeys.swift
@@ -16,7 +16,8 @@
 
 /// AnnotationKeys contains a subset of "dictionary keys" for commonly used annotations in an OCI Image Descriptor
 /// https://github.com/opencontainers/image-spec/blob/main/annotations.md
-public struct AnnotationKeys: Codable, Sendable {
+
+public struct OCIAnnotationKeys: Codable, Sendable {
     public static let containerizationIndexIndirect = "com.apple.containerization.index.indirect"
     public static let containerizationImageName = "com.apple.containerization.image.name"
     public static let containerdImageName = "io.containerd.image.name"

--- a/Sources/ContainerizationOCI/Bundle.swift
+++ b/Sources/ContainerizationOCI/Bundle.swift
@@ -29,7 +29,7 @@ private let _umount = Glibc.umount2
 
 /// `Bundle` represents an OCI runtime spec bundle for running
 /// a container.
-public struct Bundle: Sendable {
+public struct OCIBundle: Sendable {
     /// The path to the bundle.
     public let path: URL
 
@@ -49,7 +49,7 @@ public struct Bundle: Sendable {
     ///   - path: A URL pointing to where to create the bundle on the filesystem.
     ///   - spec: A data blob that should contain an OCI runtime spec. This will be written
     ///           to the bundle as a "config.json" file.
-    public static func create(path: URL, spec: Data) throws -> Bundle {
+    public static func create(path: URL, spec: Data) throws -> OCIBundle {
         try self.init(path: path, spec: spec)
     }
 
@@ -59,7 +59,7 @@ public struct Bundle: Sendable {
     ///   - path: A URL pointing to where to create the bundle on the filesystem.
     ///   - spec: An OCI runtime spec that will be written to the bundle as a "config.json"
     ///           file.
-    public static func create(path: URL, spec: ContainerizationOCI.Spec) throws -> Bundle {
+    public static func create(path: URL, spec: OCISpec) throws -> OCIBundle {
         try self.init(path: path, spec: spec)
     }
 
@@ -67,7 +67,7 @@ public struct Bundle: Sendable {
     ///
     /// - Parameters:
     ///   - path: A URL pointing to where to load the bundle from on the filesystem.
-    public static func load(path: URL) throws -> Bundle {
+    public static func load(path: URL) throws -> OCIBundle {
         try self.init(path: path)
     }
 
@@ -93,7 +93,7 @@ public struct Bundle: Sendable {
         try spec.write(to: self.configPath)
     }
 
-    private init(path: URL, spec: ContainerizationOCI.Spec) throws {
+    private init(path: URL, spec: OCISpec) throws {
         self.path = path
 
         let fm = FileManager.default
@@ -121,8 +121,8 @@ public struct Bundle: Sendable {
     }
 
     /// Load and return the OCI runtime spec written to the bundle.
-    public func loadConfig() throws -> ContainerizationOCI.Spec {
+    public func loadConfig() throws -> OCISpec {
         let data = try Data(contentsOf: self.configPath)
-        return try JSONDecoder().decode(ContainerizationOCI.Spec.self, from: data)
+        return try JSONDecoder().decode(OCISpec.self, from: data)
     }
 }

--- a/Sources/ContainerizationOCI/Client/RegistryClient+Fetch.swift
+++ b/Sources/ContainerizationOCI/Client/RegistryClient+Fetch.swift
@@ -28,7 +28,7 @@ import NIOFileSystem
 extension RegistryClient {
     /// Resolve sends a HEAD request to the registry to find root manifest descriptor.
     /// This descriptor serves as an entry point to retrieve resources from the registry.
-    public func resolve(name: String, tag: String) async throws -> Descriptor {
+    public func resolve(name: String, tag: String) async throws -> OCIDescriptor {
         var components = base
 
         // Make HEAD request to retrieve the digest header
@@ -36,10 +36,10 @@ extension RegistryClient {
 
         // The client should include an Accept header indicating which manifest content types it supports.
         let mediaTypes = [
-            MediaTypes.dockerManifest,
-            MediaTypes.dockerManifestList,
-            MediaTypes.imageManifest,
-            MediaTypes.index,
+            OCIMediaTypes.dockerManifest,
+            OCIMediaTypes.dockerManifestList,
+            OCIMediaTypes.imageManifest,
+            OCIMediaTypes.index,
             "*/*",
         ]
 
@@ -70,19 +70,19 @@ extension RegistryClient {
                 throw ContainerizationError(.invalidArgument, message: "Cannot convert \(sizeStr) to Int64")
             }
 
-            return Descriptor(mediaType: type, digest: digest, size: size)
+            return OCIDescriptor(mediaType: type, digest: digest, size: size)
         }
     }
 
     /// Fetch resource (either manifest or blob) to memory with JSON decoding.
-    public func fetch<T: Codable>(name: String, descriptor: Descriptor) async throws -> T {
+    public func fetch<T: Codable>(name: String, descriptor: OCIDescriptor) async throws -> T {
         var components = base
 
         let manifestTypes = [
-            MediaTypes.dockerManifest,
-            MediaTypes.dockerManifestList,
-            MediaTypes.imageManifest,
-            MediaTypes.index,
+            OCIMediaTypes.dockerManifest,
+            OCIMediaTypes.dockerManifestList,
+            OCIMediaTypes.imageManifest,
+            OCIMediaTypes.index,
         ]
 
         let isManifest = manifestTypes.contains(where: { $0 == descriptor.mediaType })
@@ -103,14 +103,14 @@ extension RegistryClient {
     }
 
     /// Fetch resource (either manifest or blob) to memory as raw `Data`.
-    public func fetchData(name: String, descriptor: Descriptor) async throws -> Data {
+    public func fetchData(name: String, descriptor: OCIDescriptor) async throws -> Data {
         var components = base
 
         let manifestTypes = [
-            MediaTypes.dockerManifest,
-            MediaTypes.dockerManifestList,
-            MediaTypes.imageManifest,
-            MediaTypes.index,
+            OCIMediaTypes.dockerManifest,
+            OCIMediaTypes.dockerManifestList,
+            OCIMediaTypes.imageManifest,
+            OCIMediaTypes.index,
         ]
 
         let isManifest = manifestTypes.contains(where: { $0 == descriptor.mediaType })
@@ -134,7 +134,7 @@ extension RegistryClient {
     /// This method is suitable for streaming data.
     public func fetchBlob(
         name: String,
-        descriptor: Descriptor,
+        descriptor: OCIDescriptor,
         closure: (Int64, HTTPClientResponse.Body) async throws -> Void
     ) async throws {
         var components = base
@@ -167,7 +167,7 @@ extension RegistryClient {
 
     #if os(macOS)
     /// Fetch a blob from remote registry and write the contents into a file in the provided directory.
-    public func fetchBlob(name: String, descriptor: Descriptor, into file: URL, progress: ProgressHandler?) async throws -> (Int64, SHA256Digest) {
+    public func fetchBlob(name: String, descriptor: OCIDescriptor, into file: URL, progress: ProgressHandler?) async throws -> (Int64, SHA256Digest) {
         var hasher = SHA256()
         var received: Int64 = 0
         let fs = NIOFileSystem.FileSystem.shared
@@ -203,7 +203,7 @@ extension RegistryClient {
     }
     #else
     /// Fetch a blob from remote registry and write the contents into a file in the provided directory.
-    public func fetchBlob(name: String, descriptor: Descriptor, into file: URL, progress: ProgressHandler?) async throws -> (Int64, SHA256Digest) {
+    public func fetchBlob(name: String, descriptor: OCIDescriptor, into file: URL, progress: ProgressHandler?) async throws -> (Int64, SHA256Digest) {
         var hasher = SHA256()
         var received: Int64 = 0
         guard FileManager.default.createFile(atPath: file.path, contents: nil) else {

--- a/Sources/ContainerizationOCI/Client/RegistryClient+Push.swift
+++ b/Sources/ContainerizationOCI/Client/RegistryClient+Push.swift
@@ -42,7 +42,7 @@ extension RegistryClient {
     public func push<T: Sendable & AsyncSequence>(
         name: String,
         ref tag: String,
-        descriptor: Descriptor,
+        descriptor: OCIDescriptor,
         streamGenerator: () throws -> T,
         progress: ProgressHandler?
     ) async throws where T.Element == ByteBuffer {
@@ -57,7 +57,7 @@ extension RegistryClient {
         var existCheck: [String] = []
 
         switch mediaType {
-        case MediaTypes.dockerManifest, MediaTypes.dockerManifestList, MediaTypes.imageManifest, MediaTypes.index:
+        case OCIMediaTypes.dockerManifest, OCIMediaTypes.dockerManifestList, OCIMediaTypes.imageManifest, OCIMediaTypes.index:
             isManifest = true
             existCheck = self.getManifestPath(tag: tag, digest: descriptor.digest)
         default:

--- a/Sources/ContainerizationOCI/Content/Content.swift
+++ b/Sources/ContainerizationOCI/Content/Content.swift
@@ -42,16 +42,16 @@ public protocol Content: Sendable {
 
 /// Protocol defining methods to fetch and push OCI content
 public protocol ContentClient: Sendable {
-    func fetch<T: Codable>(name: String, descriptor: Descriptor) async throws -> T
+    func fetch<T: Codable>(name: String, descriptor: OCIDescriptor) async throws -> T
 
-    func fetchBlob(name: String, descriptor: Descriptor, into file: URL, progress: ProgressHandler?) async throws -> (Int64, SHA256Digest)
+    func fetchBlob(name: String, descriptor: OCIDescriptor, into file: URL, progress: ProgressHandler?) async throws -> (Int64, SHA256Digest)
 
-    func fetchData(name: String, descriptor: Descriptor) async throws -> Data
+    func fetchData(name: String, descriptor: OCIDescriptor) async throws -> Data
 
     func push<T: Sendable & AsyncSequence>(
         name: String,
         ref: String,
-        descriptor: Descriptor,
+        descriptor: OCIDescriptor,
         streamGenerator: () throws -> T,
         progress: ProgressHandler?
     ) async throws where T.Element == ByteBuffer

--- a/Sources/ContainerizationOCI/Descriptor.swift
+++ b/Sources/ContainerizationOCI/Descriptor.swift
@@ -21,7 +21,7 @@ import Foundation
 /// Descriptor describes the disposition of targeted content.
 /// This structure provides `application/vnd.oci.descriptor.v1+json` mediatype
 /// when marshalled to JSON.
-public struct Descriptor: Codable, Sendable, Equatable {
+public struct OCIDescriptor: Codable, Sendable, Equatable {
     /// mediaType is the media type of the object this schema refers to.
     public let mediaType: String
 
@@ -40,11 +40,11 @@ public struct Descriptor: Codable, Sendable, Equatable {
     /// platform describes the platform which the image in the manifest runs on.
     ///
     /// This should only be used when referring to a manifest.
-    public var platform: Platform?
+    public var platform: OCIPlatform?
 
     public init(
         mediaType: String, digest: String, size: Int64, urls: [String]? = nil, annotations: [String: String]? = nil,
-        platform: Platform? = nil
+        platform: OCIPlatform? = nil
     ) {
         self.mediaType = mediaType
         self.digest = digest

--- a/Sources/ContainerizationOCI/ImageConfig.swift
+++ b/Sources/ContainerizationOCI/ImageConfig.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 /// ImageConfig defines the execution parameters which should be used as a base when running a container using an image.
-public struct ImageConfig: Codable, Sendable {
+public struct OCIImageConfig: Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case user = "User"
         case env = "Env"
@@ -66,7 +66,7 @@ public struct ImageConfig: Codable, Sendable {
 }
 
 /// RootFS describes a layer content addresses
-public struct Rootfs: Codable, Sendable {
+public struct OCIRootfs: Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case type
         case diffIDs = "diff_ids"
@@ -85,7 +85,7 @@ public struct Rootfs: Codable, Sendable {
 }
 
 /// History describes the history of a layer.
-public struct History: Codable, Sendable {
+public struct OCIHistory: Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case created
         case createdBy = "created_by"
@@ -123,7 +123,7 @@ public struct History: Codable, Sendable {
 
 /// Image is the JSON structure which describes some basic information about the image.
 /// This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
-public struct Image: Codable, Sendable {
+public struct OCIImage: Codable, Sendable {
     /// created is the combined date and time at which the image was created, formatted as defined by RFC 3339, section 5.6.
     public let created: String?
 
@@ -146,18 +146,18 @@ public struct Image: Codable, Sendable {
     public let variant: String?
 
     /// config defines the execution parameters which should be used as a base when running a container using the image.
-    public let config: ImageConfig?
+    public let config: OCIImageConfig?
 
     /// rootfs references the layer content addresses used by the image.
-    public let rootfs: Rootfs
+    public let rootfs: OCIRootfs
 
     /// history describes the history of each layer.
-    public let history: [History]?
+    public let history: [OCIHistory]?
 
     public init(
         created: String? = nil, author: String? = nil, architecture: String, os: String, osVersion: String? = nil,
-        osFeatures: [String]? = nil, variant: String? = nil, config: ImageConfig? = nil, rootfs: Rootfs,
-        history: [History]? = nil
+        osFeatures: [String]? = nil, variant: String? = nil, config: OCIImageConfig? = nil, rootfs: OCIRootfs,
+        history: [OCIHistory]? = nil
     ) {
         self.created = created
         self.author = author

--- a/Sources/ContainerizationOCI/Index.swift
+++ b/Sources/ContainerizationOCI/Index.swift
@@ -20,7 +20,7 @@ import Foundation
 
 /// Index references manifests for various platforms.
 /// This structure provides `application/vnd.oci.image.index.v1+json` mediatype when marshalled to JSON.
-public struct Index: Codable, Sendable {
+public struct OCIIndex: Codable, Sendable {
     /// schemaVersion is the image manifest schema that this image follows
     public let schemaVersion: Int
 
@@ -28,13 +28,13 @@ public struct Index: Codable, Sendable {
     public let mediaType: String
 
     /// manifests references platform specific manifests.
-    public var manifests: [Descriptor]
+    public var manifests: [OCIDescriptor]
 
     /// annotations contains arbitrary metadata for the image index.
     public var annotations: [String: String]?
 
     public init(
-        schemaVersion: Int = 2, mediaType: String = MediaTypes.index, manifests: [Descriptor],
+        schemaVersion: Int = 2, mediaType: String = OCIMediaTypes.index, manifests: [OCIDescriptor],
         annotations: [String: String]? = nil
     ) {
         self.schemaVersion = schemaVersion

--- a/Sources/ContainerizationOCI/Manifest.swift
+++ b/Sources/ContainerizationOCI/Manifest.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 /// Manifest provides `application/vnd.oci.image.manifest.v1+json` mediatype structure when marshalled to JSON.
-public struct Manifest: Codable, Sendable {
+public struct OCIManifest: Codable, Sendable {
     /// `schemaVersion` is the image manifest schema that this image follows.
     public let schemaVersion: Int
 
@@ -28,16 +28,16 @@ public struct Manifest: Codable, Sendable {
 
     /// `config` references a configuration object for a container, by digest.
     /// The referenced configuration object is a JSON blob that the runtime uses to set up the container.
-    public let config: Descriptor
+    public let config: OCIDescriptor
 
     /// `layers` is an indexed list of layers referenced by the manifest.
-    public let layers: [Descriptor]
+    public let layers: [OCIDescriptor]
 
     /// `annotations` contains arbitrary metadata for the image manifest.
     public let annotations: [String: String]?
 
     public init(
-        schemaVersion: Int = 2, mediaType: String = MediaTypes.imageManifest, config: Descriptor, layers: [Descriptor],
+        schemaVersion: Int = 2, mediaType: String = OCIMediaTypes.imageManifest, config: OCIDescriptor, layers: [OCIDescriptor],
         annotations: [String: String]? = nil
     ) {
         self.schemaVersion = schemaVersion

--- a/Sources/ContainerizationOCI/MediaType.swift
+++ b/Sources/ContainerizationOCI/MediaType.swift
@@ -16,9 +16,9 @@
 
 import Foundation
 
-/// MediaTypes represent all supported OCI image content types for both metadata and layer formats.
+/// OCIMediaTypes represent all supported OCI image content types for both metadata and layer formats.
 /// Follows all distributable media types in: https://github.com/opencontainers/image-spec/blob/main/specs-go/v1/mediatype.go
-public struct MediaTypes: Codable, Sendable {
+public struct OCIMediaTypes: Codable, Sendable {
     /// Specifies the media type for a content descriptor.
     public static let descriptor = "application/vnd.oci.descriptor.v1+json"
 

--- a/Sources/ContainerizationOCI/Platform.swift
+++ b/Sources/ContainerizationOCI/Platform.swift
@@ -20,7 +20,7 @@ import ContainerizationError
 import Foundation
 
 /// Platform describes the platform which the image in the manifest runs on.
-public struct Platform: Sendable, Equatable {
+public struct OCIPlatform: Sendable, Equatable {
     public static var current: Self {
         var systemInfo = utsname()
         uname(&systemInfo)
@@ -94,7 +94,7 @@ public struct Platform: Sendable, Equatable {
     ///        -  platform: A `string` value representing the platform.
     ///     ```swift
     ///     // Create a new `ImagePlatform` from string.
-    ///     let platform = try Platform(from: "linux/amd64")
+    ///     let platform = try OCIPlatformfrom: "linux/amd64")
     ///     ```
     ///     ## Throws ##
     ///     - Throws:  `Error.missingOS` if input is empty
@@ -193,7 +193,7 @@ public struct Platform: Sendable, Equatable {
 
 }
 
-extension Platform: Hashable {
+extension OCIPlatform: Hashable {
     /**
       `~=` compares two platforms to check if **lhs** platform images are compatible with **rhs** platform
       This operator can be used to check if an image of **lhs** platform can run on **rhs**:
@@ -208,7 +208,7 @@ extension Platform: Hashable {
          - rhs: platform against which compatibility is being checked
       - Returns: `true | false`
      */
-    public static func ~= (lhs: Platform, rhs: Platform) -> Bool {
+    public static func ~= (lhs: OCIPlatform, rhs: OCIPlatform) -> Bool {
         if lhs.os == rhs.os {
             if lhs._rawArch == rhs._rawArch {
                 switch rhs._rawArch {
@@ -256,7 +256,7 @@ extension Platform: Hashable {
     }
 
     /// `==` compares if **lhs** and **rhs** are the exact same platforms.
-    public static func == (lhs: Platform, rhs: Platform) -> Bool {
+    public static func == (lhs: OCIPlatform, rhs: OCIPlatform) -> Bool {
         //  NOTE:
         //  If the platform struct was created by setting the fields directly and not using (from: String)
         //  then, there is a possibility that for arm64 architecture, the variant may be set to nil
@@ -283,7 +283,7 @@ extension Platform: Hashable {
     }
 }
 
-extension Platform: Codable {
+extension OCIPlatform: Codable {
 
     enum CodingKeys: String, CodingKey {
         case os = "os"
@@ -313,7 +313,7 @@ extension Platform: Codable {
     }
 }
 
-public func createPlatformMatcher(for platform: Platform?) -> @Sendable (Platform) -> Bool {
+public func createPlatformMatcher(for platform: OCIPlatform?) -> @Sendable (OCIPlatform) -> Bool {
     if let platform {
         return { other in
             platform == other
@@ -324,8 +324,8 @@ public func createPlatformMatcher(for platform: Platform?) -> @Sendable (Platfor
     }
 }
 
-public func filterPlatforms(matcher: (Platform) -> Bool, _ descriptors: [Descriptor]) throws -> [Descriptor] {
-    var outDescriptors: [Descriptor] = []
+public func filterPlatforms(matcher: (OCIPlatform) -> Bool, _ descriptors: [OCIDescriptor]) throws -> [OCIDescriptor] {
+    var outDescriptors: [OCIDescriptor] = []
     for desc in descriptors {
         guard let p = desc.platform else {
             // pass along descriptor if the platform is not defined

--- a/Sources/ContainerizationOCI/RuntimeSpec.swift
+++ b/Sources/ContainerizationOCI/RuntimeSpec.swift
@@ -18,26 +18,26 @@
 /// have been left off, and some APIs for Linux aren't present. This was manually ported starting
 /// at the v1.2.0 release.
 
-public struct Spec: Codable, Sendable {
+public struct OCISpec: Codable, Sendable {
     public var version: String
-    public var hooks: Hook?
-    public var process: Process?
+    public var hooks: OCIHook?
+    public var process: OCIProcess?
     public var hostname, domainname: String
-    public var mounts: [Mount]
+    public var mounts: [OCIMount]
     public var annotations: [String: String]?
-    public var root: Root?
-    public var linux: Linux?
+    public var root: OCIRoot?
+    public var linux: OCILinux?
 
     public init(
         version: String = "",
-        hooks: Hook? = nil,
-        process: Process? = nil,
+        hooks: OCIHook? = nil,
+        process: OCIProcess? = nil,
         hostname: String = "",
         domainname: String = "",
-        mounts: [Mount] = [],
+        mounts: [OCIMount] = [],
         annotations: [String: String]? = nil,
-        root: Root? = nil,
-        linux: Linux? = nil
+        root: OCIRoot? = nil,
+        linux: OCILinux? = nil
     ) {
         self.version = version
         self.hooks = hooks
@@ -63,18 +63,18 @@ public struct Spec: Codable, Sendable {
     }
 }
 
-public struct Process: Codable, Sendable {
+public struct OCIProcess: Codable, Sendable {
     public var cwd: String
     public var env: [String]
-    public var consoleSize: Box?
+    public var consoleSize: OCIBox?
     public var selinuxLabel: String
     public var noNewPrivileges: Bool
     public var commandLine: String
     public var oomScoreAdj: Int?
-    public var capabilities: LinuxCapabilities?
+    public var capabilities: OCILinuxCapabilities?
     public var apparmorProfile: String
-    public var user: User
-    public var rlimits: [POSIXRlimit]
+    public var user: OCIUser
+    public var rlimits: [OCIRlimit]
     public var args: [String]
     public var terminal: Bool
 
@@ -82,15 +82,15 @@ public struct Process: Codable, Sendable {
         args: [String] = [],
         cwd: String = "/",
         env: [String] = [],
-        consoleSize: Box? = nil,
+        consoleSize: OCIBox? = nil,
         selinuxLabel: String = "",
         noNewPrivileges: Bool = false,
         commandLine: String = "",
         oomScoreAdj: Int? = nil,
-        capabilities: LinuxCapabilities? = nil,
+        capabilities: OCILinuxCapabilities? = nil,
         apparmorProfile: String = "",
-        user: User = .init(),
-        rlimits: [POSIXRlimit] = [],
+        user: OCIUser = .init(),
+        rlimits: [OCIRlimit] = [],
         terminal: Bool = false
     ) {
         self.cwd = cwd
@@ -108,21 +108,21 @@ public struct Process: Codable, Sendable {
         self.terminal = terminal
     }
 
-    public init(from config: ImageConfig) {
+    public init(from config: OCIImageConfig) {
         let cwd = config.workingDir ?? "/"
         let env = config.env ?? []
         let args = (config.entrypoint ?? []) + (config.cmd ?? [])
-        let user: User = {
+        let user: OCIUser = {
             if let rawString = config.user {
-                return User(username: rawString)
+                return OCIUser(username: rawString)
             }
-            return User()
+            return OCIUser()
         }()
         self.init(args: args, cwd: cwd, env: env, user: user)
     }
 }
 
-public struct LinuxCapabilities: Codable, Sendable {
+public struct OCILinuxCapabilities: Codable, Sendable {
     public var bounding: [String]
     public var effective: [String]
     public var inheritable: [String]
@@ -144,7 +144,7 @@ public struct LinuxCapabilities: Codable, Sendable {
     }
 }
 
-public struct Box: Codable, Sendable {
+public struct OCIBox: Codable, Sendable {
     var height, width: UInt
 
     public init(height: UInt, width: UInt) {
@@ -153,7 +153,7 @@ public struct Box: Codable, Sendable {
     }
 }
 
-public struct User: Codable, Sendable {
+public struct OCIUser: Codable, Sendable {
     public var uid: UInt32
     public var gid: UInt32
     public var umask: UInt32?
@@ -175,7 +175,7 @@ public struct User: Codable, Sendable {
     }
 }
 
-public struct Root: Codable, Sendable {
+public struct OCIRoot: Codable, Sendable {
     public var path: String
     public var readonly: Bool
 
@@ -185,22 +185,22 @@ public struct Root: Codable, Sendable {
     }
 }
 
-public struct Mount: Codable, Sendable {
+public struct OCIMount: Codable, Sendable {
     public var type: String
     public var source: String
     public var destination: String
     public var options: [String]
 
-    public var uidMappings: [LinuxIDMapping]
-    public var gidMappings: [LinuxIDMapping]
+    public var uidMappings: [OCILinuxIDMapping]
+    public var gidMappings: [OCILinuxIDMapping]
 
     public init(
         type: String,
         source: String,
         destination: String,
         options: [String] = [],
-        uidMappings: [LinuxIDMapping] = [],
-        gidMappings: [LinuxIDMapping] = []
+        uidMappings: [OCILinuxIDMapping] = [],
+        gidMappings: [OCILinuxIDMapping] = []
     ) {
         self.destination = destination
         self.type = type
@@ -211,7 +211,7 @@ public struct Mount: Codable, Sendable {
     }
 }
 
-public struct Hook: Codable, Sendable {
+public struct OCIHook: Codable, Sendable {
     public var path: String
     public var args: [String]
     public var env: [String]
@@ -225,21 +225,21 @@ public struct Hook: Codable, Sendable {
     }
 }
 
-public struct Hooks: Codable, Sendable {
-    public var prestart: [Hook]
-    public var createRuntime: [Hook]
-    public var createContainer: [Hook]
-    public var startContainer: [Hook]
-    public var poststart: [Hook]
-    public var poststop: [Hook]
+public struct OCIHooks: Codable, Sendable {
+    public var prestart: [OCIHook]
+    public var createRuntime: [OCIHook]
+    public var createContainer: [OCIHook]
+    public var startContainer: [OCIHook]
+    public var poststart: [OCIHook]
+    public var poststop: [OCIHook]
 
     public init(
-        prestart: [Hook],
-        createRuntime: [Hook],
-        createContainer: [Hook],
-        startContainer: [Hook],
-        poststart: [Hook],
-        poststop: [Hook]
+        prestart: [OCIHook],
+        createRuntime: [OCIHook],
+        createContainer: [OCIHook],
+        startContainer: [OCIHook],
+        poststart: [OCIHook],
+        poststop: [OCIHook]
     ) {
         self.prestart = prestart
         self.createRuntime = createRuntime
@@ -250,35 +250,35 @@ public struct Hooks: Codable, Sendable {
     }
 }
 
-public struct Linux: Codable, Sendable {
-    public var uidMappings: [LinuxIDMapping]
-    public var gidMappings: [LinuxIDMapping]
+public struct OCILinux: Codable, Sendable {
+    public var uidMappings: [OCILinuxIDMapping]
+    public var gidMappings: [OCILinuxIDMapping]
     public var sysctl: [String: String]?
-    public var resources: LinuxResources?
+    public var resources: OCILinuxResources?
     public var cgroupsPath: String
-    public var namespaces: [LinuxNamespace]
-    public var devices: [LinuxDevice]
-    public var seccomp: LinuxSeccomp?
+    public var namespaces: [OCILinuxNamespace]
+    public var devices: [OCILinuxDevice]
+    public var seccomp: OCILinuxSeccomp?
     public var rootfsPropagation: String
     public var maskedPaths: [String]
     public var readonlyPaths: [String]
     public var mountLabel: String
-    public var personality: LinuxPersonality?
+    public var personality: OCILinuxPersonality?
 
     public init(
-        uidMappings: [LinuxIDMapping] = [],
-        gidMappings: [LinuxIDMapping] = [],
+        uidMappings: [OCILinuxIDMapping] = [],
+        gidMappings: [OCILinuxIDMapping] = [],
         sysctl: [String: String]? = nil,
-        resources: LinuxResources? = nil,
+        resources: OCILinuxResources? = nil,
         cgroupsPath: String = "",
-        namespaces: [LinuxNamespace] = [],
-        devices: [LinuxDevice] = [],
-        seccomp: LinuxSeccomp? = nil,
+        namespaces: [OCILinuxNamespace] = [],
+        devices: [OCILinuxDevice] = [],
+        seccomp: OCILinuxSeccomp? = nil,
         rootfsPropagation: String = "",
         maskedPaths: [String] = [],
         readonlyPaths: [String] = [],
         mountLabel: String = "",
-        personality: LinuxPersonality? = nil
+        personality: OCILinuxPersonality? = nil
     ) {
         self.uidMappings = uidMappings
         self.gidMappings = gidMappings
@@ -296,17 +296,17 @@ public struct Linux: Codable, Sendable {
     }
 }
 
-public struct LinuxNamespace: Codable, Sendable {
-    public var type: LinuxNamespaceType
+public struct OCILinuxNamespace: Codable, Sendable {
+    public var type: OCILinuxNamespaceType
     public var path: String
 
-    public init(type: LinuxNamespaceType, path: String = "") {
+    public init(type: OCILinuxNamespaceType, path: String = "") {
         self.type = type
         self.path = path
     }
 }
 
-public enum LinuxNamespaceType: String, Codable, Sendable {
+public enum OCILinuxNamespaceType: String, Codable, Sendable {
     case pid
     case network
     case uts
@@ -316,7 +316,7 @@ public enum LinuxNamespaceType: String, Codable, Sendable {
     case cgroup
 }
 
-public struct LinuxIDMapping: Codable, Sendable {
+public struct OCILinuxIDMapping: Codable, Sendable {
     public var containerID: UInt32
     public var hostID: UInt32
     public var size: UInt32
@@ -328,7 +328,7 @@ public struct LinuxIDMapping: Codable, Sendable {
     }
 }
 
-public struct POSIXRlimit: Codable, Sendable {
+public struct OCIRlimit: Codable, Sendable {
     public var type: String
     public var hard: UInt64
     public var soft: UInt64
@@ -340,7 +340,7 @@ public struct POSIXRlimit: Codable, Sendable {
     }
 }
 
-public struct LinuxHugepageLimit: Codable, Sendable {
+public struct OCILinuxHugepageLimit: Codable, Sendable {
     public var pagesize: String
     public var limit: UInt64
 
@@ -350,7 +350,7 @@ public struct LinuxHugepageLimit: Codable, Sendable {
     }
 }
 
-public struct LinuxInterfacePriority: Codable, Sendable {
+public struct OCILinuxInterfacePriority: Codable, Sendable {
     public var name: String
     public var priority: UInt32
 
@@ -360,7 +360,7 @@ public struct LinuxInterfacePriority: Codable, Sendable {
     }
 }
 
-public struct LinuxBlockIODevice: Codable, Sendable {
+public struct OCILinuxBlockIODevice: Codable, Sendable {
     public var major: Int64
     public var minor: Int64
 
@@ -370,7 +370,7 @@ public struct LinuxBlockIODevice: Codable, Sendable {
     }
 }
 
-public struct LinuxWeightDevice: Codable, Sendable {
+public struct OCILinuxWeightDevice: Codable, Sendable {
     public var major: Int64
     public var minor: Int64
     public var weight: UInt16?
@@ -384,7 +384,7 @@ public struct LinuxWeightDevice: Codable, Sendable {
     }
 }
 
-public struct LinuxThrottleDevice: Codable, Sendable {
+public struct OCILinuxThrottleDevice: Codable, Sendable {
     public var major: Int64
     public var minor: Int64
     public var rate: UInt64
@@ -396,23 +396,23 @@ public struct LinuxThrottleDevice: Codable, Sendable {
     }
 }
 
-public struct LinuxBlockIO: Codable, Sendable {
+public struct OCILinuxBlockIO: Codable, Sendable {
     public var weight: UInt16?
     public var leafWeight: UInt16?
-    public var weightDevice: [LinuxWeightDevice]
-    public var throttleReadBpsDevice: [LinuxThrottleDevice]
-    public var throttleWriteBpsDevice: [LinuxThrottleDevice]
-    public var throttleReadIOPSDevice: [LinuxThrottleDevice]
-    public var throttleWriteIOPSDevice: [LinuxThrottleDevice]
+    public var weightDevice: [OCILinuxWeightDevice]
+    public var throttleReadBpsDevice: [OCILinuxThrottleDevice]
+    public var throttleWriteBpsDevice: [OCILinuxThrottleDevice]
+    public var throttleReadIOPSDevice: [OCILinuxThrottleDevice]
+    public var throttleWriteIOPSDevice: [OCILinuxThrottleDevice]
 
     public init(
         weight: UInt16?,
         leafWeight: UInt16?,
-        weightDevice: [LinuxWeightDevice],
-        throttleReadBpsDevice: [LinuxThrottleDevice],
-        throttleWriteBpsDevice: [LinuxThrottleDevice],
-        throttleReadIOPSDevice: [LinuxThrottleDevice],
-        throttleWriteIOPSDevice: [LinuxThrottleDevice]
+        weightDevice: [OCILinuxWeightDevice],
+        throttleReadBpsDevice: [OCILinuxThrottleDevice],
+        throttleWriteBpsDevice: [OCILinuxThrottleDevice],
+        throttleReadIOPSDevice: [OCILinuxThrottleDevice],
+        throttleWriteIOPSDevice: [OCILinuxThrottleDevice]
     ) {
         self.weight = weight
         self.leafWeight = leafWeight
@@ -424,7 +424,7 @@ public struct LinuxBlockIO: Codable, Sendable {
     }
 }
 
-public struct LinuxMemory: Codable, Sendable {
+public struct OCILinuxMemory: Codable, Sendable {
     public var limit: Int64?
     public var reservation: Int64?
     public var swap: Int64?
@@ -458,7 +458,7 @@ public struct LinuxMemory: Codable, Sendable {
     }
 }
 
-public struct LinuxCPU: Codable, Sendable {
+public struct OCILinuxCPU: Codable, Sendable {
     public var shares: UInt64?
     public var quota: Int64?
     public var burst: UInt64?
@@ -492,7 +492,7 @@ public struct LinuxCPU: Codable, Sendable {
     }
 }
 
-public struct LinuxPids: Codable, Sendable {
+public struct OCILinuxPids: Codable, Sendable {
     public var limit: Int64
 
     public init(limit: Int64) {
@@ -500,17 +500,17 @@ public struct LinuxPids: Codable, Sendable {
     }
 }
 
-public struct LinuxNetwork: Codable, Sendable {
+public struct OCILinuxNetwork: Codable, Sendable {
     public var classID: UInt32?
-    public var priorities: [LinuxInterfacePriority]
+    public var priorities: [OCILinuxInterfacePriority]
 
-    public init(classID: UInt32?, priorities: [LinuxInterfacePriority]) {
+    public init(classID: UInt32?, priorities: [OCILinuxInterfacePriority]) {
         self.classID = classID
         self.priorities = priorities
     }
 }
 
-public struct LinuxRdma: Codable, Sendable {
+public struct OCILinuxRdma: Codable, Sendable {
     public var hcsHandles: UInt32?
     public var hcaObjects: UInt32?
 
@@ -520,26 +520,26 @@ public struct LinuxRdma: Codable, Sendable {
     }
 }
 
-public struct LinuxResources: Codable, Sendable {
-    public var devices: [LinuxDeviceCgroup]
-    public var memory: LinuxMemory?
-    public var cpu: LinuxCPU?
-    public var pids: LinuxPids?
-    public var blockIO: LinuxBlockIO?
-    public var hugepageLimits: [LinuxHugepageLimit]
-    public var network: LinuxNetwork?
-    public var rdma: [String: LinuxRdma]?
+public struct OCILinuxResources: Codable, Sendable {
+    public var devices: [OCILinuxDeviceCgroup]
+    public var memory: OCILinuxMemory?
+    public var cpu: OCILinuxCPU?
+    public var pids: OCILinuxPids?
+    public var blockIO: OCILinuxBlockIO?
+    public var hugepageLimits: [OCILinuxHugepageLimit]
+    public var network: OCILinuxNetwork?
+    public var rdma: [String: OCILinuxRdma]?
     public var unified: [String: String]?
 
     public init(
-        devices: [LinuxDeviceCgroup] = [],
-        memory: LinuxMemory? = nil,
-        cpu: LinuxCPU? = nil,
-        pids: LinuxPids? = nil,
-        blockIO: LinuxBlockIO? = nil,
-        hugepageLimits: [LinuxHugepageLimit] = [],
-        network: LinuxNetwork? = nil,
-        rdma: [String: LinuxRdma]? = nil,
+        devices: [OCILinuxDeviceCgroup] = [],
+        memory: OCILinuxMemory? = nil,
+        cpu: OCILinuxCPU? = nil,
+        pids: OCILinuxPids? = nil,
+        blockIO: OCILinuxBlockIO? = nil,
+        hugepageLimits: [OCILinuxHugepageLimit] = [],
+        network: OCILinuxNetwork? = nil,
+        rdma: [String: OCILinuxRdma]? = nil,
         unified: [String: String] = [:]
     ) {
         self.devices = devices
@@ -554,7 +554,7 @@ public struct LinuxResources: Codable, Sendable {
     }
 }
 
-public struct LinuxDevice: Codable, Sendable {
+public struct OCILinuxDevice: Codable, Sendable {
     public var path: String
     public var type: String
     public var major: Int64
@@ -582,7 +582,7 @@ public struct LinuxDevice: Codable, Sendable {
     }
 }
 
-public struct LinuxDeviceCgroup: Codable, Sendable {
+public struct OCILinuxDeviceCgroup: Codable, Sendable {
     public var allow: Bool
     public var type: String
     public var major: Int64?
@@ -598,38 +598,38 @@ public struct LinuxDeviceCgroup: Codable, Sendable {
     }
 }
 
-public enum LinuxPersonalityDomain: String, Codable, Sendable {
+public enum OCILinuxPersonalityDomain: String, Codable, Sendable {
     case perLinux = "LINUX"
     case perLinux32 = "LINUX32"
 }
 
-public struct LinuxPersonality: Codable, Sendable {
-    public var domain: LinuxPersonalityDomain
+public struct OCILinuxPersonality: Codable, Sendable {
+    public var domain: OCILinuxPersonalityDomain
     public var flags: [String]
 
-    public init(domain: LinuxPersonalityDomain, flags: [String]) {
+    public init(domain: OCILinuxPersonalityDomain, flags: [String]) {
         self.domain = domain
         self.flags = flags
     }
 }
 
-public struct LinuxSeccomp: Codable, Sendable {
-    public var defaultAction: LinuxSeccompAction
+public struct OCILinuxSeccomp: Codable, Sendable {
+    public var defaultAction: OCILinuxSeccompAction
     public var defaultErrnoRet: UInt?
-    public var architectures: [Arch]
-    public var flags: [LinuxSeccompFlag]
+    public var architectures: [OCIArch]
+    public var flags: [OCILinuxSeccompFlag]
     public var listenerPath: String
     public var listenerMetadata: String
-    public var syscalls: [LinuxSyscall]
+    public var syscalls: [OCILinuxSyscall]
 
     public init(
-        defaultAction: LinuxSeccompAction,
+        defaultAction: OCILinuxSeccompAction,
         defaultErrnoRet: UInt?,
-        architectures: [Arch],
-        flags: [LinuxSeccompFlag],
+        architectures: [OCIArch],
+        flags: [OCILinuxSeccompFlag],
         listenerPath: String,
         listenerMetadata: String,
-        syscalls: [LinuxSyscall]
+        syscalls: [OCILinuxSyscall]
     ) {
         self.defaultAction = defaultAction
         self.defaultErrnoRet = defaultErrnoRet
@@ -641,13 +641,13 @@ public struct LinuxSeccomp: Codable, Sendable {
     }
 }
 
-public enum LinuxSeccompFlag: String, Codable, Sendable {
+public enum OCILinuxSeccompFlag: String, Codable, Sendable {
     case flagLog = "SECCOMP_FILTER_FLAG_LOG"
     case flagSpecAllow = "SECCOMP_FILTER_FLAG_SPEC_ALLOW"
     case flagWaitKillableRecv = "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV"
 }
 
-public enum Arch: String, Codable, Sendable {
+public enum OCIArch: String, Codable, Sendable {
     case archX86 = "SCMP_ARCH_X86"
     case archX86_64 = "SCMP_ARCH_X86_64"
     case archX32 = "SCMP_ARCH_X32"
@@ -669,7 +669,7 @@ public enum Arch: String, Codable, Sendable {
     case archRISCV64 = "SCMP_ARCH_RISCV64"
 }
 
-public enum LinuxSeccompAction: String, Codable, Sendable {
+public enum OCILinuxSeccompAction: String, Codable, Sendable {
     case actKill = "SCMP_ACT_KILL"
     case actKillProcess = "SCMP_ACT_KILL_PROCESS"
     case actKillThread = "SCMP_ACT_KILL_THREAD"
@@ -681,7 +681,7 @@ public enum LinuxSeccompAction: String, Codable, Sendable {
     case actNotify = "SCMP_ACT_NOTIFY"
 }
 
-public enum LinuxSeccompOperator: String, Codable, Sendable {
+public enum OCILinuxSeccompOperator: String, Codable, Sendable {
     case opNotEqual = "SCMP_CMP_NE"
     case opLessThan = "SCMP_CMP_LT"
     case opLessEqual = "SCMP_CMP_LE"
@@ -691,13 +691,13 @@ public enum LinuxSeccompOperator: String, Codable, Sendable {
     case opMaskedEqual = "SCMP_CMP_MASKED_EQ"
 }
 
-public struct LinuxSeccompArg: Codable, Sendable {
+public struct OCILinuxSeccompArg: Codable, Sendable {
     public var index: UInt
     public var value: UInt64
     public var valueTwo: UInt64
-    public var op: LinuxSeccompOperator
+    public var op: OCILinuxSeccompOperator
 
-    public init(index: UInt, value: UInt64, valueTwo: UInt64, op: LinuxSeccompOperator) {
+    public init(index: UInt, value: UInt64, valueTwo: UInt64, op: OCILinuxSeccompOperator) {
         self.index = index
         self.value = value
         self.valueTwo = valueTwo
@@ -705,17 +705,17 @@ public struct LinuxSeccompArg: Codable, Sendable {
     }
 }
 
-public struct LinuxSyscall: Codable, Sendable {
+public struct OCILinuxSyscall: Codable, Sendable {
     public var names: [String]
-    public var action: LinuxSeccompAction
+    public var action: OCILinuxSeccompAction
     public var errnoRet: UInt?
-    public var args: [LinuxSeccompArg]
+    public var args: [OCILinuxSeccompArg]
 
     public init(
         names: [String],
-        action: LinuxSeccompAction,
+        action: OCILinuxSeccompAction,
         errnoRet: UInt?,
-        args: [LinuxSeccompArg]
+        args: [OCILinuxSeccompArg]
     ) {
         self.names = names
         self.action = action

--- a/Sources/ContainerizationOCI/State.swift
+++ b/Sources/ContainerizationOCI/State.swift
@@ -14,18 +14,18 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-public enum ContainerState: String, Codable, Sendable {
+public enum OCIContainerState: String, Codable, Sendable {
     case creating
     case created
     case running
     case stopped
 }
 
-public struct State: Codable, Sendable {
+public struct OCIState: Codable, Sendable {
     public init(
         version: String,
         id: String,
-        status: ContainerState,
+        status: OCIContainerState,
         pid: Int,
         bundle: String,
         annotations: [String: String]?
@@ -38,7 +38,7 @@ public struct State: Codable, Sendable {
         self.annotations = annotations
     }
 
-    public init(instance: State) {
+    public init(instance: OCIState) {
         self.ociVersion = instance.ociVersion
         self.id = instance.id
         self.status = instance.status
@@ -49,7 +49,7 @@ public struct State: Codable, Sendable {
 
     public let ociVersion: String
     public let id: String
-    public let status: ContainerState
+    public let status: OCIContainerState
     public let pid: Int
     public let bundle: String
     public var annotations: [String: String]?
@@ -57,8 +57,8 @@ public struct State: Codable, Sendable {
 
 public let seccompFdName: String = "seccompFd"
 
-public struct ContainerProcessState: Codable, Sendable {
-    public init(version: String, fds: [String], pid: Int, metadata: String, state: State) {
+public struct OCIContainerProcessState: Codable, Sendable {
+    public init(version: String, fds: [String], pid: Int, metadata: String, state: OCIState) {
         self.ociVersion = version
         self.fds = fds
         self.pid = pid
@@ -66,7 +66,7 @@ public struct ContainerProcessState: Codable, Sendable {
         self.state = state
     }
 
-    public init(instance: ContainerProcessState) {
+    public init(instance: OCIContainerProcessState) {
         self.ociVersion = instance.ociVersion
         self.fds = instance.fds
         self.pid = instance.pid
@@ -78,5 +78,5 @@ public struct ContainerProcessState: Codable, Sendable {
     public var fds: [String]
     public let pid: Int
     public let metadata: String
-    public let state: State
+    public let state: OCIState
 }

--- a/Sources/ContainerizationOCI/Version.swift
+++ b/Sources/ContainerizationOCI/Version.swift
@@ -14,11 +14,11 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-public struct RuntimeSpecVersion: Sendable {
+public struct OCIRuntimeSpecVersion: Sendable {
     public let major, minor, patch: Int
     public let dev: String
 
-    public static let current = RuntimeSpecVersion(
+    public static let current = OCIRuntimeSpecVersion(
         major: 1,
         minor: 0,
         patch: 2,

--- a/Sources/Integration/ProcessTests.swift
+++ b/Sources/Integration/ProcessTests.swift
@@ -134,7 +134,7 @@ extension IntegrationSuite {
             try await container.create()
             try await container.start()
 
-            let execConfig = ContainerizationOCI.Process(
+            let execConfig = OCIProcess(
                 args: ["/bin/true"],
                 env: ["PATH=\(LinuxContainer.defaultPath)"]
             )
@@ -185,7 +185,7 @@ extension IntegrationSuite {
             try await container.create()
             try await container.start()
 
-            let baseExecConfig = ContainerizationOCI.Process(
+            let baseExecConfig = OCIProcess(
                 args: ["sh", "-c", "dd if=/dev/random of=/tmp/bytes bs=1M count=20 status=none ; sha256sum /tmp/bytes"],
                 env: ["PATH=\(LinuxContainer.defaultPath)"]
             )
@@ -203,7 +203,7 @@ extension IntegrationSuite {
             let output = String(data: buffer.data, encoding: .utf8)!
             let expected = String(output.split(separator: " ").first!)
             try await withThrowingTaskGroup(of: Void.self) { group in
-                let execConfig = ContainerizationOCI.Process(
+                let execConfig = OCIProcess(
                     args: ["cat", "/tmp/bytes"],
                     env: ["PATH=\(LinuxContainer.defaultPath)"]
                 )

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -120,7 +120,7 @@ struct IntegrationSuite: AsyncParsableCommand {
         var testKernel = Kernel(path: .init(filePath: kernel), platform: .linuxArm)
         testKernel.commandLine.addDebug()
         let image = try await Self.fetchImage(reference: reference, store: store)
-        let platform = Platform(arch: "arm64", os: "linux", variant: "v8")
+        let platform = OCIPlatform(arch: "arm64", os: "linux", variant: "v8")
 
         let fs: Containerization.Mount = try await {
             let fsPath = Self.testDir.appending(component: "rootfs.ext4")

--- a/Sources/cctl/ImageCommand.swift
+++ b/Sources/cctl/ImageCommand.swift
@@ -85,7 +85,7 @@ extension Application {
 
         struct ImageDisplay: Codable {
             let reference: String
-            let index: Index
+            let index: OCIIndex
         }
 
         struct Pull: AsyncParsableCommand {
@@ -109,9 +109,9 @@ extension Application {
 
             func run() async throws {
                 let imageStore = Application.imageStore
-                let platform: Platform? = try {
+                let platform: OCIPlatform? = try {
                     if let platformString {
-                        return try Platform(from: platformString)
+                        return try OCIPlatform(from: platformString)
                     }
                     return nil
                 }()
@@ -177,9 +177,9 @@ extension Application {
 
             func run() async throws {
                 let imageStore = Application.imageStore
-                let platform: Platform? = try {
+                let platform: OCIPlatform? = try {
                     if let platformString {
-                        return try Platform(from: platformString)
+                        return try OCIPlatform(from: platformString)
                     }
                     return nil
                 }()
@@ -212,9 +212,9 @@ extension Application {
             @Argument var reference: [String]
 
             func run() async throws {
-                var p: Platform? = nil
+                var p: OCIPlatform? = nil
                 if let platform {
-                    p = try Platform(from: platform)
+                    p = try OCIPlatform(from: platform)
                 }
                 let store = Application.imageStore
                 let tempDir = FileManager.default.uniqueTemporaryDirectory()

--- a/Sources/cctl/RootfsCommand.swift
+++ b/Sources/cctl/RootfsCommand.swift
@@ -41,7 +41,7 @@ extension Application {
             var vmexec: String
 
             @Option(name: .long, help: "Platform of the built binaries being packaged into the block")
-            var platformString: String = Platform.current.description
+            var platformString: String = OCIPlatform.current.description
 
             @Option(name: .long, help: "Labels to add to the built image of the form <key1>=<value1>, [<key2>=<value2>,...]")
             var labels: [String] = []
@@ -64,7 +64,7 @@ extension Application {
 
             func run() async throws {
                 try await writeArchive()
-                let p = try Platform(from: platformString)
+                let p = try OCIPlatform(from: platformString)
                 let rootfs = URL(filePath: rootfsPath)
                 let labels = Application.parseKeyValuePairs(from: labels)
                 _ = try await InitImage.create(

--- a/Sources/cctl/cctl+Utils.swift
+++ b/Sources/cctl/cctl+Utils.swift
@@ -46,8 +46,8 @@ extension Application {
     }
 }
 
-extension ContainerizationOCI.Platform {
-    static var arm64: ContainerizationOCI.Platform {
+extension OCIPlatform {
+    static var arm64: OCIPlatform {
         .init(arch: "arm64", os: "linux", variant: "v8")
     }
 }

--- a/Tests/ContainerizationOCITests/OCIImageTests.swift
+++ b/Tests/ContainerizationOCITests/OCIImageTests.swift
@@ -22,43 +22,43 @@ import Testing
 
 struct OCITests {
     @Test func config() {
-        let config = ContainerizationOCI.ImageConfig()
-        let rootfs = ContainerizationOCI.Rootfs(type: "foo", diffIDs: ["diff1", "diff2"])
-        let history = ContainerizationOCI.History()
+        let config = OCIImageConfig()
+        let rootfs = OCIRootfs(type: "foo", diffIDs: ["diff1", "diff2"])
+        let history = OCIHistory()
 
-        let image = ContainerizationOCI.Image(architecture: "arm64", os: "linux", config: config, rootfs: rootfs, history: [history])
+        let image = OCIImage(architecture: "arm64", os: "linux", config: config, rootfs: rootfs, history: [history])
         #expect(image.rootfs.type == "foo")
     }
 
     @Test func descriptor() {
-        let platform = ContainerizationOCI.Platform(arch: "arm64", os: "linux")
-        let descriptor = ContainerizationOCI.Descriptor(mediaType: MediaTypes.descriptor, digest: "123", size: 0, platform: platform)
+        let platform = OCIPlatform(arch: "arm64", os: "linux")
+        let descriptor = OCIDescriptor(mediaType: OCIMediaTypes.descriptor, digest: "123", size: 0, platform: platform)
 
         #expect(descriptor.platform?.architecture == "arm64")
         #expect(descriptor.platform?.os == "linux")
     }
 
     @Test func index() {
-        var descriptors: [ContainerizationOCI.Descriptor] = []
+        var descriptors: [OCIDescriptor] = []
         for i in 0..<5 {
-            let descriptor = ContainerizationOCI.Descriptor(mediaType: MediaTypes.descriptor, digest: "\(i)", size: Int64(i))
+            let descriptor = OCIDescriptor(mediaType: OCIMediaTypes.descriptor, digest: "\(i)", size: Int64(i))
             descriptors.append(descriptor)
         }
 
-        let index = ContainerizationOCI.Index(schemaVersion: 1, manifests: descriptors)
+        let index = OCIIndex(schemaVersion: 1, manifests: descriptors)
         #expect(index.manifests.count == 5)
     }
 
     @Test func manifests() {
-        var descriptors: [ContainerizationOCI.Descriptor] = []
+        var descriptors: [OCIDescriptor] = []
         for i in 0..<5 {
-            let descriptor = ContainerizationOCI.Descriptor(mediaType: MediaTypes.descriptor, digest: "\(i)", size: Int64(i))
+            let descriptor = OCIDescriptor(mediaType: OCIMediaTypes.descriptor, digest: "\(i)", size: Int64(i))
             descriptors.append(descriptor)
         }
 
-        let config = ContainerizationOCI.Descriptor(mediaType: MediaTypes.descriptor, digest: "123", size: 0)
+        let config = OCIDescriptor(mediaType: OCIMediaTypes.descriptor, digest: "123", size: 0)
 
-        let manifest = ContainerizationOCI.Manifest(schemaVersion: 1, config: config, layers: descriptors)
+        let manifest = OCIManifest(schemaVersion: 1, config: config, layers: descriptors)
         #expect(manifest.config.digest == "123")
         #expect(manifest.layers.count == 5)
     }

--- a/Tests/ContainerizationOCITests/OCIPlatformTests.swift
+++ b/Tests/ContainerizationOCITests/OCIPlatformTests.swift
@@ -22,48 +22,48 @@ import Testing
 
 struct OCIPlatformTests {
     @Test func identicalPlatforms() {
-        let amd64lhs = Platform(arch: "amd64", os: "linux")
-        let amd64rhs = Platform(arch: "amd64", os: "linux")
+        let amd64lhs = OCIPlatform(arch: "amd64", os: "linux")
+        let amd64rhs = OCIPlatform(arch: "amd64", os: "linux")
         #expect(amd64lhs == amd64rhs, "amd64 platforms should be equal")
 
-        let arm64lhs = Platform(arch: "arm64", os: "linux")
-        let arm64rhs = Platform(arch: "arm64", os: "linux")
+        let arm64lhs = OCIPlatform(arch: "arm64", os: "linux")
+        let arm64rhs = OCIPlatform(arch: "arm64", os: "linux")
         #expect(arm64lhs == arm64rhs, "arm64 platforms should be equal")
     }
 
     @Test func differentOS() {
-        let lhs = Platform(arch: "arm64", os: "linux")
-        let rhs = Platform(arch: "arm64", os: "darwin")
+        let lhs = OCIPlatform(arch: "arm64", os: "linux")
+        let rhs = OCIPlatform(arch: "arm64", os: "darwin")
         #expect(lhs != rhs, "Different OS should not be equal")
     }
 
     @Test func differentArch() {
-        let lhs = Platform(arch: "amd64", os: "linux")
-        let rhs = Platform(arch: "arm64", os: "linux")
+        let lhs = OCIPlatform(arch: "amd64", os: "linux")
+        let rhs = OCIPlatform(arch: "arm64", os: "linux")
         #expect(lhs != rhs, "Different arch should not be equal")
     }
 
     @Test func arm64_sameVariant() {
-        let lhs = Platform(arch: "arm64", os: "linux", variant: "v8")
-        let rhs = Platform(arch: "arm64", os: "linux", variant: "v8")
+        let lhs = OCIPlatform(arch: "arm64", os: "linux", variant: "v8")
+        let rhs = OCIPlatform(arch: "arm64", os: "linux", variant: "v8")
         #expect(lhs == rhs, "Both OS arm64, same arch, same variant => equal")
     }
 
     @Test func arm64_nilAndV8() {
-        let lhs = Platform(arch: "arm64", os: "linux", variant: nil)
-        let rhs = Platform(arch: "arm64", os: "linux", variant: "v8")
+        let lhs = OCIPlatform(arch: "arm64", os: "linux", variant: nil)
+        let rhs = OCIPlatform(arch: "arm64", os: "linux", variant: "v8")
         #expect(lhs == rhs, "One variant nil and other v8 => equal under special arm64 rule")
     }
 
     @Test func arm64_nilAndV7() {
-        let lhs = Platform(arch: "arm64", os: "linux", variant: nil)
-        let rhs = Platform(arch: "arm64", os: "linux", variant: "v7")
+        let lhs = OCIPlatform(arch: "arm64", os: "linux", variant: nil)
+        let rhs = OCIPlatform(arch: "arm64", os: "linux", variant: "v7")
         #expect(lhs != rhs, "nil vs v7 is not covered by the special rule => not equal")
     }
 
     @Test func arm64_bothNil() {
-        let lhs = Platform(arch: "arm64", os: "linux", variant: nil)
-        let rhs = Platform(arch: "arm64", os: "linux", variant: nil)
+        let lhs = OCIPlatform(arch: "arm64", os: "linux", variant: nil)
+        let rhs = OCIPlatform(arch: "arm64", os: "linux", variant: nil)
         #expect(lhs == rhs, "Both nil variants => variantEqual is true => overall equal")
     }
 }

--- a/Tests/ContainerizationTests/ImageTests/ImageStoreImagePullTests.swift
+++ b/Tests/ContainerizationTests/ImageTests/ImageStoreImagePullTests.swift
@@ -47,15 +47,15 @@ final class ImageStoreImagePullTests {
         let img = try await self.store.pull(reference: "ghcr.io/apple/containerization/dockermanifestimage:0.0.2")
 
         let rootDescriptor = img.descriptor
-        let index: ContainerizationOCI.Index = try await contentStore.get(digest: rootDescriptor.digest)!
+        let index: OCIIndex = try await contentStore.get(digest: rootDescriptor.digest)!
 
         #expect(index.manifests.count == 1)
         let desc = index.manifests.first!
         #expect(desc.platform!.architecture == "amd64")
 
         await #expect(throws: Never.self) {
-            let manifest: ContainerizationOCI.Manifest = try await self.contentStore.get(digest: desc.digest)!
-            let _: ContainerizationOCI.Image = try await self.contentStore.get(digest: manifest.config.digest)!
+            let manifest: OCIManifest = try await self.contentStore.get(digest: desc.digest)!
+            let _: OCIImage = try await self.contentStore.get(digest: manifest.config.digest)!
             for layer in manifest.layers {
                 _ = try await self.contentStore.get(digest: layer.digest)!
             }
@@ -64,15 +64,15 @@ final class ImageStoreImagePullTests {
 
     @Test(
         arguments: [
-            (Platform(arch: "arm64", os: "linux", variant: "v8"), imagePullArm64Layers),
-            (Platform(arch: "amd64", os: "linux"), imagePullAmd64Layers),
+            (OCIPlatform(arch: "arm64", os: "linux", variant: "v8"), imagePullArm64Layers),
+            (OCIPlatform(arch: "amd64", os: "linux"), imagePullAmd64Layers),
             (nil, imagePullTestAllLayers),
         ])
-    func testPullSinglePlatform(platform: Platform?, expectLayers: [String]) async throws {
+    func testPullSinglePlatform(platform: OCIPlatform?, expectLayers: [String]) async throws {
         let img = try await self.store.pull(
             reference: "ghcr.io/linuxcontainers/alpine:3.20@sha256:0a6a86d44d7f93c4f2b8dea7f0eee64e72cb98635398779f3610949632508d57", platform: platform)
         let rootDescriptor = img.descriptor
-        let index: ContainerizationOCI.Index = try await contentStore.get(digest: rootDescriptor.digest)!
+        let index: OCIIndex = try await contentStore.get(digest: rootDescriptor.digest)!
         var foundMatch = false
         for desc in index.manifests {
             if let platform {
@@ -82,8 +82,8 @@ final class ImageStoreImagePullTests {
             }
             foundMatch = true
             await #expect(throws: Never.self) {
-                let manifest: ContainerizationOCI.Manifest = try await self.contentStore.get(digest: desc.digest)!
-                let _: ContainerizationOCI.Image = try await self.contentStore.get(digest: manifest.config.digest)!
+                let manifest: OCIManifest = try await self.contentStore.get(digest: desc.digest)!
+                let _: OCIImage = try await self.contentStore.get(digest: manifest.config.digest)!
                 for layer in manifest.layers {
                     _ = try await self.contentStore.get(digest: layer.digest)!
                 }

--- a/vminitd/Sources/vmexec/ExecCommand.swift
+++ b/vminitd/Sources/vmexec/ExecCommand.swift
@@ -40,7 +40,7 @@ struct ExecCommand: ParsableCommand {
         let src = URL(fileURLWithPath: processPath)
         let processBytes = try Data(contentsOf: src)
         let process = try JSONDecoder().decode(
-            ContainerizationOCI.Process.self,
+            OCIProcess.self,
             from: processBytes
         )
         try execInNamespaces(process: process, log: log)
@@ -59,7 +59,7 @@ struct ExecCommand: ParsableCommand {
     }
 
     private func execInNamespaces(
-        process: ContainerizationOCI.Process,
+        process: OCIProcess,
         log: Logger
     ) throws {
         // CLOEXEC the pipe fd that signals process readiness.

--- a/vminitd/Sources/vmexec/Mount.swift
+++ b/vminitd/Sources/vmexec/Mount.swift
@@ -20,10 +20,10 @@ import Foundation
 import Musl
 
 struct ContainerMount {
-    private let mounts: [ContainerizationOCI.Mount]
+    private let mounts: [OCIMount]
     private let rootfs: String
 
-    init(rootfs: String, mounts: [ContainerizationOCI.Mount]) {
+    init(rootfs: String, mounts: [OCIMount]) {
         self.rootfs = rootfs
         self.mounts = mounts
     }
@@ -55,9 +55,9 @@ struct ContainerMount {
     }
 }
 
-extension ContainerizationOCI.Mount {
-    func toOSMount() -> ContainerizationOS.Mount {
-        ContainerizationOS.Mount(
+extension OCIMount {
+    func toOSMount() -> Mount {
+        Mount(
             type: self.type,
             source: self.source,
             target: self.destination,

--- a/vminitd/Sources/vmexec/RunCommand.swift
+++ b/vminitd/Sources/vmexec/RunCommand.swift
@@ -34,12 +34,12 @@ struct RunCommand: ParsableCommand {
         LoggingSystem.bootstrap(App.standardError)
         let log = Logger(label: "vmexec")
 
-        let bundle = try ContainerizationOCI.Bundle.load(path: URL(filePath: bundlePath))
+        let bundle = try OCIBundle.load(path: URL(filePath: bundlePath))
         let ociSpec = try bundle.loadConfig()
         try execInNamespace(spec: ociSpec, log: log)
     }
 
-    private func childRootSetup(rootfs: ContainerizationOCI.Root, mounts: [ContainerizationOCI.Mount], log: Logger) throws {
+    private func childRootSetup(rootfs: OCIRoot, mounts: [OCIMount], log: Logger) throws {
         // setup rootfs
         try prepareRoot(rootfs: rootfs.path)
         try mountRootfs(rootfs: rootfs.path, mounts: mounts)
@@ -49,7 +49,7 @@ struct RunCommand: ParsableCommand {
         try reOpenDevNull()
     }
 
-    private func execInNamespace(spec: ContainerizationOCI.Spec, log: Logger) throws {
+    private func execInNamespace(spec: OCISpec, log: Logger) throws {
         guard let process = spec.process else {
             fatalError("no process configuration found in runtime spec")
         }
@@ -138,7 +138,7 @@ struct RunCommand: ParsableCommand {
         }
     }
 
-    private func mountRootfs(rootfs: String, mounts: [ContainerizationOCI.Mount]) throws {
+    private func mountRootfs(rootfs: String, mounts: [OCIMount]) throws {
         let containerMount = ContainerMount(rootfs: rootfs, mounts: mounts)
         try containerMount.mountToRootfs()
         try containerMount.configureConsole()

--- a/vminitd/Sources/vmexec/vmexec.swift
+++ b/vminitd/Sources/vmexec/vmexec.swift
@@ -68,7 +68,7 @@ extension App {
         }
     }
 
-    static func exec(process: ContainerizationOCI.Process) throws {
+    static func exec(process: OCIProcess) throws {
         let executable = strdup(process.args[0])
         var argv = process.args.map { strdup($0) }
         argv += [nil]
@@ -87,7 +87,7 @@ extension App {
         fatalError("execvpe failed")
     }
 
-    static func setPermissions(user: ContainerizationOCI.User) throws {
+    static func setPermissions(user: OCIUser) throws {
         if user.additionalGids.count > 0 {
             guard setgroups(user.additionalGids.count, user.additionalGids) == 0 else {
                 throw App.Errno(stage: "setgroups()")
@@ -104,7 +104,7 @@ extension App {
         }
     }
 
-    static func fixStdioPerms(user: ContainerizationOCI.User) throws {
+    static func fixStdioPerms(user: OCIUser) throws {
         for i in 0...2 {
             var fdStat = stat()
             try withUnsafeMutablePointer(to: &fdStat) { pointer in
@@ -122,7 +122,7 @@ extension App {
         }
     }
 
-    static func setRLimits(rlimits: [ContainerizationOCI.POSIXRlimit]) throws {
+    static func setRLimits(rlimits: [OCIRlimit]) throws {
         for rl in rlimits {
             var limit = rlimit(rlim_cur: rl.soft, rlim_max: rl.hard)
             let resource: Int32

--- a/vminitd/Sources/vminitd/ManagedContainer.swift
+++ b/vminitd/Sources/vminitd/ManagedContainer.swift
@@ -25,7 +25,7 @@ actor ManagedContainer {
     let initProcess: ManagedProcess
 
     private let _log: Logger
-    private let _bundle: ContainerizationOCI.Bundle
+    private let _bundle: OCIBundle
     private var _execs: [String: ManagedProcess] = [:]
 
     var pid: Int32 {
@@ -35,10 +35,10 @@ actor ManagedContainer {
     init(
         id: String,
         stdio: HostStdio,
-        spec: ContainerizationOCI.Spec,
+        spec: OCISpec,
         log: Logger
     ) throws {
-        let bundle = try ContainerizationOCI.Bundle.create(
+        let bundle = try OCIBundle.create(
             path: Self.craftBundlePath(id: id),
             spec: spec
         )
@@ -73,7 +73,7 @@ extension ManagedContainer {
     func createExec(
         id: String,
         stdio: HostStdio,
-        process: ContainerizationOCI.Process
+        process: OCIProcess
     ) throws {
         // Write the process config to the bundle, and pass this on
         // over to ManagedProcess to deal with.
@@ -144,8 +144,8 @@ extension ManagedContainer {
     }
 }
 
-extension ContainerizationOCI.Bundle {
-    func createExecSpec(id: String, process: ContainerizationOCI.Process) throws {
+extension OCIBundle {
+    func createExecSpec(id: String, process: OCIProcess) throws {
         let specDir = self.path.appending(path: "execs/\(id)")
 
         let fm = FileManager.default

--- a/vminitd/Sources/vminitd/ManagedProcess.swift
+++ b/vminitd/Sources/vminitd/ManagedProcess.swift
@@ -65,7 +65,7 @@ final class ManagedProcess: Sendable {
     init(
         id: String,
         stdio: HostStdio,
-        bundle: ContainerizationOCI.Bundle,
+        bundle: OCIBundle,
         owningPid: Int32? = nil,
         log: Logger
     ) throws {

--- a/vminitd/Sources/vminitd/Server+GRPC.swift
+++ b/vminitd/Sources/vminitd/Server+GRPC.swift
@@ -257,7 +257,7 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContextAsyncProvid
             ])
 
         do {
-            let mnt = ContainerizationOS.Mount(
+            let mnt = Mount(
                 type: request.type,
                 source: request.source,
                 target: request.destination,
@@ -376,7 +376,7 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContextAsyncProvid
 
         do {
             var ociSpec = try JSONDecoder().decode(
-                ContainerizationOCI.Spec.self,
+                OCISpec.self,
                 from: request.configuration
             )
 
@@ -833,7 +833,7 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContextAsyncProvid
 }
 
 extension Initd {
-    func ociAlterations(ociSpec: inout ContainerizationOCI.Spec) throws {
+    func ociAlterations(ociSpec: inout OCISpec) throws {
         guard var process = ociSpec.process else {
             throw ContainerizationError(
                 .invalidArgument,


### PR DESCRIPTION
Fixes #202

A large majority of the types in this package were extremely generically named making it common to have to reference the types as ContainerizationOCI.TheType. This change prefixes all of the core runtime spec, and image spec types with OCI, and then adjusts our code to reference these new names so we still build :)

This is a breaking change, but I'd rather pull the bandaid now.