### PR TITLE
Allow reusing virtiofs mounts

### DIFF
--- a/Sources/Containerization/Hash.swift
+++ b/Sources/Containerization/Hash.swift
@@ -18,10 +18,15 @@
 
 import Crypto
 import ContainerizationError
+import Foundation
 
 func hashMountSource(source: String) throws -> String {
-    guard let data = source.data(using: .utf8) else {
-        throw ContainerizationError(.invalidArgument, message: "\(source) could not be converted to Data")
+    let resolvedSource = URL(fileURLWithPath: source)
+        .resolvingSymlinksInPath()
+        .path
+
+    guard let data = resolvedSource.data(using: .utf8) else {
+        throw ContainerizationError(.invalidArgument, message: "\(resolvedSource) could not be converted to Data")
     }
     return String(SHA256.hash(data: data).encoded.prefix(36))
 }

--- a/Sources/Containerization/Mount.swift
+++ b/Sources/Containerization/Mount.swift
@@ -132,7 +132,7 @@ public struct Mount: Sendable {
 #if os(macOS)
 
 extension Mount {
-    func configure(config: inout VZVirtualMachineConfiguration) throws {
+    func configure(config: inout VZVirtualMachineConfiguration, usedVirtioFSTags: inout Set<String>) throws {
         switch self.runtimeOptions {
         case .virtioblk(let options):
             let device = try VZDiskImageStorageDeviceAttachment.mountToVZAttachment(mount: self, options: options)
@@ -144,6 +144,13 @@ extension Mount {
             }
 
             let name = try hashMountSource(source: self.source)
+
+            // Skip creating VZVirtioFileSystemDeviceConfiguration if tag already exists.
+            if usedVirtioFSTags.contains(name) {
+                return
+            }
+
+            usedVirtioFSTags.insert(name)
             let urlSource = URL(fileURLWithPath: source)
 
             let device = VZVirtioFileSystemDeviceConfiguration(tag: name)

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -209,6 +209,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             "container hostname": testHostname,
             "container hosts": testHostsFile,
             "container mount": testMounts,
+            "container mount duplicate": testDuplicateMount,
             "nested virt": testNestedVirtualizationEnabled,
             "container manager": testContainerManagerCreate,
         ]


### PR DESCRIPTION
Fwiw, this is a bit odd, but it's also very simple to support and feels odd that this was failing today. This also adds in a tiny bit of logic in hashMountSource to resolve the path of symlinks, so now even symlinks to the same dir can be supplied N times without a new virtiofs device.