### PR TITLE
Make vmm create protocol async

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -364,7 +364,7 @@ extension LinuxContainer {
         try await self.state.withLock { state in
             try state.validateForCreate()
 
-            let vm = try self.vmm.create(container: self)
+            let vm = try await self.vmm.create(container: self)
             try await vm.start()
             do {
                 let relayManager = UnixSocketRelayManager(vm: vm)

--- a/Sources/Containerization/VirtualMachineManager.swift
+++ b/Sources/Containerization/VirtualMachineManager.swift
@@ -16,5 +16,5 @@
 
 /// A protocol to implement for virtual machine isolated containers.
 public protocol VirtualMachineManager: Sendable {
-    func create(container: Container) throws -> any VirtualMachineInstance
+    func create(container: Container) async throws -> any VirtualMachineInstance
 }


### PR DESCRIPTION
The `vmm.create` call is already made within an async function. This PR updates the protocol to allow other vmm implementations more flexibility in `create`.