### PR TITLE
Integration: Run tests concurrently

### DIFF
--- a/Sources/Integration/ContainerTests.swift
+++ b/Sources/Integration/ContainerTests.swift
@@ -27,7 +27,7 @@ extension IntegrationSuite {
     func testProcessTrue() async throws {
         let id = "test-process-true"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/true"]
         }
@@ -46,7 +46,7 @@ extension IntegrationSuite {
     func testProcessFalse() async throws {
         let id = "test-process-false"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/false"]
         }
@@ -91,7 +91,7 @@ extension IntegrationSuite {
 
     func testProcessEchoHi() async throws {
         let id = "test-process-echo-hi"
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
 
         let buffer = BufferWriter()
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
@@ -123,7 +123,7 @@ extension IntegrationSuite {
     func testMultipleConcurrentProcesses() async throws {
         let id = "test-concurrent-processes"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/sleep", "1000"]
         }
@@ -165,7 +165,7 @@ extension IntegrationSuite {
 
     func testMultipleConcurrentProcessesOutputStress() async throws {
         let id = "test-concurrent-processes-output-stress"
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/sleep", "1000"]
         }
@@ -234,7 +234,7 @@ extension IntegrationSuite {
     func testProcessUser() async throws {
         let id = "test-process-user"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         var buffer = BufferWriter()
         var container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/usr/bin/id"]
@@ -327,7 +327,7 @@ extension IntegrationSuite {
     func testProcessTtyEnvvar() async throws {
         let id = "test-process-tty-envvar"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let buffer = BufferWriter()
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["env"]
@@ -361,7 +361,7 @@ extension IntegrationSuite {
     func testProcessHomeEnvvar() async throws {
         let id = "test-process-home-envvar"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let buffer = BufferWriter()
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["env"]
@@ -394,7 +394,7 @@ extension IntegrationSuite {
     func testProcessCustomHomeEnvvar() async throws {
         let id = "test-process-custom-home-envvar"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let customHomeEnvvar = "HOME=/tmp/custom/home"
         let buffer = BufferWriter()
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
@@ -426,7 +426,7 @@ extension IntegrationSuite {
     func testHostname() async throws {
         let id = "test-container-hostname"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let buffer = BufferWriter()
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/hostname"]
@@ -454,7 +454,7 @@ extension IntegrationSuite {
     func testHostsFile() async throws {
         let id = "test-container-hosts-file"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let entry = Hosts.Entry.localHostIPV4(comment: "Testaroo")
         let buffer = BufferWriter()
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
@@ -483,7 +483,7 @@ extension IntegrationSuite {
     func testProcessStdin() async throws {
         let id = "test-container-stdin"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let buffer = BufferWriter()
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["cat"]
@@ -511,7 +511,7 @@ extension IntegrationSuite {
     func testMounts() async throws {
         let id = "test-cat-mount"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let buffer = BufferWriter()
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             let directory = try createMountDirectory()
@@ -541,7 +541,7 @@ extension IntegrationSuite {
     func testPauseResume() async throws {
         let id = "test-pause-resume"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["sleep", "infinity"]
         }
@@ -562,7 +562,7 @@ extension IntegrationSuite {
     func testPauseResumeWait() async throws {
         let id = "test-pause-resume-wait"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["sleep", "2"]
         }
@@ -592,7 +592,7 @@ extension IntegrationSuite {
     func testPauseResumeIO() async throws {
         let id = "test-pause-resume-io"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let buffer = BufferWriter()
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["ping", "-c", "5", "localhost"]
@@ -626,7 +626,7 @@ extension IntegrationSuite {
     func testNestedVirtualizationEnabled() async throws {
         let id = "test-nested-virt"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/true"]
             config.virtualization = true
@@ -655,7 +655,7 @@ extension IntegrationSuite {
         let id = "test-container-manager"
 
         // Get the kernel from bootstrap
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
 
         // Create ContainerManager with kernel and initfs reference
         var manager = try ContainerManager(vmm: bs.vmm)
@@ -696,7 +696,7 @@ extension IntegrationSuite {
         let id = "test-container-stop-idempotency"
 
         // Get the kernel from bootstrap
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
 
         // Create ContainerManager with kernel and initfs reference
         var manager = try ContainerManager(vmm: bs.vmm)
@@ -739,7 +739,7 @@ extension IntegrationSuite {
         let id = "test-container-reuse"
 
         // Get the kernel from bootstrap
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
 
         // Create ContainerManager with kernel and initfs reference
         var manager = try ContainerManager(vmm: bs.vmm)
@@ -789,7 +789,7 @@ extension IntegrationSuite {
     func testContainerDevConsole() async throws {
         let id = "test-container-devconsole"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
 
         var manager = try ContainerManager(vmm: bs.vmm)
         defer {
@@ -837,7 +837,7 @@ extension IntegrationSuite {
     func testContainerStatistics() async throws {
         let id = "test-container-statistics"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["sleep", "infinity"]
         }
@@ -880,7 +880,7 @@ extension IntegrationSuite {
     func testCgroupLimits() async throws {
         let id = "test-cgroup-limits"
 
-        let bs = try await bootstrap()
+        let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["sleep", "infinity"]
             config.cpus = 2

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -23,6 +23,65 @@ import ContainerizationOS
 import Foundation
 import Logging
 import NIOCore
+import Synchronization
+
+actor UnpackCoordinator {
+    private var inFlight: [String: Task<Containerization.Mount, Error>] = [:]
+
+    func unpack(
+        key: String,
+        operation: @escaping @Sendable () async throws -> Containerization.Mount
+    ) async throws -> Containerization.Mount {
+        if let existing = inFlight[key] {
+            return try await existing.value
+        }
+
+        let task = Task {
+            try await operation()
+        }
+        inFlight[key] = task
+
+        defer {
+            inFlight.removeValue(forKey: key)
+        }
+
+        return try await task.value
+    }
+}
+
+struct Test: Sendable {
+    var name: String
+    var work: @Sendable () async throws -> Void
+
+    init(_ name: String, _ work: @escaping @Sendable () async throws -> Void) {
+        self.name = name
+        self.work = work
+    }
+}
+
+final class JobQueue<T>: Sendable where T: Sendable {
+    struct State: Sendable {
+        var next = 0
+        var jobs: [T]
+    }
+
+    private let lock: Mutex<State>
+    init(_ jobs: [T]) {
+        self.lock = Mutex(State(jobs: jobs))
+    }
+
+    func pop() -> T? {
+        self.lock.withLock { state in
+            guard state.next < state.jobs.count else {
+                return nil
+            }
+            defer {
+                state.next += 1
+            }
+            return state.jobs[state.next]
+        }
+    }
+}
 
 let log = {
     LoggingSystem.bootstrap(StreamLogHandler.standardError)
@@ -83,11 +142,16 @@ struct IntegrationSuite: AsyncParsableCommand {
 
     static let initImage = "vminit:latest"
 
+    private static let unpackCoordinator = UnpackCoordinator()
+
     @Option(name: .shortAndLong, help: "Path to a log file")
     var bootlog: String
 
     @Option(name: .shortAndLong, help: "Path to a kernel binary")
     var kernel: String = "./bin/vmlinux"
+
+    @Option(name: .shortAndLong, help: "Maximum number of concurrent tests")
+    var maxConcurrency: Int = 8
 
     static func binPath(name: String) -> URL {
         URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
@@ -95,7 +159,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             .appendingPathComponent(name)
     }
 
-    func bootstrap() async throws -> (rootfs: Containerization.Mount, vmm: VirtualMachineManager, image: Containerization.Image) {
+    func bootstrap(_ testID: String) async throws -> (rootfs: Containerization.Mount, vmm: VirtualMachineManager, image: Containerization.Image) {
         let reference = "ghcr.io/linuxcontainers/alpine:3.20"
         let store = Self.imageStore
 
@@ -122,8 +186,9 @@ struct IntegrationSuite: AsyncParsableCommand {
         let image = try await Self.fetchImage(reference: reference, store: store)
         let platform = Platform(arch: "arm64", os: "linux", variant: "v8")
 
-        let fs: Containerization.Mount = try await {
-            let fsPath = Self.testDir.appending(component: "rootfs.ext4")
+        // Unpack to shared location with coordination to prevent concurrent unpacks
+        let fsPath = Self.testDir.appending(component: image.digest)
+        let fs = try await Self.unpackCoordinator.unpack(key: fsPath.absolutePath()) {
             do {
                 let unpacker = EXT4Unpacker(blockSizeInBytes: 2.gib())
                 return try await unpacker.unpack(image, for: platform, at: fsPath)
@@ -138,9 +203,10 @@ struct IntegrationSuite: AsyncParsableCommand {
                 }
                 throw err
             }
-        }()
+        }
 
-        let clPath = Self.testDir.appending(component: "rn.ext4").absolutePath()
+        // Clone to test-specific path
+        let clPath = Self.testDir.appending(component: "\(testID).ext4").absolutePath()
         try? FileManager.default.removeItem(atPath: clPath)
 
         let cl = try fs.clone(to: clPath)
@@ -195,63 +261,76 @@ struct IntegrationSuite: AsyncParsableCommand {
         let suiteStarted = CFAbsoluteTimeGetCurrent()
         log.info("starting integration suite\n")
 
-        let tests: [String: () async throws -> Void] = [
-            "process true": testProcessTrue,
-            "process false": testProcessFalse,
-            "process echo hi": testProcessEchoHi,
-            "process user": testProcessUser,
-            "process stdin": testProcessStdin,
-            "process home envvar": testProcessHomeEnvvar,
-            "process custom home envvar": testProcessCustomHomeEnvvar,
-            "process tty ensure TERM": testProcessTtyEnvvar,
-            "multiple concurrent processes": testMultipleConcurrentProcesses,
-            "multiple concurrent processes with output stress": testMultipleConcurrentProcessesOutputStress,
-            "container hostname": testHostname,
-            "container hosts": testHostsFile,
-            "container mount": testMounts,
-            "container pause and resume": testPauseResume,
-            "container pause, resume and wait": testPauseResumeWait,
-            "container pause, resume and verify io": testPauseResumeIO,
-            "nested virt": testNestedVirtualizationEnabled,
-            "container manager": testContainerManagerCreate,
-            "container reuse": testContainerReuse,
-            "container /dev/console": testContainerDevConsole,
-            "container statistics": testContainerStatistics,
-            "container cgroup limits": testCgroupLimits,
+        let tests: [Test] = [
+            Test("process true", testProcessTrue),
+            Test("process false", testProcessFalse),
+            Test("process echo hi", testProcessEchoHi),
+            Test("process user", testProcessUser),
+            Test("process stdin", testProcessStdin),
+            Test("process home envvar", testProcessHomeEnvvar),
+            Test("process custom home envvar", testProcessCustomHomeEnvvar),
+            Test("process tty ensure TERM", testProcessTtyEnvvar),
+            Test("multiple concurrent processes", testMultipleConcurrentProcesses),
+            Test("multiple concurrent processes with output stress", testMultipleConcurrentProcessesOutputStress),
+            Test("container hostname", testHostname),
+            Test("container hosts", testHostsFile),
+            Test("container mount", testMounts),
+            Test("container pause and resume", testPauseResume),
+            Test("container pause, resume and wait", testPauseResumeWait),
+            Test("container pause, resume and verify io", testPauseResumeIO),
+            Test("nested virt", testNestedVirtualizationEnabled),
+            Test("container manager", testContainerManagerCreate),
+            Test("container reuse", testContainerReuse),
+            Test("container /dev/console", testContainerDevConsole),
+            Test("container statistics", testContainerStatistics),
+            Test("container cgroup limits", testCgroupLimits),
         ]
 
-        var passed = 0
-        var skipped = 0
-        for (name, test) in tests {
-            do {
-                log.info("test \(name) started...")
+        let passed: Atomic<Int> = Atomic(0)
+        let skipped: Atomic<Int> = Atomic(0)
 
-                let started = CFAbsoluteTimeGetCurrent()
-                try await test()
-                let lasted = CFAbsoluteTimeGetCurrent() - started
-                log.info("✅ test \(name) complete in \(lasted)s.")
-                passed += 1
-            } catch let err as SkipTest {
-                log.info("⏭️ skipped test: \(err)")
-                skipped += 1
-            } catch {
-                log.error("❌ test \(name) failed: \(error)")
+        await withTaskGroup(of: Void.self) { group in
+            let jobQueue = JobQueue(tests)
+            for _ in 0..<maxConcurrency {
+                group.addTask { @Sendable in
+                    while let job = jobQueue.pop() {
+                        do {
+                            log.info("test \(job.name) started...")
+
+                            let started = CFAbsoluteTimeGetCurrent()
+                            try await job.work()
+                            let lasted = CFAbsoluteTimeGetCurrent() - started
+
+                            log.info("✅ test \(job.name) complete in \(lasted)s.")
+                            passed.add(1, ordering: .acquiring)
+                        } catch let err as SkipTest {
+                            log.info("⏭️ skipped test: \(err)")
+                            skipped.add(1, ordering: .acquiringAndReleasing)
+                        } catch {
+                            log.error("❌ test \(job.name) failed: \(error)")
+                        }
+                    }
+                }
             }
+            await group.waitForAll()
         }
 
+        let passedCount = passed.load(ordering: .acquiring)
+        let skippedCount = skipped.load(ordering: .acquiring)
+
         let ended = CFAbsoluteTimeGetCurrent() - suiteStarted
-        var finishingText = "\n\nIntegration suite completed in \(ended)s with \(passed)/\(tests.count) passed"
-        if skipped > 0 {
-            finishingText += " and \(skipped)/\(tests.count) skipped"
+        var finishingText = "\n\nIntegration suite completed in \(ended)s with \(passedCount)/\(tests.count) passed"
+        if skipped.load(ordering: .acquiring) > 0 {
+            finishingText += " and \(skippedCount)/\(tests.count) skipped"
         }
         finishingText += "!"
 
         log.info("\(finishingText)")
 
-        if passed + skipped < tests.count {
+        try? FileManager.default.removeItem(at: Self.testDir)
+        if passedCount + skippedCount < tests.count {
             log.error("❌")
             throw ExitCode(1)
         }
-        try? FileManager.default.removeItem(at: Self.testDir)
     }
 }


### PR DESCRIPTION
Today all of the tests are ran serially which on an M1 Max comes out to usually around 30+ seconds for me. This seems much too long to wait for what these tests actually do.. There was one decent deterrent in the way of getting these to actually run concurrently however, which is that today every test uses the exact same image, and it is unpacked every single time in the `bootstrap` method. Every invocation after the first doesn't actually re-unpack the image, as the logic for "is this unpacked" is just a stat on the path, but what this means once we try and run the same on > 1 thread is they will all compete with each other on unpacking, and sometimes (almost always) trample over each other. This can result in guests trying to mount a faulty filesystem:

[    0.303404] EXT4-fs (vdb): VFS: Can't find ext4 filesystem

Ideally we have API to handle this, but for now I've invented a shoddy unpack coordinator type that just keys off of a path and halts any other threads if an unpack for that path is already in progress.

Timings (10 runs, image already pulled, max concurrency == 8):

New avg: 11s
Old Avg: 31s