### PR TITLE
Update InterfaceStatistics.swift license header

### DIFF
--- a/Sources/Containerization/InterfaceStatistics.swift
+++ b/Sources/Containerization/InterfaceStatistics.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Containerization project authors. All rights reserved.
+// Copyright © 2025 Apple Inc. and the Containerization project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vminitd/Package.resolved
+++ b/vminitd/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ad8dec3662e872df8c3ddac4ec4c8531e98364117608a6d45321fb43e9d95a57",
+  "originHash" : "0855d97d95dd20ece9675e6b2aa0f7560c0843a73eadc8b42b9a9353047cb802",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -188,15 +188,6 @@
       "state" : {
         "revision" : "e7187309187695115033536e8fc9b2eb87fd956d",
         "version" : "2.8.0"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax.git",
-      "state" : {
-        "revision" : "0dff260d3d1bb99c382d8dfcd6bb093e5e9cbd36",
-        "version" : "602.0.0-prerelease-2025-05-29"
       }
     },
     {


### PR DESCRIPTION
Checked in before the all rights reserved was removed shortly after.