### PR TITLE
VirtualMachineManager: Rework protocol

### DIFF
--- a/Sources/Containerization/ContainerManager.swift
+++ b/Sources/Containerization/ContainerManager.swift
@@ -197,12 +197,15 @@ public struct ContainerManager: Sendable {
     }
 
     /// Create a new manager with the provided kernel, initfs mount, image store
-    /// and optional network implementation.
+    /// and optional network implementation. This will use a Virtualization.framework
+    /// backed VMM implicitly.
     public init(
         kernel: Kernel,
         initfs: Mount,
         imageStore: ImageStore,
-        network: Network? = nil
+        network: Network? = nil,
+        rosetta: Bool = false,
+        nestedVirtualization: Bool = false
     ) throws {
         self.imageStore = imageStore
         self.network = network
@@ -210,17 +213,22 @@ public struct ContainerManager: Sendable {
         self.vmm = VZVirtualMachineManager(
             kernel: kernel,
             initialFilesystem: initfs,
-            bootlog: self.imageStore.path.appendingPathComponent("bootlog.log").absolutePath()
+            bootlog: imageStore.path.appendingPathComponent("bootlog.log").absolutePath(),
+            rosetta: rosetta,
+            nestedVirtualization: nestedVirtualization
         )
     }
 
     /// Create a new manager with the provided kernel, initfs mount, root state
-    /// directory and optional network implementation.
+    /// directory and optional network implementation. This will use a Virtualization.framework
+    /// backed VMM implicitly.
     public init(
         kernel: Kernel,
         initfs: Mount,
         root: URL? = nil,
-        network: Network? = nil
+        network: Network? = nil,
+        rosetta: Bool = false,
+        nestedVirtualization: Bool = false
     ) throws {
         if let root {
             self.imageStore = try ImageStore(path: root)
@@ -232,17 +240,22 @@ public struct ContainerManager: Sendable {
         self.vmm = VZVirtualMachineManager(
             kernel: kernel,
             initialFilesystem: initfs,
-            bootlog: self.imageStore.path.appendingPathComponent("bootlog.log").absolutePath()
+            bootlog: imageStore.path.appendingPathComponent("bootlog.log").absolutePath(),
+            rosetta: rosetta,
+            nestedVirtualization: nestedVirtualization
         )
     }
 
     /// Create a new manager with the provided kernel, initfs reference, image store
-    /// and optional network implementation.
+    /// and optional network implementation. This will use a Virtualization.framework
+    /// backed VMM implicitly.
     public init(
         kernel: Kernel,
         initfsReference: String,
         imageStore: ImageStore,
-        network: Network? = nil
+        network: Network? = nil,
+        rosetta: Bool = false,
+        nestedVirtualization: Bool = false
     ) async throws {
         self.imageStore = imageStore
         self.network = network
@@ -269,16 +282,21 @@ public struct ContainerManager: Sendable {
         self.vmm = VZVirtualMachineManager(
             kernel: kernel,
             initialFilesystem: initfs,
-            bootlog: self.imageStore.path.appendingPathComponent("bootlog.log").absolutePath()
+            bootlog: self.imageStore.path.appendingPathComponent("bootlog.log").absolutePath(),
+            rosetta: rosetta,
+            nestedVirtualization: nestedVirtualization
         )
     }
 
     /// Create a new manager with the provided kernel and image reference for the initfs.
+    /// This will use a Virtualization.framework backed VMM implicitly.
     public init(
         kernel: Kernel,
         initfsReference: String,
         root: URL? = nil,
-        network: Network? = nil
+        network: Network? = nil,
+        rosetta: Bool = false,
+        nestedVirtualization: Bool = false
     ) async throws {
         if let root {
             self.imageStore = try ImageStore(path: root)
@@ -309,7 +327,9 @@ public struct ContainerManager: Sendable {
         self.vmm = VZVirtualMachineManager(
             kernel: kernel,
             initialFilesystem: initfs,
-            bootlog: self.imageStore.path.appendingPathComponent("bootlog.log").absolutePath()
+            bootlog: self.imageStore.path.appendingPathComponent("bootlog.log").absolutePath(),
+            rosetta: rosetta,
+            nestedVirtualization: nestedVirtualization
         )
     }
 

--- a/Sources/Containerization/VMConfiguration.swift
+++ b/Sources/Containerization/VMConfiguration.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationOCI
+import Foundation
+
+/// Protocol for VM creation configuration. Allows VMMs to extend with specific settings
+/// while maintaining a common core configuration.
+public protocol VMCreationConfig: Sendable {
+    /// The common VM configuration that all VMMs must support.
+    var configuration: VMConfiguration { get }
+}
+
+/// Standard VM creation configuration with only common settings.
+public struct StandardVMConfig: VMCreationConfig {
+    public var configuration: VMConfiguration
+
+    public init(configuration: VMConfiguration) {
+        self.configuration = configuration
+    }
+}
+
+/// Configuration for creating a virtual machine instance.
+public struct VMConfiguration: Sendable {
+    /// The amount of CPUs to allocate.
+    public var cpus: Int
+    /// The memory in bytes to allocate.
+    public var memoryInBytes: UInt64
+    /// The network interfaces to attach.
+    public var interfaces: [any Interface]
+    /// Mounts organized by metadata ID (e.g. container ID).
+    /// Each ID maps to an array of mounts for that workload.
+    public var mountsByID: [String: [Mount]]
+    /// Optional file path to store serial boot logs.
+    public var bootlog: URL?
+    /// Enable nested virtualization support. If the VirtualMachineManager
+    /// does not support this feature, it MUST return an .unsupported ContainerizationError.
+    public var nestedVirtualization: Bool
+
+    public init(
+        cpus: Int = 4,
+        memoryInBytes: UInt64 = 1024 * 1024 * 1024,
+        interfaces: [any Interface] = [],
+        mountsByID: [String: [Mount]] = [:],
+        bootlog: URL? = nil,
+        nestedVirtualization: Bool = false
+    ) {
+        self.cpus = cpus
+        self.memoryInBytes = memoryInBytes
+        self.interfaces = interfaces
+        self.mountsByID = mountsByID
+        self.bootlog = bootlog
+        self.nestedVirtualization = nestedVirtualization
+    }
+}

--- a/Sources/Containerization/VirtualMachineInstance.swift
+++ b/Sources/Containerization/VirtualMachineInstance.swift
@@ -33,7 +33,7 @@ public protocol VirtualMachineInstance: Sendable {
     // The state of the virtual machine.
     var state: VirtualMachineInstanceState { get }
 
-    var mounts: [AttachedFilesystem] { get }
+    var mounts: [String: [AttachedFilesystem]] { get }
     /// Dial the Agent. It's up the VirtualMachineInstance to determine
     /// what port the agent is listening on.
     func dialAgent() async throws -> Agent

--- a/Sources/Containerization/VirtualMachineManager.swift
+++ b/Sources/Containerization/VirtualMachineManager.swift
@@ -16,5 +16,5 @@
 
 /// A protocol to implement for virtual machine isolated containers.
 public protocol VirtualMachineManager: Sendable {
-    func create(container: Container) async throws -> any VirtualMachineInstance
+    func create(config: some VMCreationConfig) async throws -> any VirtualMachineInstance
 }

--- a/Sources/cctl/RunCommand.swift
+++ b/Sources/cctl/RunCommand.swift
@@ -79,6 +79,7 @@ extension Application {
             var manager = try await ContainerManager(
                 kernel: kernel,
                 initfsReference: "vminit:latest",
+                rosetta: rosetta
             )
             let sigwinchStream = AsyncSignalHandler.create(notify: [SIGWINCH])
 
@@ -96,7 +97,6 @@ extension Application {
                 config.process.setTerminalIO(terminal: current)
                 config.process.arguments = arguments
                 config.process.workingDirectory = cwd
-                config.rosetta = rosetta
 
                 for mount in self.mounts {
                     let paths = mount.split(separator: ":")


### PR DESCRIPTION
Today this protocols create method is just odd. Our only implementation of it immediately casts to LinuxContainer, failing if it cannot do so. I think what might make more sense is to pass in a configuration itself with core parameters that we expect every vmm to be able to support, and then in a specific implementation they can continue to cast this type to a specific one to possibly extract some extra configuration values (rosetta for VZ for example).

This rework will also make it simpler to support a Pod type, as the vm setup is identical and simple.