### PR TITLE
LinuxContainer: Allow reuse after being stopped

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -194,7 +194,7 @@ public final class LinuxContainer: Container, Sendable {
 
         mutating func setCreating() throws {
             switch self {
-            case .initialized:
+            case .initialized, .stopped:
                 self = .creating(.init())
             default:
                 throw ContainerizationError(

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -211,6 +211,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             "container mount": testMounts,
             "nested virt": testNestedVirtualizationEnabled,
             "container manager": testContainerManagerCreate,
+            "container reuse": testContainerReuse,
         ]
 
         var passed = 0


### PR DESCRIPTION
After the container is stopped it's a bit odd how we don't allow the object to be restarted. If someone wanted to continuously rerun the same container they'd need to make a new object every time even though all guest state is blown away on stop() so it's a clean slate.

This change makes it so that you can create+start again after stop (although create stands out like a sore thumb now as stop -> create is just strange).