### PR TITLE
VZVirtualMachineInstance: Move event loop shutdown slightly up

### DIFF
--- a/Sources/Containerization/VZVirtualMachineInstance.swift
+++ b/Sources/Containerization/VZVirtualMachineInstance.swift
@@ -168,8 +168,8 @@ extension VZVirtualMachineInstance {
 
             try await self.timeSyncer.close()
 
-            try await self.vm.stop(queue: self.queue)
             try await self.group.shutdownGracefully()
+            try await self.vm.stop(queue: self.queue)
         }
     }
 


### PR DESCRIPTION
This and the work on it should likely be gone before vm shutdown.