### PR TITLE
Kernel: Fix `make`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Containerization depends on specific versions of `grpc-swift` and `swift-protobu
 make protos
 ```
 
+## Building a kernel
+
+If you'd like to build your own kernel please see the instructions in the [kernel directory](./kernel/README.md).
+
 ## Documentation
 
 Generate the API documentation for local viewing with:

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -1,9 +1,0 @@
-FROM ghcr.io/apple/backpack-test/kernel-build:latest as build
-COPY . /src
-WORKDIR /src
-RUN make prepare-kernel
-RUN make build-kernel
-
-FROM scratch
-LABEL org.opencontainers.image.source=https://github.com/apple/containerization
-COPY --from=build /src/kernel.arm64 /

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -13,19 +13,29 @@
 # limitations under the License.
 
 KSOURCE ?= https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.14.9.tar.xz
-KIMAGE ?= ghcr.io/apple/test-images/kernel-build:latest
+KIMAGE ?= kernel-build:0.1
+CURDIR := $(shell pwd)
 
-all:
+.DEFAULT_GOAL := all
+
+.PHONY: all
+all: kernel-build-image
+all: kernel-build
+
+.PHONY: kernel-build-image
+kernel-build-image:
+	container build image/ -f image/Dockerfile -t ${KIMAGE}
+
+.PHONY: kernel-build
+kernel-build:
 ifeq (,$(wildcard source.tar.xz))
 	curl -SsL -o source.tar.xz ${KSOURCE}
 endif
-	../bin/cctl run \
+	container run \
 		--cpus 8 \
-		--memory 16384 \
-		--fs-size 32768 \
-		--kernel ../bin/vmlinux \
-		--init ../bin/init.block \
-		--image ${KIMAGE} \
-		--mount .:/kernel \
+		--rm \
+		--memory 16g \
+		-v ${CURDIR}:/kernel \
 		--cwd /kernel \
-		-- /bin/bash -c "./build.sh"
+		${KIMAGE} \
+		/bin/bash -c "./build.sh"

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -2,7 +2,6 @@
 
 This directory includes an optimized kernel configuration to produce a fast and lightweight kernel for container use.
 
-
 - `config-arm64` includes the kernel `CONFIG_` options.
 - `Makefile` includes the kernel version and source package url.
 - `build.sh` scripts the kernel build process.
@@ -10,13 +9,7 @@ This directory includes an optimized kernel configuration to produce a fast and 
 
 ## Building
 
-1. Build the `Containerization` project by running `make` in the root of the repository.
-2. Place a kernel you want to use in `bin/vmlinux` directory of the repository.
+1. The build process relies on having the `container` tool installed (https://github.com/apple/container/releases).
+2. Run `make`. This should create the image used for building the resulting Linux kernel, and then run a container with that image to perform the kernel build.
 
-    a. This kernel will be used to launch the build container.
-
-    b. To fetch a default kernel run `make fetch-default-kernel` in the root of the repository.
-3. Run `make` in the `/kernel` directory. 
-
-A `kernel/vmlinux` will be the result of the build.
-
+A `kernel/vmlinux` file will be the result of the build.

--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -1,17 +1,3 @@
-# Copyright © 2025 Apple Inc. and the Containerization project authors. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 #!/bin/bash
 # Copyright © 2025 Apple Inc. and the Containerization project authors. All rights reserved.
 #
@@ -26,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 
 set -e
 

--- a/kernel/image/Dockerfile
+++ b/kernel/image/Dockerfile
@@ -5,12 +5,11 @@ RUN apt-get update && apt-get install -y \
     bc \
     binutils-multiarch \
     binutils-aarch64-linux-gnu \
-    binutils-x86-64-linux-gnu \
     bison \
     flex \
     gcc \
+    xz-utils \
     gcc-aarch64-linux-gnu \
-    gcc-x86-64-linux-gnu \
     git \
     libncurses-dev \
     make \
@@ -22,8 +21,7 @@ RUN apt-get update && apt-get install -y \
 COPY sources.list /etc/apt/sources.list
 
 RUN apt-get update \
-&&  dpkg --add-architecture amd64 \
 &&  dpkg --add-architecture arm64 \
-&&  apt-get install -y libelf-dev:amd64 libelf-dev:arm64 \
+&&  apt-get install -y libelf-dev:arm64 \
 &&  apt-get clean \
 &&  rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #296

Today the kernel subdirectory is somewhat useless. The dockerfile we had tried to use an image that isn't actually on ghcr, so everything would kind of just crap out. This change swaps things so that we build a local image that has all the bits needed to compile the kernel, and then uses that image to build the resulting kernel and plop it in the current working directory. This change does add a reliance on `container` being installed however, but for folks that need to build a custom kernel this doesn't seem like too much of an issue to me.