### PR TITLE
chore: restrict GitHub workflow permissions - future-proof

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -1,5 +1,8 @@
 name: Build and publish containerization test images
 
+permissions:
+  contents: read
+
 on: 
   workflow_dispatch: 
     inputs: 

--- a/.github/workflows/containerization-build-template.yml
+++ b/.github/workflows/containerization-build-template.yml
@@ -1,5 +1,8 @@
 name: Build containerization template
 
+permissions:
+  contents: read
+
 on: 
   workflow_call:
     inputs:

--- a/.github/workflows/containerization-build.yml
+++ b/.github/workflows/containerization-build.yml
@@ -1,5 +1,8 @@
 name: Build containerization
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, reopened, synchronize]

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -1,6 +1,10 @@
 # Manual workflow for releasing docs ad-hoc. Workflow can only be run for main or release branches. 
 # Workflow does NOT publish a release of containerization.
 name: Deploy application website
+
+permissions:
+  contents: read
+
 on: 
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release containerization
 
+permissions:
+  contents: read
+
 on: 
   push: 
     tags:


### PR DESCRIPTION
See https://github.com/swiftlang/github-workflows/issues/167 for additional context

This approach aligns with security best practices, as detailed in the following documentation:

- https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes
- https://openssf.org/blog/2024/08/12/mitigating-attack-vectors-in-github-workflows/


The default GITHUB_TOKEN permissions are defined at the repository level. This PR modifies the workflow-level overrides to conform to OpenSSF best practices -> defense in depth.

Allow me to quote OpenSSF:
https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

> The highest score is awarded when the permissions definitions in each workflow's yaml file are set as read-only at the top level and the required write permissions are declared at the run-level.”

> Remediation steps
> - Set top-level permissions as read-all or contents: read as described in GitHub's documentation.
> - Set any required write permissions at the job-level. Only set the permissions required for that job; do not set permissions: write-all at the job level.


Compare to the LLVM project:

Top-level: contents read, e.g. https://github.com/swiftlang/llvm-project/blob/next/.github/workflows/build-ci-container-windows.yml#L3-L4 -> this makes it future-proof

Job-level: Allow write permissions as needed, e.g. https://github.com/swiftlang/llvm-project/blob/next/.github/workflows/build-ci-container-windows.yml#L53-L58
