### PR TITLE
Make KeychainQuery errors type public

### DIFF
--- a/Sources/ContainerizationOS/Keychain/KeychainQuery.swift
+++ b/Sources/ContainerizationOS/Keychain/KeychainQuery.swift
@@ -135,7 +135,7 @@ public struct KeychainQuery {
 }
 
 extension KeychainQuery {
-    enum Error: Swift.Error {
+    public enum Error: Swift.Error {
         case unhandledError(status: Int32)
         case unexpectedDataFetched
         case keyNotPresent(key: String)


### PR DESCRIPTION
There have been a few issues filed in container [here](https://github.com/apple/container/issues/254) and [here](https://github.com/apple/container/issues/321), where people are unable to pull or push to registries despite a successful login to that registry. 

Making this enum public so that we can get the error in container and handle it correctly. 

