### PR TITLE
Allow runtime options for generic mounts

### DIFF
--- a/Sources/Containerization/Mount.swift
+++ b/Sources/Containerization/Mount.swift
@@ -43,10 +43,10 @@ public struct Mount: Sendable {
     public enum RuntimeOptions: Sendable {
         case virtioblk([String])
         case virtiofs([String])
-        case any
+        case any([String])
     }
 
-    init(
+    public init(
         type: String,
         source: String,
         destination: String,
@@ -98,14 +98,15 @@ public struct Mount: Sendable {
         type: String,
         source: String,
         destination: String,
-        options: [String] = []
+        options: [String] = [],
+        runtimeOptions: [String] = []
     ) -> Self {
         .init(
             type: type,
             source: source,
             destination: destination,
             options: options,
-            runtimeOptions: .any
+            runtimeOptions: .any(runtimeOptions)
         )
     }
 


### PR DESCRIPTION
Make generic mounts more flexible by passing in runtime options and making the init function public 