### PR TITLE
vminitd: Proper pty setup / mount /dev/console

### DIFF
--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -212,6 +212,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             "nested virt": testNestedVirtualizationEnabled,
             "container manager": testContainerManagerCreate,
             "container reuse": testContainerReuse,
+            "container /dev/console": testContainerDevConsole,
         ]
 
         var passed = 0

--- a/Sources/Integration/VMTests.swift
+++ b/Sources/Integration/VMTests.swift
@@ -172,6 +172,54 @@ extension IntegrationSuite {
         }
     }
 
+    func testContainerDevConsole() async throws {
+        let id = "test-container-devconsole"
+
+        let bs = try await bootstrap()
+
+        let manager = try ContainerManager(vmm: bs.vmm)
+        defer {
+            try? manager.delete(id)
+        }
+
+        let buffer = BufferWriter()
+        let container = try await manager.create(
+            id,
+            image: bs.image,
+            rootfs: bs.rootfs
+        ) { config in
+            // We mount devtmpfs by default, and while this includes creating
+            // /dev/console typically that'll be pointing to /dev/hvc0 (the
+            // virtio serial console). This is just a character device, so a trivial
+            // way to check that our bind mounted console setup worked is by just
+            // parsing `mount`'s output and looking for /dev/console as it wouldn't
+            // be there normally without our dance.
+            config.process.arguments = ["mount"]
+            config.process.terminal = true
+            config.process.stdout = buffer
+        }
+
+        try await container.create()
+        try await container.start()
+
+        let status = try await container.wait()
+        try await container.stop()
+        guard status == 0 else {
+            throw IntegrationError.assert(msg: "process status \(status) != 0")
+        }
+
+        guard let str = String(data: buffer.data, encoding: .utf8) else {
+            throw IntegrationError.assert(
+                msg: "failed to convert standard output to a UTF8 string")
+        }
+
+        let devConsole = "/dev/console"
+        guard str.contains(devConsole) else {
+            throw IntegrationError.assert(
+                msg: "process should have \(devConsole) in `mount` output")
+        }
+    }
+
     private func createMountDirectory() throws -> URL {
         let dir = FileManager.default.uniqueTemporaryDirectory(create: true)
         try "hello".write(to: dir.appendingPathComponent("hi.txt"), atomically: true, encoding: .utf8)

--- a/Sources/cctl/RunCommand.swift
+++ b/Sources/cctl/RunCommand.swift
@@ -65,7 +65,8 @@ extension Application {
         @Option(name: .long, help: "Current working directory")
         var cwd: String = "/"
 
-        @Argument var arguments: [String] = ["/bin/sh"]
+        @Argument(parsing: .captureForPassthrough)
+        var arguments: [String] = ["/bin/sh"]
 
         func run() async throws {
             let kernel = Kernel(

--- a/vminitd/Sources/vmexec/Console.swift
+++ b/vminitd/Sources/vmexec/Console.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Containerization project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Musl
+
+class Console {
+    let master: Int32
+    let slavePath: String
+
+    init() throws {
+        let masterFD = open("/dev/ptmx", O_RDWR | O_NOCTTY | O_CLOEXEC)
+        guard masterFD != -1 else {
+            throw App.Errno(stage: "open_ptmx")
+        }
+
+        guard unlockpt(masterFD) == 0 else {
+            throw App.Errno(stage: "unlockpt")
+        }
+
+        guard let slavePath = ptsname(masterFD) else {
+            throw App.Errno(stage: "ptsname")
+        }
+
+        self.master = masterFD
+        self.slavePath = String(cString: slavePath)
+    }
+
+    func configureStdIO() throws {
+        let path = self.slavePath
+        let slaveFD = open(path, O_RDWR)
+        guard slaveFD != -1 else {
+            throw App.Errno(stage: "open_pts")
+        }
+        defer { Musl.close(slaveFD) }
+
+        for fd: Int32 in 0...2 {
+            guard dup3(slaveFD, fd, 0) != -1 else {
+                throw App.Errno(stage: "dup3")
+            }
+        }
+    }
+
+    func close() throws {
+        guard Musl.close(self.master) == 0 else {
+            throw App.Errno(stage: "close")
+        }
+    }
+}

--- a/vminitd/Sources/vmexec/ExecCommand.swift
+++ b/vminitd/Sources/vmexec/ExecCommand.swift
@@ -62,35 +62,66 @@ struct ExecCommand: ParsableCommand {
         process: ContainerizationOCI.Process,
         log: Logger
     ) throws {
-        // CLOEXEC the pipe fd that signals process readiness.
-        let syncfd = FileHandle(fileDescriptor: 3)
-        if fcntl(3, F_SETFD, FD_CLOEXEC) == -1 {
-            throw App.Errno(stage: "cloexec(syncfd)")
-        }
+        let syncPipe = FileHandle(fileDescriptor: 3)
+        let ackPipe = FileHandle(fileDescriptor: 4)
 
         try Self.enterNS(path: "/proc/\(self.parentPid)/ns/cgroup", nsType: CLONE_NEWCGROUP)
         try Self.enterNS(path: "/proc/\(self.parentPid)/ns/pid", nsType: CLONE_NEWPID)
         try Self.enterNS(path: "/proc/\(self.parentPid)/ns/uts", nsType: CLONE_NEWUTS)
         try Self.enterNS(path: "/proc/\(self.parentPid)/ns/mnt", nsType: CLONE_NEWNS)
 
-        let childPipe = Pipe()
-        try childPipe.setCloexec()
         let processID = fork()
 
         guard processID != -1 else {
-            try? childPipe.fileHandleForReading.close()
-            try? childPipe.fileHandleForWriting.close()
-            try? syncfd.close()
+            try? syncPipe.close()
+            try? ackPipe.close()
 
             throw App.Errno(stage: "fork")
         }
 
         if processID == 0 {  // child
-            try childPipe.fileHandleForReading.close()
-            try syncfd.close()
+            // Wait for the grandparent to tell us that they acked our pid.
+            guard let data = try ackPipe.read(upToCount: App.ackPid.count) else {
+                throw App.Failure(message: "read ack pipe")
+            }
+            guard let pidAckStr = String(data: data, encoding: .utf8) else {
+                throw App.Failure(message: "convert ack pipe data to string")
+            }
+
+            guard pidAckStr == App.ackPid else {
+                throw App.Failure(message: "received invalid acknowledgement string: \(pidAckStr)")
+            }
 
             guard setsid() != -1 else {
                 throw App.Errno(stage: "setsid()")
+            }
+
+            if process.terminal {
+                let pty = try Console()
+                try pty.configureStdIO()
+                var masterFD = pty.master
+
+                let data = Data(bytes: &masterFD, count: MemoryLayout.size(ofValue: masterFD))
+                try syncPipe.write(contentsOf: data)
+                try syncPipe.close()
+
+                // Wait for the grandparent to tell us that they acked our console.
+                guard let data = try ackPipe.read(upToCount: App.ackConsole.count) else {
+                    throw App.Failure(message: "read ack pipe")
+                }
+
+                guard let consoleAckStr = String(data: data, encoding: .utf8) else {
+                    throw App.Failure(message: "convert ack pipe data to string")
+                }
+
+                guard consoleAckStr == App.ackConsole else {
+                    throw App.Failure(message: "received invalid acknowledgement string: \(consoleAckStr)")
+                }
+
+                guard ioctl(0, UInt(TIOCSCTTY), 0) != -1 else {
+                    throw App.Errno(stage: "setctty(0)")
+                }
+                try pty.close()
             }
 
             // Apply O_CLOEXEC to all file descriptors except stdio.
@@ -106,26 +137,13 @@ struct ExecCommand: ParsableCommand {
             // Set uid, gid, and supplementary groups
             try App.setPermissions(user: process.user)
 
-            if process.terminal {
-                guard ioctl(0, UInt(TIOCSCTTY), 0) != -1 else {
-                    throw App.Errno(stage: "setctty()")
-                }
-            }
-
             try App.exec(process: process)
         } else {  // parent process
-            try childPipe.fileHandleForWriting.close()
-
-            // wait until the pipe is closed then carry on.
-            _ = try childPipe.fileHandleForReading.readToEnd()
-            try childPipe.fileHandleForReading.close()
-
-            // send our child's pid to our parent before we exit.
+            // Send our child's pid to our parent before we exit.
             var childPid = processID
             let data = Data(bytes: &childPid, count: MemoryLayout.size(ofValue: childPid))
 
-            try syncfd.write(contentsOf: data)
-            try syncfd.close()
+            try syncPipe.write(contentsOf: data)
         }
     }
 }

--- a/vminitd/Sources/vmexec/Mount.swift
+++ b/vminitd/Sources/vmexec/Mount.swift
@@ -36,8 +36,7 @@ struct ContainerMount {
     }
 
     func configureConsole() throws {
-        let ptmx = self.rootfs.standardizingPath.appendingPathComponent("/dev/ptmx")
-
+        let ptmx = self.rootfs.standardizingPath.appendingPathComponent("dev/ptmx")
         guard remove(ptmx) == 0 else {
             throw App.Errno(stage: "remove(ptmx)")
         }

--- a/vminitd/Sources/vmexec/RunCommand.swift
+++ b/vminitd/Sources/vmexec/RunCommand.swift
@@ -49,92 +49,120 @@ struct RunCommand: ParsableCommand {
         try reOpenDevNull()
     }
 
-    private func execInNamespace(spec: ContainerizationOCI.Spec, log: Logger) throws {
+    private func childSetup(
+        spec: ContainerizationOCI.Spec,
+        ackPipe: FileHandle,
+        syncPipe: FileHandle,
+        log: Logger
+    ) throws {
         guard let process = spec.process else {
-            fatalError("no process configuration found in runtime spec")
+            throw App.Failure(message: "no process configuration found in runtime spec")
         }
         guard let root = spec.root else {
-            fatalError("no root found in runtime spec")
+            throw App.Failure(message: "no root found in runtime spec")
         }
 
-        let syncfd = FileHandle(fileDescriptor: 3)
-        if fcntl(3, F_SETFD, FD_CLOEXEC) == -1 {
-            throw App.Errno(stage: "cloexec(syncfd)")
+        // Wait for the grandparent to tell us that they acked our pid.
+        guard let data = try ackPipe.read(upToCount: App.ackPid.count) else {
+            throw App.Failure(message: "read ack pipe")
         }
+        guard let pidAckStr = String(data: data, encoding: .utf8) else {
+            throw App.Failure(message: "convert ack pipe data to string")
+        }
+
+        guard pidAckStr == App.ackPid else {
+            throw App.Failure(message: "received invalid acknowledgement string: \(pidAckStr)")
+        }
+
+        guard unshare(CLONE_NEWCGROUP) == 0 else {
+            throw App.Errno(stage: "unshare(cgroup)")
+        }
+
+        guard setsid() != -1 else {
+            throw App.Errno(stage: "setsid()")
+        }
+
+        try childRootSetup(rootfs: root, mounts: spec.mounts, log: log)
+
+        if process.terminal {
+            let pty = try Console()
+            try pty.configureStdIO()
+            var masterFD = pty.master
+
+            let data = Data(bytes: &masterFD, count: MemoryLayout.size(ofValue: masterFD))
+            try syncPipe.write(contentsOf: data)
+            try syncPipe.close()
+
+            // Wait for the grandparent to tell us that they acked our console.
+            guard let data = try ackPipe.read(upToCount: App.ackConsole.count) else {
+                throw App.Failure(message: "read ack pipe")
+            }
+
+            guard let consoleAckStr = String(data: data, encoding: .utf8) else {
+                throw App.Failure(message: "convert ack pipe data to string")
+            }
+
+            guard consoleAckStr == App.ackConsole else {
+                throw App.Failure(message: "received invalid acknowledgement string: \(consoleAckStr)")
+            }
+
+            guard ioctl(0, UInt(TIOCSCTTY), 0) != -1 else {
+                throw App.Errno(stage: "setctty(0)")
+            }
+
+            try mountConsole(path: pty.slavePath)
+            try pty.close()
+        }
+
+        if !spec.hostname.isEmpty {
+            let errCode = spec.hostname.withCString { ptr in
+                Musl.sethostname(ptr, spec.hostname.count)
+            }
+            guard errCode == 0 else {
+                throw App.Errno(stage: "sethostname()")
+            }
+        }
+
+        // Apply O_CLOEXEC to all file descriptors except stdio.
+        // This ensures that all unwanted fds we may have accidentally
+        // inherited are marked close-on-exec so they stay out of the
+        // container.
+        try App.applyCloseExecOnFDs()
+
+        try App.setRLimits(rlimits: process.rlimits)
+
+        // Change stdio to be owned by the requested user.
+        try App.fixStdioPerms(user: process.user)
+
+        // Set uid, gid, and supplementary groups.
+        try App.setPermissions(user: process.user)
+
+        // Finally execve the container process.
+        try App.exec(process: process)
+    }
+
+    private func execInNamespace(spec: ContainerizationOCI.Spec, log: Logger) throws {
+        let syncPipe = FileHandle(fileDescriptor: 3)
+        let ackPipe = FileHandle(fileDescriptor: 4)
 
         guard unshare(CLONE_NEWPID | CLONE_NEWNS | CLONE_NEWUTS) == 0 else {
             throw App.Errno(stage: "unshare(pid|mnt|uts)")
         }
 
-        let childPipe = Pipe()
-        try childPipe.setCloexec()
         let processID = fork()
-
         guard processID != -1 else {
-            try? childPipe.fileHandleForReading.close()
-            try? childPipe.fileHandleForWriting.close()
-            try? syncfd.close()
-
+            try? syncPipe.close()
+            try? ackPipe.close()
             throw App.Errno(stage: "fork")
         }
 
         if processID == 0 {  // child
-            try childPipe.fileHandleForReading.close()
-            try syncfd.close()
-
-            guard unshare(CLONE_NEWCGROUP) == 0 else {
-                throw App.Errno(stage: "unshare(cgroup)")
-            }
-
-            guard setsid() != -1 else {
-                throw App.Errno(stage: "setsid()")
-            }
-
-            try childRootSetup(rootfs: root, mounts: spec.mounts, log: log)
-
-            if !spec.hostname.isEmpty {
-                let errCode = spec.hostname.withCString { ptr in
-                    Musl.sethostname(ptr, spec.hostname.count)
-                }
-                guard errCode == 0 else {
-                    throw App.Errno(stage: "sethostname()")
-                }
-            }
-
-            // Apply O_CLOEXEC to all file descriptors except stdio.
-            // This ensures that all unwanted fds we may have accidentally
-            // inherited are marked close-on-exec so they stay out of the
-            // container.
-            try App.applyCloseExecOnFDs()
-
-            try App.setRLimits(rlimits: process.rlimits)
-
-            // Change stdio to be owned by the requested user.
-            try App.fixStdioPerms(user: process.user)
-
-            // Set uid, gid, and supplementary groups.
-            try App.setPermissions(user: process.user)
-
-            if process.terminal {
-                guard ioctl(0, UInt(TIOCSCTTY), 0) != -1 else {
-                    throw App.Errno(stage: "setctty()")
-                }
-            }
-
-            try App.exec(process: process)
+            try childSetup(spec: spec, ackPipe: ackPipe, syncPipe: syncPipe, log: log)
         } else {  // parent process
-            try childPipe.fileHandleForWriting.close()
-
-            // wait until the pipe is closed then carry on.
-            _ = try childPipe.fileHandleForReading.readToEnd()
-            try childPipe.fileHandleForReading.close()
-
-            // send our child's pid to our parent before we exit.
+            // Send our child's pid before we exit.
             var childPid = processID
             let data = Data(bytes: &childPid, count: MemoryLayout.size(ofValue: childPid))
-
-            try syncfd.write(contentsOf: data)
-            try syncfd.close()
+            try syncPipe.write(contentsOf: data)
         }
     }
 
@@ -221,7 +249,6 @@ struct RunCommand: ParsableCommand {
         if newRoot <= 0 {
             throw App.Errno(stage: "open(newroot)")
         }
-
         defer { close(newRoot) }
 
         // change cwd to the new root
@@ -255,5 +282,20 @@ struct RunCommand: ParsableCommand {
         let cStringCopy = UnsafeMutableBufferPointer<CChar>.allocate(capacity: cString.count)
         _ = cStringCopy.initialize(from: cString)
         return UnsafeMutablePointer(cStringCopy.baseAddress)
+    }
+
+    private func mountConsole(path: String) throws {
+        let console = "/dev/console"
+        if access(console, F_OK) != 0 {
+            let fd = open(console, O_RDWR | O_CREAT, mode_t(UInt16(0o600)))
+            guard fd != -1 else {
+                throw App.Errno(stage: "open(/dev/console)")
+            }
+            close(fd)
+        }
+
+        guard mount(path, console, "bind", UInt(MS_BIND), nil) == 0 else {
+            throw App.Errno(stage: "mount(console)")
+        }
     }
 }

--- a/vminitd/Sources/vmexec/vmexec.swift
+++ b/vminitd/Sources/vmexec/vmexec.swift
@@ -29,6 +29,9 @@ import Musl
 
 @main
 struct App: ParsableCommand {
+    static let ackPid = "AckPid"
+    static let ackConsole = "AckConsole"
+
     static let configuration = CommandConfiguration(
         commandName: "vmexec",
         version: "0.1.0",
@@ -160,5 +163,12 @@ extension App {
     static func Errno(stage: String, info: String = "") -> ContainerizationError {
         let posix = POSIXError(.init(rawValue: errno)!, userInfo: ["stage": stage])
         return ContainerizationError(.internalError, message: "\(info) \(String(describing: posix))")
+    }
+
+    static func Failure(message: String) -> ContainerizationError {
+        ContainerizationError(
+            .internalError,
+            message: message
+        )
     }
 }

--- a/vminitd/Sources/vminitd/ManagedProcess.swift
+++ b/vminitd/Sources/vminitd/ManagedProcess.swift
@@ -29,8 +29,11 @@ final class ManagedProcess: Sendable {
     private let log: Logger
     private let process: Command
     private let state: Mutex<State>
-    private let syncfd: Pipe
     private let owningPid: Int32?
+    private let ackPipe: FileHandle
+    private let syncPipe: FileHandle
+    private let terminal: Bool
+    private let bundle: ContainerizationOCI.Bundle
 
     private struct State {
         init(io: IO) {
@@ -51,16 +54,21 @@ final class ManagedProcess: Sendable {
 
     // swiftlint: disable type_name
     protocol IO {
+        func attach(pid: Int32, fd: Int32) throws
         func start(process: inout Command) throws
-        func closeAfterExec() throws
         func resize(size: Terminal.Size) throws
+        func close() throws
         func closeStdin() throws
+        func closeAfterExec() throws
     }
     // swiftlint: enable type_name
 
     static func localizeLogger(log: inout Logger, id: String) {
         log[metadataKey: "id"] = "\(id)"
     }
+
+    private static let ackPid = "AckPid"
+    private static let ackConsole = "AckConsole"
 
     init(
         id: String,
@@ -75,9 +83,13 @@ final class ManagedProcess: Sendable {
         self.log = log
         self.owningPid = owningPid
 
-        let syncfd = Pipe()
-        try syncfd.setCloexec()
-        self.syncfd = syncfd
+        let syncPipe = Pipe()
+        try syncPipe.setCloexec()
+        self.syncPipe = syncPipe.fileHandleForReading
+
+        let ackPipe = Pipe()
+        try ackPipe.setCloexec()
+        self.ackPipe = ackPipe.fileHandleForWriting
 
         let args: [String]
         if let owningPid {
@@ -95,7 +107,10 @@ final class ManagedProcess: Sendable {
         var process = Command(
             "/sbin/vmexec",
             arguments: args,
-            extraFiles: [syncfd.fileHandleForWriting]
+            extraFiles: [
+                syncPipe.fileHandleForWriting,
+                ackPipe.fileHandleForReading,
+            ]
         )
 
         var io: IO
@@ -121,6 +136,8 @@ final class ManagedProcess: Sendable {
         try io.start(process: &process)
 
         self.process = process
+        self.terminal = stdio.terminal
+        self.bundle = bundle
         self.state = Mutex(State(io: io))
     }
 }
@@ -136,30 +153,77 @@ extension ManagedProcess {
 
             // Start the underlying process.
             try process.start()
+            defer {
+                try? self.ackPipe.close()
+                try? self.syncPipe.close()
+            }
 
             // Close our side of any pipes.
-            try syncfd.fileHandleForWriting.close()
             try $0.io.closeAfterExec()
 
-            guard let piddata = try syncfd.fileHandleForReading.readToEnd() else {
+            let size = MemoryLayout<Int32>.size
+            guard let piddata = try syncPipe.read(upToCount: size) else {
                 throw ContainerizationError(.internalError, message: "no pid data from sync pipe")
             }
 
-            let i = piddata.withUnsafeBytes { ptr in
+            guard piddata.count == size else {
+                throw ContainerizationError(.internalError, message: "invalid payload")
+            }
+
+            let pid = piddata.withUnsafeBytes { ptr in
                 ptr.load(as: Int32.self)
             }
 
-            log.info("got back pid data \(i)")
-            $0.pid = i
+            log.info(
+                "got back pid data",
+                metadata: [
+                    "id": "\(pid)"
+                ])
+            $0.pid = pid
+
+            // Ack the pid from the child.
+            log.info(
+                "sending pid acknowledgement",
+                metadata: [
+                    "pid": "\(pid)"
+                ])
+            try self.ackPipe.write(contentsOf: Self.ackPid.data(using: .utf8)!)
+
+            if self.terminal {
+                log.info(
+                    "wait for pty fd",
+                    metadata: [
+                        "id": "\(id)"
+                    ])
+
+                // Wait for a new write that will contain the pty fd if we asked for one.
+                guard let ptyFd = try syncPipe.read(upToCount: size) else {
+                    throw ContainerizationError(
+                        .internalError,
+                        message: "no pty data from sync pipe"
+                    )
+                }
+                let fd = ptyFd.withUnsafeBytes { ptr in
+                    ptr.load(as: Int32.self)
+                }
+                log.info(
+                    "received pty fd from container, attaching",
+                    metadata: [
+                        "id": "\(id)"
+                    ])
+
+                try $0.io.attach(pid: pid, fd: fd)
+                try self.ackPipe.write(contentsOf: Self.ackConsole.data(using: .utf8)!)
+            }
 
             log.info(
                 "started managed process",
                 metadata: [
-                    "pid": "\(i)",
+                    "pid": "\(pid)",
                     "id": "\(id)",
                 ])
 
-            return i
+            return pid
         }
     }
 
@@ -172,6 +236,12 @@ extension ManagedProcess {
                 ])
 
             $0.exitStatus = status
+
+            do {
+                try $0.io.close()
+            } catch {
+                self.log.error("failed to close io for process: \(error)")
+            }
 
             for waiter in $0.waiters {
                 waiter.resume(returning: status)


### PR DESCRIPTION
Closes #246 
Closes #145

We need to allocate the pty in the containers ns otherwise you run into funny outcomes later. This change additionally mounts /dev/console by binding the pty opened in the containers namespace onto it. Today /dev/console is solely from devtmpfs which points at /dev/hvc0, or the virtio serial console. This causes systemds output to go to serial/the bootlog
instead of what folks would expect. This should make systemd like us a lot more than it does today.

Another large change that was somewhat required here is the changes in IOPair. EPOLLHUP on a pty is deceptively weird to handle as it could be reopened, so we can't do what we were doing today and just close all the fds. To remedy this I skip exiting on HUP for pty's and instead just cleanup at process exit time, but ensure to drain the pty beforehand.