### PR TITLE
Add /dev/rtc symlink

### DIFF
--- a/vminitd/Sources/vmexec/RunCommand.swift
+++ b/vminitd/Sources/vmexec/RunCommand.swift
@@ -160,6 +160,7 @@ struct RunCommand: ParsableCommand {
             ("/proc/self/fd/0", "/dev/stdin"),
             ("/proc/self/fd/1", "/dev/stdout"),
             ("/proc/self/fd/2", "/dev/stderr"),
+            ("/dev/rtc0", "/dev/rtc"),
         ]
 
         let rootfsURL = URL(fileURLWithPath: rootfs)
@@ -169,7 +170,7 @@ struct RunCommand: ParsableCommand {
                 if errno == EEXIST {
                     continue
                 }
-                throw App.Errno(stage: "symlink()")
+                throw App.Errno(stage: "symlink(\(src) -> \(dest.path))")
             }
         }
     }


### PR DESCRIPTION
Closes #251

We use devtmpfs today so our pal /dev/rtc0 is there. It's typical to have a /dev/rtc symlink to /dev/rtc0.