### PR TITLE
vminitd: Log spec for exec processes

### DIFF
--- a/vminitd/Sources/vminitd/ManagedContainer.swift
+++ b/vminitd/Sources/vminitd/ManagedContainer.swift
@@ -50,7 +50,7 @@ actor ManagedContainer {
             path: Self.craftBundlePath(id: id),
             spec: spec
         )
-        log.info("created bundle with spec \(spec)")
+        log.debug("created bundle with spec \(spec)")
 
         let cgManager = Cgroup2Manager(
             group: URL(filePath: cgroupsPath),
@@ -101,6 +101,8 @@ extension ManagedContainer {
         stdio: HostStdio,
         process: ContainerizationOCI.Process
     ) throws {
+        log.debug("creating exec process with \(process)")
+
         // Write the process config to the bundle, and pass this on
         // over to ManagedProcess to deal with.
         try self.bundle.createExecSpec(


### PR DESCRIPTION
We had a log for the initial oci runtime spec, but we don't log anything for execed processes. This makes it hard to look into issues that may be due to just a mistake in the spec and nothing wrong with the actual logic of the program.