### PR TITLE
vminitd: Wait for execvpe to return to continue

### DIFF
--- a/vminitd/Sources/vmexec/ExecCommand.swift
+++ b/vminitd/Sources/vmexec/ExecCommand.swift
@@ -101,7 +101,6 @@ struct ExecCommand: ParsableCommand {
 
                 let data = Data(bytes: &masterFD, count: MemoryLayout.size(ofValue: masterFD))
                 try syncPipe.write(contentsOf: data)
-                try syncPipe.close()
 
                 // Wait for the grandparent to tell us that they acked our console.
                 guard let data = try ackPipe.read(upToCount: App.ackConsole.count) else {

--- a/vminitd/Sources/vmexec/RunCommand.swift
+++ b/vminitd/Sources/vmexec/RunCommand.swift
@@ -91,7 +91,6 @@ struct RunCommand: ParsableCommand {
 
             let data = Data(bytes: &masterFD, count: MemoryLayout.size(ofValue: masterFD))
             try syncPipe.write(contentsOf: data)
-            try syncPipe.close()
 
             // Wait for the grandparent to tell us that they acked our console.
             guard let data = try ackPipe.read(upToCount: App.ackConsole.count) else {


### PR DESCRIPTION
Today, because we don't wait for execvpe to finish to continue onwards, it's possible that if you did an exec quick enough after starting an init process for a container, that you could join the init processes namespaces before pivot_root has taken place which is quite fun. Let's wait for exec to finish (or an error to occur) to prevent this.