### PR TITLE
Vminitd: Remove special cased /run mount

### DIFF
--- a/Sources/Containerization/Agent/Vminitd.swift
+++ b/Sources/Containerization/Agent/Vminitd.swift
@@ -56,6 +56,8 @@ extension Vminitd: VirtualMachineAgent {
         try await setenv(key: "PATH", value: Self.defaultPath)
 
         let mounts: [ContainerizationOCI.Mount] = [
+            // NOTE: /proc is always done implicitly by the guest agent.
+            .init(type: "tmpfs", source: "tmpfs", destination: "/run"),
             .init(type: "sysfs", source: "sysfs", destination: "/sys"),
             .init(type: "tmpfs", source: "tmpfs", destination: "/tmp"),
             .init(type: "devpts", source: "devpts", destination: "/dev/pts", options: ["gid=5", "mode=620", "ptmxmode=666"]),

--- a/vminitd/Sources/vminitd/Application.swift
+++ b/vminitd/Sources/vminitd/Application.swift
@@ -99,10 +99,7 @@ struct Application {
             log.error("failed to mount /proc")
             exit(1)
         }
-        guard Musl.mount("tmpfs", "/run", "tmpfs", 0, "") == 0 else {
-            log.error("failed to mount /run")
-            exit(1)
-        }
+
         try Binfmt.mount()
 
         log.logLevel = .debug


### PR DESCRIPTION
Revisiting this, I'm not a huge fan of having /run be special cased for some reason