### PR TITLE
Check for supported types in the `@SendableProperty` macro

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -54,7 +54,7 @@ public final class LinuxContainer: Container, Sendable {
         var dns: DNS? = nil
     }
 
-    @SendableProperty
+    @SendablePropertyUnchecked
     private var state: State
 
     private let config: Mutex<Configuration>

--- a/Sources/SendableProperty/SendableProperty.swift
+++ b/Sources/SendableProperty/SendableProperty.swift
@@ -14,33 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-// `Synchronization` will be automatically imported with `SendableProperty`.
-@_exported import Synchronization
-
 // A declaration of the `@SendableProperty` macro.
 @attached(peer, names: arbitrary)
 @attached(accessor)
 public macro SendableProperty() = #externalMacro(module: "SendablePropertyMacros", type: "SendablePropertyMacro")
-
-/// A synchronization primitive that protects shared mutable state via mutual exclusion.
-public final class Synchronized<T>: Sendable {
-    private let lock: Mutex<State>
-
-    private struct State: @unchecked Sendable {
-        var value: T
-    }
-
-    /// Creates a new instance.
-    /// - Parameter value: The initial value.
-    public init(_ value: T) {
-        self.lock = Mutex(State(value: value))
-    }
-
-    /// Calls the given closure after acquiring the lock and returns its value.
-    /// - Parameter body: The body of code to execute while the lock is held.
-    public func withLock<R>(_ body: (inout T) throws -> R) rethrows -> R {
-        try lock.withLock { state in
-            try body(&state.value)
-        }
-    }
-}

--- a/Sources/SendableProperty/SendablePropertyUnchecked.swift
+++ b/Sources/SendableProperty/SendablePropertyUnchecked.swift
@@ -14,17 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-/// Errors that can be thrown by `@SendableProperty`.
-enum SendablePropertyError: CustomStringConvertible, Error {
-    case unexpectedError
-    case onlyApplicableToVar
-    case notApplicableToType
-
-    var description: String {
-        switch self {
-        case .unexpectedError: return "The macro encountered an unexpected error"
-        case .onlyApplicableToVar: return "The macro can only be applied to a variable"
-        case .notApplicableToType: return "The macro can't be applied to a variable of this type"
-        }
-    }
-}
+// A declaration of the `@SendablePropertyUnchecked` macro.
+@attached(peer, names: arbitrary)
+@attached(accessor)
+public macro SendablePropertyUnchecked() = #externalMacro(module: "SendablePropertyMacros", type: "SendablePropertyMacroUnchecked")

--- a/Sources/SendablePropertyMacros/SendablePropertyError.swift
+++ b/Sources/SendablePropertyMacros/SendablePropertyError.swift
@@ -18,11 +18,13 @@
 enum SendablePropertyError: CustomStringConvertible, Error {
     case unexpectedError
     case onlyApplicableToVar
+    case notApplicableToType
 
     var description: String {
         switch self {
         case .unexpectedError: return "@SendableProperty encountered an unexpected error"
         case .onlyApplicableToVar: return "@SendableProperty can only be applied to a variable"
+        case .notApplicableToType: return "@SendableProperty can't be applied to a variable of this type"
         }
     }
 }

--- a/Sources/SendablePropertyMacros/SendablePropertyMacroUnchecked.swift
+++ b/Sources/SendablePropertyMacros/SendablePropertyMacroUnchecked.swift
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Containerization project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SwiftCompilerPlugin
+import SwiftParser
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// A macro that allows to make a property of a custom type thread-safe keeping the `Sendable` conformance of the type. This macro can be used with classes and enums. Avoid using it with structs, arrays, and dictionaries.
+public struct SendablePropertyMacroUnchecked: PeerMacro {
+    private static func peerPropertyName(for propertyName: String) -> String {
+        "_" + propertyName
+    }
+
+    /// The macro expansion that introduces a `Sendable`-conforming "peer" declaration for a thread-safe storage for the value of the given declaration of a variable.
+    /// - Parameters:
+    ///   - node: The given attribute node.
+    ///   - declaration: The given declaration.
+    ///   - context: The macro expansion context.
+    public static func expansion(
+        of node: SwiftSyntax.AttributeSyntax, providingPeersOf declaration: some SwiftSyntax.DeclSyntaxProtocol, in context: some SwiftSyntaxMacros.MacroExpansionContext
+    ) throws -> [SwiftSyntax.DeclSyntax] {
+        guard let varDecl = declaration.as(VariableDeclSyntax.self),
+            let binding = varDecl.bindings.first,
+            let pattern = binding.pattern.as(IdentifierPatternSyntax.self)
+        else {
+            throw SendablePropertyError.onlyApplicableToVar
+        }
+
+        let propertyName = pattern.identifier.text
+        let hasInitializer = binding.initializer != nil
+        let initializerValue = binding.initializer?.value.description ?? "nil"
+
+        var genericTypeAnnotation = ""
+        if let typeAnnotation = binding.typeAnnotation {
+            let typeName = typeAnnotation.type.description.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+            genericTypeAnnotation = "<\(typeName)\(hasInitializer ? "" : "?")>"
+        }
+
+        let accessLevel = varDecl.modifiers.first(where: { ["open", "public", "internal", "fileprivate", "private"].contains($0.name.text) })?.name.text ?? "internal"
+
+        // Create a peer property
+        let peerPropertyName = self.peerPropertyName(for: propertyName)
+        let peerProperty: DeclSyntax =
+            """
+            \(raw: accessLevel) let \(raw: peerPropertyName) = Synchronized\(raw: genericTypeAnnotation)(\(raw: initializerValue))
+            """
+        return [peerProperty]
+    }
+}
+
+extension SendablePropertyMacroUnchecked: AccessorMacro {
+    /// The macro expansion that adds `Sendable`-conforming accessors to the given declaration of a variable.
+    /// - Parameters:
+    ///   - node: The given attribute node.
+    ///   - declaration: The given declaration.
+    ///   - context: The macro expansion context.
+    public static func expansion(
+        of node: SwiftSyntax.AttributeSyntax, providingAccessorsOf declaration: some SwiftSyntax.DeclSyntaxProtocol, in context: some SwiftSyntaxMacros.MacroExpansionContext
+    ) throws -> [SwiftSyntax.AccessorDeclSyntax] {
+        guard let varDecl = declaration.as(VariableDeclSyntax.self),
+            let binding = varDecl.bindings.first,
+            let pattern = binding.pattern.as(IdentifierPatternSyntax.self)
+        else {
+            throw SendablePropertyError.onlyApplicableToVar
+        }
+
+        let propertyName = pattern.identifier.text
+        let hasInitializer = binding.initializer != nil
+
+        // Replace the property with an accessor
+        let peerPropertyName = Self.peerPropertyName(for: propertyName)
+
+        let accessorGetter: AccessorDeclSyntax =
+            """
+            get {
+                \(raw: peerPropertyName).withLock { $0\(raw: hasInitializer ? "" : "!") }
+            }
+            """
+        let accessorSetter: AccessorDeclSyntax =
+            """
+            set {
+                \(raw: peerPropertyName).withLock { $0 = newValue }
+            }
+            """
+
+        return [accessorGetter, accessorSetter]
+    }
+}

--- a/Sources/SendablePropertyMacros/SendablePropertyPlugin.swift
+++ b/Sources/SendablePropertyMacros/SendablePropertyPlugin.swift
@@ -17,10 +17,11 @@
 import SwiftCompilerPlugin
 import SwiftSyntaxMacros
 
-/// A plugin that registers the `SendablePropertyMacro`.
+/// A plugin that registers the `SendablePropertyMacroUnchecked` and `SendablePropertyMacro`.
 @main
 struct SendablePropertyPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
-        SendablePropertyMacro.self
+        SendablePropertyMacroUnchecked.self,
+        SendablePropertyMacro.self,
     ]
 }

--- a/Tests/SendablePropertyTests/SendablePropertyTests.swift
+++ b/Tests/SendablePropertyTests/SendablePropertyTests.swift
@@ -76,4 +76,70 @@ final class SendablePropertyTests: XCTestCase {
         }
         dispatchGroup.wait()
     }
+
+    func testMacroWithSupportedTypes() throws {
+        final class TestMacro: Sendable {
+            @SendableProperty
+            var int: Int
+            @SendableProperty
+            var uint: UInt
+            @SendableProperty
+            var int16: Int16
+            @SendableProperty
+            var uint16: UInt16
+            @SendableProperty
+            var int32: Int32
+            @SendableProperty
+            var uint32: UInt32
+            @SendableProperty
+            var int64: Int64
+            @SendableProperty
+            var uint64: UInt64
+            @SendableProperty
+            var float: Float
+            @SendableProperty
+            var double: Double
+            @SendableProperty
+            var bool: Bool
+            @SendableProperty
+            var unsafeRawPoiner: UnsafeRawPointer
+            @SendableProperty
+            var unsafeMutableRawPointer: UnsafeMutableRawPointer
+            @SendableProperty
+            var unsafePoiner: UnsafePointer<Int>
+            @SendableProperty
+            var unsafeMutablePointer: UnsafeMutablePointer<Int>
+
+            @SendableProperty
+            var intOpt: Int?
+            @SendableProperty
+            var uintOpt: UInt?
+            @SendableProperty
+            var int16Opt: Int16?
+            @SendableProperty
+            var uint16Opt: UInt16?
+            @SendableProperty
+            var int32Opt: Int32?
+            @SendableProperty
+            var uint32Opt: UInt32?
+            @SendableProperty
+            var int64Opt: Int64?
+            @SendableProperty
+            var uint64Opt: UInt64?
+            @SendableProperty
+            var floaOptt: Float?
+            @SendableProperty
+            var doubleOpt: Double?
+            @SendableProperty
+            var boolOpt: Bool?
+            @SendableProperty
+            var unsafeRawPoinerOpt: UnsafeRawPointer?
+            @SendableProperty
+            var unsafeMutableRawPointerOpt: UnsafeMutableRawPointer?
+            @SendableProperty
+            var unsafePoinerOpt: UnsafePointer<Int>?
+            @SendableProperty
+            var unsafeMutablePointerOpt: UnsafeMutablePointer<Int>?
+        }
+    }
 }


### PR DESCRIPTION
- The `@SendableProperty` macro now checks for supported types to prevent a misuse with unsupported types like structs, dictionaries, and arrays
- The new `@SendablePropertyUnchecked` can be used with classes and enums