### PR TITLE
Revert "Vminitd: Remove special cased /run mount (#233)"

### DIFF
--- a/Sources/Containerization/Agent/Vminitd.swift
+++ b/Sources/Containerization/Agent/Vminitd.swift
@@ -56,8 +56,6 @@ extension Vminitd: VirtualMachineAgent {
         try await setenv(key: "PATH", value: Self.defaultPath)
 
         let mounts: [ContainerizationOCI.Mount] = [
-            // NOTE: /proc is always done implicitly by the guest agent.
-            .init(type: "tmpfs", source: "tmpfs", destination: "/run"),
             .init(type: "sysfs", source: "sysfs", destination: "/sys"),
             .init(type: "tmpfs", source: "tmpfs", destination: "/tmp"),
             .init(type: "devpts", source: "devpts", destination: "/dev/pts", options: ["gid=5", "mode=620", "ptmxmode=666"]),

--- a/Sources/cctl/RunCommand.swift
+++ b/Sources/cctl/RunCommand.swift
@@ -43,6 +43,9 @@ extension Application {
         @Option(name: .customLong("fs-size"), help: "The size to create the block filesystem as")
         var fsSizeInMB: UInt64 = 2048
 
+        @Flag(name: .customLong("rosetta"), help: "Enable rosetta x64 emulation")
+        var rosetta = false
+
         @Option(name: .customLong("mount"), help: "Directory to share into the container (Example: /foo:/bar)")
         var mounts: [String] = []
 
@@ -92,6 +95,7 @@ extension Application {
                 config.process.setTerminalIO(terminal: current)
                 config.process.arguments = arguments
                 config.process.workingDirectory = cwd
+                config.rosetta = rosetta
 
                 for mount in self.mounts {
                     let paths = mount.split(separator: ":")

--- a/vminitd/Sources/vminitd/Application.swift
+++ b/vminitd/Sources/vminitd/Application.swift
@@ -99,7 +99,10 @@ struct Application {
             log.error("failed to mount /proc")
             exit(1)
         }
-
+        guard Musl.mount("tmpfs", "/run", "tmpfs", 0, "") == 0 else {
+            log.error("failed to mount /run")
+            exit(1)
+        }
         try Binfmt.mount()
 
         log.logLevel = .debug


### PR DESCRIPTION
This reverts commit 5f7dcd2a1687d28ee5cb28e274d23acf57f760fc. Rosetta is setup at /run because the guest rootfs is ro, and unfortunately this happens prior to LinuxContainer getting to mount any of this. I'm not super happy about this, but we can figure something out later.

Additionally this adds a rosetta flag to cctl so we can quickly spotcheck things like this again.