### PR TITLE
Close a handle inside a lock

### DIFF
--- a/Sources/ContainerizationOS/Socket/Socket.swift
+++ b/Sources/ContainerizationOS/Socket/Socket.swift
@@ -179,25 +179,24 @@ extension Socket {
     }
 
     public func close() throws {
-        let (handleToClose, sourceToCancel) = state.withLock { currentState -> (FileHandle?, DispatchSourceRead?) in
+        try state.withLock { currentState in
             guard let handle = currentState.handle else {
                 // Already closed.
-                return (nil, nil)
+                return
             }
-
+            
+            let acceptSource = currentState.acceptSource
+            
+            acceptSource?.cancel()
+            try handle.close()
+            
             currentState = State(
                 socketState: currentState.socketState,
                 handle: nil,
                 type: currentState.type,
                 acceptSource: nil
             )
-
-            return (handle, currentState.acceptSource)
         }
-
-        // Close outside the lock to avoid a deadlock.
-        sourceToCancel?.cancel()
-        try handleToClose?.close()
     }
 
     public func write(data: any DataProtocol) throws -> Int {


### PR DESCRIPTION
Improves https://github.com/apple/containerization/pull/245. A potential deadlock risk was not proven. This PR moves the closing operation inside the lock to prevent leaking an unclosed handle in case of an error.