### PR TITLE
Print the Swift version before building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ release: all
 .PHONY: containerization
 containerization:
 	@echo Building containerization binaries...
+	@$(SWIFT) --version
 	@$(SWIFT) build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION)
 
 	@echo Copying containerization binaries...

--- a/vminitd/Makefile
+++ b/vminitd/Makefile
@@ -38,6 +38,7 @@ all:
 	@mkdir -p ./bin/
 	@rm -f ./bin/vminitd
 	@rm -f ./bin/vmexec
+	@swift --version
 	@swift build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION)
 	@install "$(VMINITD_BIN_PATH)/vminitd" ./bin/
 	@install "$(VMINITD_BIN_PATH)/vmexec" ./bin/


### PR DESCRIPTION
With the changes in this PR, we'll print the Swift version before building. This mirrors a similar change in container, introduced in https://github.com/apple/container/pull/550.