### PR TITLE
Handle the same file name in the `fetchBlob` method

### DIFF
--- a/Sources/ContainerizationOCI/Client/LocalOCILayoutClient.swift
+++ b/Sources/ContainerizationOCI/Client/LocalOCILayoutClient.swift
@@ -42,7 +42,7 @@ package final class LocalOCILayoutClient: ContentClient {
         }
 
         var hasher = SHA256()
-        let chunkSize = 1024 * 1024
+        let chunkSize = Int(getpagesize()) * 1024
 
         while true {
             let chunk = fileHandle.readData(ofLength: chunkSize)


### PR DESCRIPTION
With the suggested change, when a file exists, we'll verify whether it has the same content before skipping it.