### PR TITLE
Handle warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@
 # Build configuration variables
 # The default version ID 0.0.0 indicates a local development build or PRB
 BUILD_CONFIGURATION ?= debug
+WARNINGS_AS_ERRORS ?= true
+SWIFT_CONFIGURATION = $(if $(filter-out false,$(WARNINGS_AS_ERRORS)),-Xswiftc -warnings-as-errors)
 
 # Commonly used locations
 SWIFT := "/usr/bin/swift"
@@ -42,7 +44,7 @@ release: all
 .PHONY: containerization
 containerization:
 	@echo Building containerization binaries...
-	@$(SWIFT) build -c $(BUILD_CONFIGURATION)
+	@$(SWIFT) build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION)
 
 	@echo Copying containerization binaries...
 	@mkdir -p bin
@@ -85,7 +87,7 @@ update-libarchive-source:
 .PHONY: test
 test:
 	@echo Testing all test targets...
-	@$(SWIFT) test --enable-code-coverage
+	@$(SWIFT) test --enable-code-coverage $(SWIFT_CONFIGURATION)
 
 .PHONY: integration
 integration:

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ cross-prep:
 .PHONY: vminitd
 vminitd:
 	@mkdir -p ./bin
-	@"$(MAKE)" -C vminitd BUILD_CONFIGURATION=$(BUILD_CONFIGURATION)
+	@"$(MAKE)" -C vminitd BUILD_CONFIGURATION=$(BUILD_CONFIGURATION) WARNINGS_AS_ERRORS=$(WARNINGS_AS_ERRORS)
 
 .PHONY: update-libarchive-source
 update-libarchive-source:

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ all: init
 release: BUILD_CONFIGURATION = release
 release: all
 
+.PHONY: allow-warnings
+allow-warnings: WARNINGS_AS_ERRORS = false
+allow-warnings: all
+
 .PHONY: containerization
 containerization:
 	@echo Building containerization binaries...

--- a/vminitd/Makefile
+++ b/vminitd/Makefile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 BUILD_CONFIGURATION := debug
-SWIFT_CONFIGURATION := --swift-sdk aarch64-swift-linux-musl
+WARNINGS_AS_ERRORS ?= true
+SWIFT_WARNING_CONFIG = $(if $(filter-out false,$(WARNINGS_AS_ERRORS)),-Xswiftc -warnings-as-errors)
+SWIFT_CONFIGURATION := --swift-sdk aarch64-swift-linux-musl $(SWIFT_WARNING_CONFIG)
 
 SWIFT_VERSION = 6.2-snapshot-2025-06-25
 SWIFT_SDK_URL = https://download.swift.org/swift-6.2-branch/static-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-06-25-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-06-25-a_static-linux-0.0.1.artifactbundle.tar.gz

--- a/vminitd/Makefile
+++ b/vminitd/Makefile
@@ -42,6 +42,10 @@ all:
 	@install "$(VMINITD_BIN_PATH)/vminitd" ./bin/
 	@install "$(VMINITD_BIN_PATH)/vmexec" ./bin/
 
+.PHONY: allow-warnings
+allow-warnings: WARNINGS_AS_ERRORS = false
+allow-warnings: all
+
 .PHONY: cross-prep
 cross-prep: linux-sdk macos-sdk
 


### PR DESCRIPTION
To handle warnings as errors when building, use `make`. To allow warnings when building, use `make allow-warnings`.
To handle warnings as errors when testing, use `make test`. To allow warnings when testing, use `make WARNINGS_AS_ERRORS=false test`.