### PR TITLE
Update xcode developer dir to new regularly updated symlink

### DIFF
--- a/.github/workflows/containerization-build-template.yml
+++ b/.github/workflows/containerization-build-template.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
       packages: write
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_26.b1.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode-latest.app/Contents/Developer"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The Xcode installation on the runners is regularly updated to the latest release. A symlink at /Applications/Xcode-latest.app points to the most recent installation. We should not rely on a specific version path. 