### PR TITLE
Ensure mutable properties aren't accessed outside their intended thread-safe usage patterns

### DIFF
--- a/Sources/Containerization/Image/ImageStore/ImageStore+ReferenceManager.swift
+++ b/Sources/Containerization/Image/ImageStore/ImageStore+ReferenceManager.swift
@@ -21,7 +21,7 @@ import Foundation
 extension ImageStore {
     /// A ReferenceManager handles the mappings between an image's
     /// reference and the underlying descriptor inside of a content store.
-    internal actor ReferenceManager: Sendable {
+    internal actor ReferenceManager {
         private let path: URL
 
         private typealias State = [String: Descriptor]

--- a/Sources/Containerization/TimeSyncer.swift
+++ b/Sources/Containerization/TimeSyncer.swift
@@ -17,7 +17,7 @@
 import Foundation
 import Logging
 
-actor TimeSyncer: Sendable {
+actor TimeSyncer {
     private var task: Task<Void, Never>?
     private var context: Vminitd?
     private let logger: Logger?

--- a/vminitd/Sources/vminitd/OSFile+Splice.swift
+++ b/vminitd/Sources/vminitd/OSFile+Splice.swift
@@ -18,9 +18,9 @@ import Foundation
 
 extension OSFile {
     struct SpliceFile: Sendable {
-        var file: OSFile
-        var offset: Int
-        let pipe = Pipe()
+        fileprivate var file: OSFile
+        fileprivate var offset: Int
+        fileprivate let pipe = Pipe()
 
         var fileDescriptor: Int32 {
             file.fileDescriptor


### PR DESCRIPTION
This PR modifies the access level of certain mutable properties to ensure their thread-safe usage. It doesn't address https://github.com/apple/containerization/issues/246 at this time.