### PR TITLE
Chore: Simplify AttachedFilesystem constructor

### DIFF
--- a/Sources/Containerization/AttachedFilesystem.swift
+++ b/Sources/Containerization/AttachedFilesystem.swift
@@ -33,16 +33,14 @@ public struct AttachedFilesystem: Sendable {
         switch mount.type {
         case "virtiofs":
             let name = try hashMountSource(source: mount.source)
-            self.type = mount.type
             self.source = name
         case "ext4":
             let char = try allocator.allocate()
-            self.type = mount.type
             self.source = "/dev/vd\(char)"
         default:
-            self.type = mount.type
             self.source = mount.source
         }
+        self.type = mount.type
         self.options = mount.options
         self.destination = mount.destination
     }


### PR DESCRIPTION
The type copy is the exact same on any of the types, just move it outside of the cases like we have for options and destination.