### PR TITLE
vminitd: Removed extraneous import

### DIFF
--- a/vminitd/Sources/vminitd/Server.swift
+++ b/vminitd/Sources/vminitd/Server.swift
@@ -18,7 +18,6 @@ import ContainerizationError
 import Foundation
 import GRPC
 import Logging
-import Musl
 import NIOCore
 import NIOPosix
 


### PR DESCRIPTION
We shouldn't need this import anymore

cc: @crosbymichael 