### PR TITLE
Adds `--add-file` to allow adding files to initfs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ init: containerization vminitd
 	@rm -f bin/init.rootfs.tar.gz bin/init.block
 	@./bin/cctl rootfs create \
 		--vminitd vminitd/bin/vminitd \
-		--labels org.opencontainers.image.source=https://github.com/apple/containerization \
 		--vmexec vminitd/bin/vmexec \
+		--label org.opencontainers.image.source=https://github.com/apple/containerization \
 		--image vminit:latest \
 		bin/init.rootfs.tar.gz
 


### PR DESCRIPTION
- Motivation is to be able to add the `swift-backtrace-static` binary as needed.
- Use singlular `--add-file` and `--label` options since both accept multiple invocations with single values each.

Example usage:

```bash
./bin/cctl rootfs create \
                --vminitd vminitd/bin/vminitd \
                --vmexec vminitd/bin/vmexec \
                --add-file /Users/john/.swiftpm/swift-sdks/swift-6.2-RELEASE_static-linux-0.0.1.artifactbundle/swift-6.2-RELEASE_static-linux-0.0.1/swift-linux-musl/musl-1.2.5.sdk/aarch64/usr/libexec/swift/linux-static/swift-backtrace-static:sbin/swift-backtrace \
                --label org.opencontainers.image.source=https://github.com/apple/containerization \
                --image vminit:latest \
                bin/init.rootfs.tar.gz
```