### PR TITLE
Replace public computed properties with locks in setters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Version and build configuration variables
+# Build configuration variables
 # The default version ID 0.0.0 indicates a local development build or PRB
 BUILD_CONFIGURATION ?= debug
 
@@ -42,10 +42,10 @@ release: all
 .PHONY: containerization
 containerization:
 	@echo Building containerization binaries...
-	@mkdir -p bin
 	@$(SWIFT) build -c $(BUILD_CONFIGURATION)
 
 	@echo Copying containerization binaries...
+	@mkdir -p bin
 	@install "$(BUILD_BIN_DIR)/cctl" ./bin/
 	@install "$(BUILD_BIN_DIR)/containerization-integration" ./bin/
 
@@ -147,7 +147,7 @@ cleancontent:
 
 .PHONY: clean
 clean:
-	@echo Cleaning the build files...
+	@echo Cleaning build files...
 	@rm -rf bin/
 	@rm -rf _site/
 	@rm -rf _serve/

--- a/Sources/Containerization/NATNetworkInterface.swift
+++ b/Sources/Containerization/NATNetworkInterface.swift
@@ -26,31 +26,12 @@ import Synchronization
 /// container/virtual machine.
 @available(macOS 26, *)
 public final class NATNetworkInterface: Interface, Sendable {
-    public var address: String {
-        state.withLock { $0.address }
-    }
-
-    public var gateway: String? {
-        state.withLock { $0.gateway }
-    }
+    public let address: String
+    public let gateway: String?
+    public let macAddress: String?
 
     @available(macOS 26, *)
-    public var reference: vmnet_network_ref {
-        state.withLock { $0.reference }
-    }
-
-    public var macAddress: String? {
-        state.withLock { $0.macAddress }
-    }
-
-    private struct State {
-        var address: String
-        var gateway: String?
-        var reference: vmnet_network_ref!
-        var macAddress: String?
-    }
-
-    private let state: Mutex<State>
+    public nonisolated(unsafe) let reference: vmnet_network_ref!
 
     @available(macOS 26, *)
     public init(
@@ -59,13 +40,10 @@ public final class NATNetworkInterface: Interface, Sendable {
         reference: sending vmnet_network_ref,
         macAddress: String? = nil
     ) {
-        let state = State(
-            address: address,
-            gateway: gateway,
-            reference: reference,
-            macAddress: macAddress
-        )
-        self.state = Mutex(state)
+        self.address = address
+        self.gateway = gateway
+        self.macAddress = macAddress
+        self.reference = reference
     }
 
     @available(macOS, obsoleted: 26, message: "Use init(address:gateway:reference:macAddress:) instead")
@@ -74,13 +52,10 @@ public final class NATNetworkInterface: Interface, Sendable {
         gateway: String?,
         macAddress: String? = nil
     ) {
-        let state = State(
-            address: address,
-            gateway: gateway,
-            reference: nil,
-            macAddress: macAddress
-        )
-        self.state = Mutex(state)
+        self.address = address
+        self.gateway = gateway
+        self.macAddress = macAddress
+        self.reference = nil
     }
 }
 

--- a/Sources/Containerization/NATNetworkInterface.swift
+++ b/Sources/Containerization/NATNetworkInterface.swift
@@ -27,22 +27,11 @@ import Synchronization
 @available(macOS 26, *)
 public final class NATNetworkInterface: Interface, Sendable {
     public var address: String {
-        get {
-            state.withLock { $0.address }
-        }
-        set {
-            state.withLock { $0.address = newValue }
-        }
-
+        state.withLock { $0.address }
     }
 
     public var gateway: String? {
-        get {
-            state.withLock { $0.gateway }
-        }
-        set {
-            state.withLock { $0.gateway = newValue }
-        }
+        state.withLock { $0.gateway }
     }
 
     @available(macOS 26, *)
@@ -51,12 +40,7 @@ public final class NATNetworkInterface: Interface, Sendable {
     }
 
     public var macAddress: String? {
-        get {
-            state.withLock { $0.macAddress }
-        }
-        set {
-            state.withLock { $0.macAddress = newValue }
-        }
+        state.withLock { $0.macAddress }
     }
 
     private struct State {


### PR DESCRIPTION
This PR replaces public computed properties with setters in the `NATNetworkInterface` class with constants to avoid using locks in the setters. A new instance of `NATNetworkInterface` should be created to change these values.