### PR TITLE
Introduce new experimental LinuxPod type

### DIFF
--- a/Sources/Containerization/LinuxPod.swift
+++ b/Sources/Containerization/LinuxPod.swift
@@ -1,0 +1,736 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+#if os(macOS)
+import ContainerizationError
+import ContainerizationExtras
+import ContainerizationOCI
+import Foundation
+import Logging
+import Synchronization
+
+import struct ContainerizationOS.Terminal
+
+/// NOTE: Experimental API
+///
+/// `LinuxPod` allows managing multiple Linux containers within a single
+/// virtual machine. Each container has its own rootfs and process, but
+/// shares the VM's resources (CPU, memory, network).
+public final class LinuxPod: Sendable {
+    /// The identifier of the pod.
+    public let id: String
+
+    /// Configuration for the pod.
+    public let config: Configuration
+
+    /// The configuration for the LinuxPod.
+    public struct Configuration: Sendable {
+        /// The amount of cpus for the pod's VM.
+        public var cpus: Int = 4
+        /// The memory in bytes to give to the pod's VM.
+        public var memoryInBytes: UInt64 = 1024.mib()
+        /// The network interfaces for the pod.
+        public var interfaces: [any Interface] = []
+        /// The DNS configuration for the pod.
+        public var dns: DNS?
+        /// Whether nested virtualization should be turned on for the pod.
+        public var virtualization: Bool = false
+        /// Optional file path to store serial boot logs.
+        public var bootlog: URL?
+
+        public init() {}
+    }
+
+    /// Configuration for a container within the pod.
+    public struct ContainerConfiguration: Sendable {
+        /// Configuration for the init process of the container.
+        public var process = LinuxProcessConfiguration()
+        /// Optional per-container CPU limit (can exceed pod total for oversubscription).
+        public var cpus: Int?
+        /// Optional per-container memory limit in bytes (can exceed pod total for oversubscription).
+        public var memoryInBytes: UInt64?
+        /// The hostname for the container.
+        public var hostname: String = ""
+        /// The system control options for the container.
+        public var sysctl: [String: String] = [:]
+        /// The mounts for the container.
+        public var mounts: [Mount] = LinuxContainer.defaultMounts()
+        /// The Unix domain socket relays to setup for the container.
+        public var sockets: [UnixSocketConfiguration] = []
+
+        public init() {}
+    }
+
+    private struct PodContainer: Sendable {
+        let id: String
+        let rootfs: Mount
+        let config: ContainerConfiguration
+        var state: ContainerState
+        var process: LinuxProcess?
+
+        enum ContainerState: Sendable {
+            case registered
+            case created
+            case started
+            case stopped
+            case errored
+        }
+    }
+
+    private let state: AsyncMutex<State>
+
+    // Ports to be allocated from for stdio and for
+    // unix socket relays that are sharing a guest
+    // uds to the host.
+    private let hostVsockPorts: Atomic<UInt32>
+    // Ports we request the guest to allocate for unix socket relays from
+    // the host.
+    private let guestVsockPorts: Atomic<UInt32>
+
+    private struct State: Sendable {
+        var phase: Phase
+        var containers: [String: PodContainer]
+    }
+
+    private enum Phase: Sendable {
+        /// The pod has been created but no live resources are running.
+        case initialized
+        /// The pod's virtual machine has been setup and the runtime environment has been configured.
+        case created(CreatedState)
+        /// An error occurred during the lifetime of this class.
+        case errored(Swift.Error)
+
+        struct CreatedState: Sendable {
+            let vm: any VirtualMachineInstance
+            let relayManager: UnixSocketRelayManager
+        }
+
+        func createdState(_ operation: String) throws -> CreatedState {
+            switch self {
+            case .created(let state):
+                return state
+            case .errored(let err):
+                throw err
+            default:
+                throw ContainerizationError(
+                    .invalidState,
+                    message: "failed to \(operation): pod must be created"
+                )
+            }
+        }
+
+        mutating func validateForCreate() throws {
+            switch self {
+            case .initialized:
+                break
+            case .errored(let err):
+                throw err
+            default:
+                throw ContainerizationError(
+                    .invalidState,
+                    message: "pod must be in initialized state to create"
+                )
+            }
+        }
+
+        mutating func setErrored(error: Swift.Error) {
+            self = .errored(error)
+        }
+    }
+
+    private let vmm: VirtualMachineManager
+    private let logger: Logger?
+
+    /// Create a new `LinuxPod`. A `VirtualMachineManager` instance must be
+    /// provided that will handle launching the virtual machine the containers
+    /// will execute inside of.
+    public init(
+        _ id: String,
+        vmm: VirtualMachineManager,
+        logger: Logger? = nil,
+        configuration: (inout Configuration) throws -> Void
+    ) throws {
+        self.id = id
+        self.vmm = vmm
+        self.hostVsockPorts = Atomic<UInt32>(0x1000_0000)
+        self.guestVsockPorts = Atomic<UInt32>(0x1000_0000)
+        self.logger = logger
+
+        var config = Configuration()
+        try configuration(&config)
+
+        self.config = config
+        self.state = AsyncMutex(State(phase: .initialized, containers: [:]))
+    }
+
+    private static func createDefaultRuntimeSpec(_ containerID: String, podID: String) -> Spec {
+        .init(
+            process: .init(),
+            hostname: containerID,
+            root: .init(
+                path: Self.guestRootfsPath(containerID),
+                readonly: false
+            ),
+            linux: .init(
+                resources: .init(),
+                cgroupsPath: "/container/pod/\(podID)/\(containerID)"
+            )
+        )
+    }
+
+    private func generateRuntimeSpec(containerID: String, config: ContainerConfiguration) -> Spec {
+        var spec = Self.createDefaultRuntimeSpec(containerID, podID: self.id)
+
+        // Process configuration
+        spec.process = config.process.toOCI()
+
+        // General toggles
+        spec.hostname = config.hostname
+
+        // Linux toggles
+        spec.linux?.sysctl = config.sysctl
+
+        // Resource limits (if specified)
+        if let cpus = config.cpus, cpus > 0 {
+            spec.linux?.resources?.cpu = LinuxCPU(
+                quota: Int64(cpus * 100_000),
+                period: 100_000
+            )
+        }
+        if let memoryInBytes = config.memoryInBytes, memoryInBytes > 0 {
+            spec.linux?.resources?.memory = LinuxMemory(
+                limit: Int64(memoryInBytes)
+            )
+        }
+
+        return spec
+    }
+
+    private static func guestRootfsPath(_ containerID: String) -> String {
+        "/run/container/\(containerID)/rootfs"
+    }
+}
+
+extension LinuxPod {
+    /// Number of CPU cores allocated to the pod's VM.
+    public var cpus: Int {
+        config.cpus
+    }
+
+    /// Amount of memory in bytes allocated for the pod's VM.
+    public var memoryInBytes: UInt64 {
+        config.memoryInBytes
+    }
+
+    /// Network interfaces of the pod.
+    public var interfaces: [any Interface] {
+        config.interfaces
+    }
+
+    /// Add a container to the pod. This must be called before `create()`.
+    /// The container will be registered but not started.
+    public func addContainer(
+        _ id: String,
+        rootfs: Mount,
+        configuration: @Sendable @escaping (inout ContainerConfiguration) throws -> Void
+    ) async throws {
+        try await self.state.withLock { state in
+            guard case .initialized = state.phase else {
+                throw ContainerizationError(
+                    .invalidState,
+                    message: "pod must be initialized to add container"
+                )
+            }
+
+            guard state.containers[id] == nil else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "container with id \(id) already exists in pod"
+                )
+            }
+
+            var config = ContainerConfiguration()
+            try configuration(&config)
+
+            state.containers[id] = PodContainer(
+                id: id,
+                rootfs: rootfs,
+                config: config,
+                state: .registered,
+                process: nil
+            )
+        }
+    }
+
+    /// Create and start the underlying pod's virtual machine and set up
+    /// the runtime environment. All registered containers will have their
+    /// rootfs mounted, but no init processes will be running.
+    public func create() async throws {
+        try await self.state.withLock { state in
+            try state.phase.validateForCreate()
+
+            // Build mountsByID for all containers.
+            var mountsByID: [String: [Mount]] = [:]
+            for (id, container) in state.containers {
+                mountsByID[id] = [container.rootfs] + container.config.mounts
+            }
+
+            let vmConfig = VMConfiguration(
+                cpus: self.config.cpus,
+                memoryInBytes: self.config.memoryInBytes,
+                interfaces: self.config.interfaces,
+                mountsByID: mountsByID,
+                bootlog: self.config.bootlog,
+                nestedVirtualization: self.config.virtualization
+            )
+            let creationConfig = StandardVMConfig(configuration: vmConfig)
+            let vm = try await self.vmm.create(config: creationConfig)
+            let relayManager = UnixSocketRelayManager(vm: vm)
+            try await vm.start()
+
+            do {
+                let containers = state.containers
+                try await vm.withAgent { agent in
+                    try await agent.standardSetup()
+
+                    // Mount all container rootfs
+                    for (_, container) in containers {
+                        guard let attachments = vm.mounts[container.id], let rootfsAttachment = attachments.first else {
+                            throw ContainerizationError(.notFound, message: "rootfs mount not found for container \(container.id)")
+                        }
+                        var rootfs = rootfsAttachment.to
+                        rootfs.destination = Self.guestRootfsPath(container.id)
+                        try await agent.mount(rootfs)
+                    }
+
+                    // Start up unix socket relays for each container
+                    for (_, container) in containers {
+                        for socket in container.config.sockets {
+                            try await self.relayUnixSocket(
+                                socket: socket,
+                                containerID: container.id,
+                                relayManager: relayManager,
+                                agent: agent
+                            )
+                        }
+                    }
+
+                    // For every interface asked for:
+                    // 1. Add the address requested
+                    // 2. Online the adapter
+                    // 3. If a gateway IP address is present, add the default route.
+                    for (index, i) in self.interfaces.enumerated() {
+                        let name = "eth\(index)"
+                        try await agent.addressAdd(name: name, address: i.address)
+                        try await agent.up(name: name, mtu: 1280)
+                        if let gateway = i.gateway {
+                            try await agent.routeAddDefault(name: name, gateway: gateway)
+                        }
+                    }
+
+                    // Setup /etc/resolv.conf if asked for
+                    if let dns = self.config.dns {
+                        // Configure DNS in each container's rootfs
+                        for (_, container) in containers {
+                            try await agent.configureDNS(
+                                config: dns,
+                                location: Self.guestRootfsPath(container.id)
+                            )
+                        }
+                    }
+                }
+
+                // Transition all containers to created state
+                for id in state.containers.keys {
+                    state.containers[id]?.state = .created
+                }
+
+                state.phase = .created(.init(vm: vm, relayManager: relayManager))
+            } catch {
+                try? await relayManager.stopAll()
+                try? await vm.stop()
+                state.phase.setErrored(error: error)
+                throw error
+            }
+        }
+    }
+
+    /// Start a container's initial process.
+    public func startContainer(_ containerID: String) async throws {
+        try await self.state.withLock { state in
+            let createdState = try state.phase.createdState("startContainer")
+
+            guard var container = state.containers[containerID] else {
+                throw ContainerizationError(
+                    .notFound,
+                    message: "container \(containerID) not found in pod"
+                )
+            }
+
+            guard container.state == .created else {
+                throw ContainerizationError(
+                    .invalidState,
+                    message: "container \(containerID) must be in created state to start"
+                )
+            }
+
+            let agent = try await createdState.vm.dialAgent()
+            do {
+                var spec = self.generateRuntimeSpec(containerID: containerID, config: container.config)
+                // We don't need the rootfs, nor do OCI runtimes want it included.
+                let containerMounts = createdState.vm.mounts[containerID] ?? []
+                spec.mounts = containerMounts.dropFirst().map { $0.to }
+
+                let stdio = IOUtil.setup(
+                    portAllocator: self.hostVsockPorts,
+                    stdin: container.config.process.stdin,
+                    stdout: container.config.process.stdout,
+                    stderr: container.config.process.stderr
+                )
+
+                let process = LinuxProcess(
+                    containerID,
+                    containerID: containerID,
+                    spec: spec,
+                    io: stdio,
+                    agent: agent,
+                    vm: createdState.vm,
+                    logger: self.logger
+                )
+                try await process.start()
+
+                container.process = process
+                container.state = .started
+                state.containers[containerID] = container
+            } catch {
+                try? await agent.close()
+                throw error
+            }
+        }
+    }
+
+    /// Stop a container from executing.
+    public func stopContainer(_ containerID: String) async throws {
+        try await self.state.withLock { state in
+            let createdState = try state.phase.createdState("stopContainer")
+
+            guard var container = state.containers[containerID] else {
+                throw ContainerizationError(
+                    .notFound,
+                    message: "container \(containerID) not found in pod"
+                )
+            }
+
+            // Allow stop to be called multiple times
+            if container.state == .stopped {
+                return
+            }
+
+            guard container.state == .started, let process = container.process else {
+                throw ContainerizationError(
+                    .invalidState,
+                    message: "container \(containerID) must be in started state to stop"
+                )
+            }
+
+            do {
+                // Check if the vm is even still running
+                if createdState.vm.state == .stopped {
+                    container.state = .stopped
+                    state.containers[containerID] = container
+                    return
+                }
+
+                try await process.kill(SIGKILL)
+                try await process.wait(timeoutInSeconds: 3)
+
+                try await createdState.vm.withAgent { agent in
+                    // Unmount the rootfs
+                    try await agent.umount(
+                        path: Self.guestRootfsPath(containerID),
+                        flags: 0
+                    )
+                }
+
+                // Clean up the process resources
+                try await process.delete()
+
+                container.process = nil
+                container.state = .stopped
+                state.containers[containerID] = container
+            } catch {
+                container.state = .errored
+                container.process = nil
+                state.containers[containerID] = container
+
+                throw error
+            }
+        }
+    }
+
+    /// Stop the pod's VM and all containers.
+    public func stop() async throws {
+        try await self.state.withLock { state in
+            let createdState = try state.phase.createdState("stop")
+
+            do {
+                try await createdState.relayManager.stopAll()
+
+                // Stop all containers
+                let containerIDs = Array(state.containers.keys)
+
+                for containerID in containerIDs {
+                    // Stop the container inline
+                    guard var container = state.containers[containerID] else {
+                        continue
+                    }
+
+                    if container.state == .stopped {
+                        continue
+                    }
+
+                    if let process = container.process, container.state == .started {
+                        if createdState.vm.state != .stopped {
+                            try? await process.kill(SIGKILL)
+                            _ = try? await process.wait(timeoutInSeconds: 3)
+
+                            try? await createdState.vm.withAgent { agent in
+                                try await agent.umount(
+                                    path: Self.guestRootfsPath(containerID),
+                                    flags: 0
+                                )
+                            }
+                        }
+
+                        try? await process.delete()
+                        container.process = nil
+                        container.state = .stopped
+                        state.containers[containerID] = container
+                    }
+                }
+
+                try await createdState.vm.stop()
+                state.phase = .initialized
+            } catch {
+                try? await createdState.vm.stop()
+                state.phase.setErrored(error: error)
+                throw error
+            }
+        }
+    }
+
+    /// Pause the pod's VM.
+    public func pause() async throws {
+        try await self.state.withLock { state in
+            let createdState = try state.phase.createdState("pause")
+            try await createdState.vm.pause()
+        }
+    }
+
+    /// Resume the pod's VM.
+    public func resume() async throws {
+        try await self.state.withLock { state in
+            let createdState = try state.phase.createdState("resume")
+            try await createdState.vm.resume()
+        }
+    }
+
+    /// Send a signal to a container.
+    public func killContainer(_ containerID: String, signal: Int32) async throws {
+        try await self.state.withLock { state in
+            guard let container = state.containers[containerID], let process = container.process else {
+                throw ContainerizationError(
+                    .notFound,
+                    message: "container \(containerID) not found or not started"
+                )
+            }
+            try await process.kill(signal)
+        }
+    }
+
+    /// Wait for a container to exit. Returns the exit code.
+    @discardableResult
+    public func waitContainer(_ containerID: String, timeoutInSeconds: Int64? = nil) async throws -> ExitStatus {
+        let process = try await self.state.withLock { state in
+            guard let container = state.containers[containerID], let process = container.process else {
+                throw ContainerizationError(
+                    .notFound,
+                    message: "container \(containerID) not found or not started"
+                )
+            }
+            return process
+        }
+        return try await process.wait(timeoutInSeconds: timeoutInSeconds)
+    }
+
+    /// Resize a container's terminal (if one was requested).
+    public func resizeContainer(_ containerID: String, to: Terminal.Size) async throws {
+        try await self.state.withLock { state in
+            guard let container = state.containers[containerID], let process = container.process else {
+                throw ContainerizationError(
+                    .notFound,
+                    message: "container \(containerID) not found or not started"
+                )
+            }
+            try await process.resize(to: to)
+        }
+    }
+
+    /// Execute a new process in a container.
+    public func execInContainer(
+        _ containerID: String,
+        processID: String,
+        configuration: @Sendable @escaping (inout LinuxProcessConfiguration) throws -> Void
+    ) async throws -> LinuxProcess {
+        try await self.state.withLock { state in
+            let createdState = try state.phase.createdState("execInContainer")
+
+            guard let container = state.containers[containerID] else {
+                throw ContainerizationError(
+                    .notFound,
+                    message: "container \(containerID) not found in pod"
+                )
+            }
+
+            guard container.state == .started else {
+                throw ContainerizationError(
+                    .invalidState,
+                    message: "container \(containerID) must be started to exec"
+                )
+            }
+
+            var spec = self.generateRuntimeSpec(containerID: containerID, config: container.config)
+            var config = LinuxProcessConfiguration()
+            try configuration(&config)
+            spec.process = config.toOCI()
+
+            let stdio = IOUtil.setup(
+                portAllocator: self.hostVsockPorts,
+                stdin: config.stdin,
+                stdout: config.stdout,
+                stderr: config.stderr
+            )
+            let agent = try await createdState.vm.dialAgent()
+            let process = LinuxProcess(
+                processID,
+                containerID: containerID,
+                spec: spec,
+                io: stdio,
+                agent: agent,
+                vm: createdState.vm,
+                logger: self.logger
+            )
+            return process
+        }
+    }
+
+    /// List all container IDs in the pod.
+    public func listContainers() async -> [String] {
+        await self.state.withLock { state in
+            Array(state.containers.keys)
+        }
+    }
+
+    /// Get statistics for containers in the pod.
+    public func statistics(containerIDs: [String]? = nil) async throws -> [ContainerStatistics] {
+        let (createdState, ids) = try await self.state.withLock { state in
+            let createdState = try state.phase.createdState("statistics")
+            let ids = containerIDs ?? Array(state.containers.keys)
+            return (createdState, ids)
+        }
+
+        let stats = try await createdState.vm.withAgent { agent in
+            try await agent.containerStatistics(containerIDs: ids)
+        }
+
+        return stats
+    }
+
+    /// Dial a vsock port in the pod's VM.
+    public func dialVsock(port: UInt32) async throws -> FileHandle {
+        try await self.state.withLock { state in
+            let createdState = try state.phase.createdState("dialVsock")
+            return try await createdState.vm.dial(port)
+        }
+    }
+
+    /// Close a container's standard input to signal no more input is arriving.
+    public func closeContainerStdin(_ containerID: String) async throws {
+        try await self.state.withLock { state in
+            guard let container = state.containers[containerID], let process = container.process else {
+                throw ContainerizationError(
+                    .notFound,
+                    message: "container \(containerID) not found or not started"
+                )
+            }
+            try await process.closeStdin()
+        }
+    }
+
+    /// Relay a unix socket for a container.
+    public func relayUnixSocket(_ containerID: String, socket: UnixSocketConfiguration) async throws {
+        try await self.state.withLock { state in
+            let createdState = try state.phase.createdState("relayUnixSocket")
+
+            guard let _ = state.containers[containerID] else {
+                throw ContainerizationError(
+                    .notFound,
+                    message: "container \(containerID) not found in pod"
+                )
+            }
+
+            try await createdState.vm.withAgent { agent in
+                try await self.relayUnixSocket(
+                    socket: socket,
+                    containerID: containerID,
+                    relayManager: createdState.relayManager,
+                    agent: agent
+                )
+            }
+        }
+    }
+
+    private func relayUnixSocket(
+        socket: UnixSocketConfiguration,
+        containerID: String,
+        relayManager: UnixSocketRelayManager,
+        agent: any VirtualMachineAgent
+    ) async throws {
+        guard let relayAgent = agent as? SocketRelayAgent else {
+            throw ContainerizationError(
+                .unsupported,
+                message: "VirtualMachineAgent does not support relaySocket surface"
+            )
+        }
+
+        var socket = socket
+
+        // Adjust paths to be relative to the container's rootfs
+        let rootInGuest = URL(filePath: Self.guestRootfsPath(containerID))
+
+        if socket.direction == .into {
+            socket.destination = rootInGuest.appending(path: socket.destination.path)
+        } else {
+            socket.source = rootInGuest.appending(path: socket.source.path)
+        }
+
+        let port = self.hostVsockPorts.wrappingAdd(1, ordering: .relaxed).oldValue
+        try await relayManager.start(port: port, socket: socket)
+        try await relayAgent.relaySocket(port: port, configuration: socket)
+    }
+}
+
+#endif

--- a/Sources/Integration/PodTests.swift
+++ b/Sources/Integration/PodTests.swift
@@ -1,0 +1,732 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Containerization
+import ContainerizationError
+import ContainerizationOCI
+import ContainerizationOS
+import Foundation
+import Logging
+
+extension IntegrationSuite {
+    /// Clone a rootfs mount to a new location for use by a container in a pod
+    private func cloneRootfs(_ rootfs: Containerization.Mount, testID: String, containerID: String) throws -> Containerization.Mount {
+        let clonePath = Self.testDir.appending(component: "\(testID)-\(containerID).ext4").absolutePath()
+        try? FileManager.default.removeItem(atPath: clonePath)
+        return try rootfs.clone(to: clonePath)
+    }
+
+    func testPodSingleContainer() async throws {
+        let id = "test-pod-single-container"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        try await pod.addContainer("container1", rootfs: bs.rootfs) { config in
+            config.process.arguments = ["/bin/true"]
+        }
+
+        try await pod.create()
+        try await pod.startContainer("container1")
+
+        let status = try await pod.waitContainer("container1")
+        try await pod.stop()
+
+        guard status.exitCode == 0 else {
+            throw IntegrationError.assert(msg: "process status \(status) != 0")
+        }
+    }
+
+    func testPodMultipleContainers() async throws {
+        let id = "test-pod-multiple-containers"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        try await pod.addContainer("container1", rootfs: try cloneRootfs(bs.rootfs, testID: id, containerID: "container1")) { config in
+            config.process.arguments = ["/bin/true"]
+        }
+
+        try await pod.addContainer("container2", rootfs: try cloneRootfs(bs.rootfs, testID: id, containerID: "container2")) { config in
+            config.process.arguments = ["/bin/echo", "hello"]
+        }
+
+        try await pod.create()
+
+        try await pod.startContainer("container1")
+        let status1 = try await pod.waitContainer("container1")
+
+        try await pod.startContainer("container2")
+        let status2 = try await pod.waitContainer("container2")
+
+        try await pod.stop()
+
+        guard status1.exitCode == 0 else {
+            throw IntegrationError.assert(msg: "container1 status \(status1) != 0")
+        }
+
+        guard status2.exitCode == 0 else {
+            throw IntegrationError.assert(msg: "container2 status \(status2) != 0")
+        }
+    }
+
+    func testPodContainerOutput() async throws {
+        let id = "test-pod-container-output"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        let buffer = BufferWriter()
+        try await pod.addContainer("container1", rootfs: bs.rootfs) { config in
+            config.process.arguments = ["/bin/echo", "hello from pod"]
+            config.process.stdout = buffer
+        }
+
+        try await pod.create()
+        try await pod.startContainer("container1")
+
+        let status = try await pod.waitContainer("container1")
+        try await pod.stop()
+
+        guard status.exitCode == 0 else {
+            throw IntegrationError.assert(msg: "process status \(status) != 0")
+        }
+
+        guard String(data: buffer.data, encoding: .utf8) == "hello from pod\n" else {
+            throw IntegrationError.assert(
+                msg: "process should have returned on stdout 'hello from pod' != '\(String(data: buffer.data, encoding: .utf8)!)'")
+        }
+    }
+
+    func testPodConcurrentContainers() async throws {
+        let id = "test-pod-concurrent-containers"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        // Add 5 containers
+        for i in 0..<5 {
+            try await pod.addContainer("container\(i)", rootfs: try cloneRootfs(bs.rootfs, testID: id, containerID: "container\(i)")) { config in
+                config.process.arguments = ["/bin/sleep", "1"]
+            }
+        }
+
+        try await pod.create()
+
+        // Start all containers concurrently
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for i in 0..<5 {
+                group.addTask {
+                    try await pod.startContainer("container\(i)")
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        // Wait for all containers concurrently
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for i in 0..<5 {
+                group.addTask {
+                    let status = try await pod.waitContainer("container\(i)")
+                    if status.exitCode != 0 {
+                        throw IntegrationError.assert(msg: "container\(i) status \(status) != 0")
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        try await pod.stop()
+    }
+
+    func testPodExecInContainer() async throws {
+        let id = "test-pod-exec-in-container"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        try await pod.addContainer("container1", rootfs: bs.rootfs) { config in
+            config.process.arguments = ["/bin/sleep", "100"]
+        }
+
+        try await pod.create()
+        try await pod.startContainer("container1")
+
+        let buffer = BufferWriter()
+        let exec = try await pod.execInContainer("container1", processID: "exec1") { config in
+            config.arguments = ["/bin/echo", "exec test"]
+            config.stdout = buffer
+        }
+
+        try await exec.start()
+        let status = try await exec.wait()
+        try await exec.delete()
+
+        try await pod.killContainer("container1", signal: SIGKILL)
+        try await pod.waitContainer("container1")
+        try await pod.stop()
+
+        guard status.exitCode == 0 else {
+            throw IntegrationError.assert(msg: "exec status \(status) != 0")
+        }
+
+        guard String(data: buffer.data, encoding: .utf8) == "exec test\n" else {
+            throw IntegrationError.assert(
+                msg: "exec should have returned 'exec test' != '\(String(data: buffer.data, encoding: .utf8)!)'")
+        }
+    }
+
+    func testPodContainerHostname() async throws {
+        let id = "test-pod-container-hostname"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        let buffer = BufferWriter()
+        try await pod.addContainer("container1", rootfs: bs.rootfs) { config in
+            config.process.arguments = ["/bin/hostname"]
+            config.hostname = "my-pod-container"
+            config.process.stdout = buffer
+        }
+
+        try await pod.create()
+        try await pod.startContainer("container1")
+
+        let status = try await pod.waitContainer("container1")
+        try await pod.stop()
+
+        guard status.exitCode == 0 else {
+            throw IntegrationError.assert(msg: "process status \(status) != 0")
+        }
+
+        guard String(data: buffer.data, encoding: .utf8) == "my-pod-container\n" else {
+            throw IntegrationError.assert(
+                msg: "hostname should be 'my-pod-container' != '\(String(data: buffer.data, encoding: .utf8)!)'")
+        }
+    }
+
+    func testPodPauseResume() async throws {
+        let id = "test-pod-pause-resume"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        try await pod.addContainer("container1", rootfs: bs.rootfs) { config in
+            config.process.arguments = ["/bin/sleep", "infinity"]
+        }
+
+        try await pod.create()
+        try await pod.startContainer("container1")
+
+        // Test pause/resume
+        try await pod.pause()
+        try await Task.sleep(for: .milliseconds(500))
+        try await pod.resume()
+
+        try await pod.killContainer("container1", signal: SIGKILL)
+        try await pod.waitContainer("container1")
+        try await pod.stop()
+    }
+
+    func testPodStopContainerIdempotency() async throws {
+        let id = "test-pod-stop-container-idempotency"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        try await pod.addContainer("container1", rootfs: bs.rootfs) { config in
+            config.process.arguments = ["/bin/true"]
+        }
+
+        try await pod.create()
+        try await pod.startContainer("container1")
+
+        let status = try await pod.waitContainer("container1")
+        guard status.exitCode == 0 else {
+            throw IntegrationError.assert(msg: "process status \(status) != 0")
+        }
+
+        // Stop container twice - should not fail
+        try await pod.stopContainer("container1")
+        try await pod.stopContainer("container1")
+
+        try await pod.stop()
+    }
+
+    func testPodListContainers() async throws {
+        let id = "test-pod-list-containers"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        let containerIDs = ["container1", "container2", "container3"]
+        for containerID in containerIDs {
+            try await pod.addContainer(containerID, rootfs: try cloneRootfs(bs.rootfs, testID: id, containerID: containerID)) { config in
+                config.process.arguments = ["/bin/true"]
+            }
+        }
+
+        let listedContainers = await pod.listContainers()
+
+        guard Set(listedContainers) == Set(containerIDs) else {
+            throw IntegrationError.assert(
+                msg: "listed containers \(listedContainers) != expected \(containerIDs)")
+        }
+
+        try await pod.create()
+        try await pod.stop()
+    }
+
+    func testPodContainerStatistics() async throws {
+        let id = "test-pod-container-statistics"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        try await pod.addContainer("container1", rootfs: try cloneRootfs(bs.rootfs, testID: id, containerID: "container1")) { config in
+            config.process.arguments = ["/bin/sleep", "infinity"]
+        }
+
+        try await pod.addContainer("container2", rootfs: try cloneRootfs(bs.rootfs, testID: id, containerID: "container2")) { config in
+            config.process.arguments = ["/bin/sleep", "infinity"]
+        }
+
+        do {
+            try await pod.create()
+            try await pod.startContainer("container1")
+            try await pod.startContainer("container2")
+
+            let stats = try await pod.statistics()
+
+            guard stats.count == 2 else {
+                throw IntegrationError.assert(msg: "expected 2 container stats, got \(stats.count)")
+            }
+
+            let containerIDs = Set(stats.map { $0.id })
+            guard containerIDs == Set(["container1", "container2"]) else {
+                throw IntegrationError.assert(msg: "unexpected container IDs in stats: \(containerIDs)")
+            }
+
+            for stat in stats {
+                guard stat.process.current > 0 else {
+                    throw IntegrationError.assert(msg: "container \(stat.id) process count should be > 0")
+                }
+
+                guard stat.memory.usageBytes > 0 else {
+                    throw IntegrationError.assert(msg: "container \(stat.id) memory usage should be > 0")
+                }
+
+                print("Container \(stat.id) statistics:")
+                print("  Processes: \(stat.process.current)")
+                print("  Memory: \(stat.memory.usageBytes) bytes")
+                print("  CPU: \(stat.cpu.usageUsec) usec")
+            }
+
+            try await pod.stop()
+        } catch {
+            try? await pod.stop()
+            throw error
+        }
+    }
+
+    func testPodContainerResourceLimits() async throws {
+        let id = "test-pod-container-resource-limits"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        try await pod.addContainer("container1", rootfs: bs.rootfs) { config in
+            config.process.arguments = ["/bin/sleep", "infinity"]
+            config.cpus = 2
+            config.memoryInBytes = 256.mib()
+        }
+
+        do {
+            try await pod.create()
+            try await pod.startContainer("container1")
+
+            // Verify memory limit
+            let memoryBuffer = BufferWriter()
+            let memoryExec = try await pod.execInContainer("container1", processID: "check-memory") { config in
+                config.arguments = ["cat", "/sys/fs/cgroup/memory.max"]
+                config.stdout = memoryBuffer
+            }
+            try await memoryExec.start()
+            var status = try await memoryExec.wait()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "check-memory status \(status) != 0")
+            }
+            try await memoryExec.delete()
+
+            guard let memoryLimit = String(data: memoryBuffer.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+                throw IntegrationError.assert(msg: "failed to parse memory.max")
+            }
+            let expectedMemory = "\(256.mib())"
+            guard memoryLimit == expectedMemory else {
+                throw IntegrationError.assert(msg: "memory.max \(memoryLimit) != expected \(expectedMemory)")
+            }
+
+            // Verify CPU limit
+            let cpuBuffer = BufferWriter()
+            let cpuExec = try await pod.execInContainer("container1", processID: "check-cpu") { config in
+                config.arguments = ["cat", "/sys/fs/cgroup/cpu.max"]
+                config.stdout = cpuBuffer
+            }
+            try await cpuExec.start()
+            status = try await cpuExec.wait()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "check-cpu status \(status) != 0")
+            }
+            try await cpuExec.delete()
+
+            guard let cpuLimit = String(data: cpuBuffer.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+                throw IntegrationError.assert(msg: "failed to parse cpu.max")
+            }
+            let expectedCpu = "200000 100000"  // 2 CPUs: quota=200000, period=100000
+            guard cpuLimit == expectedCpu else {
+                throw IntegrationError.assert(msg: "cpu.max '\(cpuLimit)' != expected '\(expectedCpu)'")
+            }
+
+            try await pod.killContainer("container1", signal: SIGKILL)
+            try await pod.waitContainer("container1")
+            try await pod.stop()
+        } catch {
+            try? await pod.stop()
+            throw error
+        }
+    }
+
+    func testPodContainerFilesystemIsolation() async throws {
+        let id = "test-pod-container-filesystem-isolation"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        try await pod.addContainer("container1", rootfs: try cloneRootfs(bs.rootfs, testID: id, containerID: "container1")) { config in
+            config.process.arguments = ["/bin/sleep", "infinity"]
+        }
+
+        try await pod.addContainer("container2", rootfs: try cloneRootfs(bs.rootfs, testID: id, containerID: "container2")) { config in
+            config.process.arguments = ["/bin/sleep", "infinity"]
+        }
+
+        do {
+            try await pod.create()
+            try await pod.startContainer("container1")
+            try await pod.startContainer("container2")
+
+            // Write a file in container1
+            let writeExec = try await pod.execInContainer("container1", processID: "write-file") { config in
+                config.arguments = ["sh", "-c", "echo 'secret data' > /tmp/container1-secret.txt"]
+            }
+            try await writeExec.start()
+            var status = try await writeExec.wait()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "write-file status \(status) != 0")
+            }
+            try await writeExec.delete()
+
+            // Verify the file exists in container1
+            let readBuffer1 = BufferWriter()
+            let readExec1 = try await pod.execInContainer("container1", processID: "read-file-1") { config in
+                config.arguments = ["cat", "/tmp/container1-secret.txt"]
+                config.stdout = readBuffer1
+            }
+            try await readExec1.start()
+            status = try await readExec1.wait()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "read-file-1 status \(status) != 0")
+            }
+            try await readExec1.delete()
+
+            guard String(data: readBuffer1.data, encoding: .utf8) == "secret data\n" else {
+                throw IntegrationError.assert(msg: "file content in container1 should be 'secret data'")
+            }
+
+            // Try to read the file from container2 - should fail
+            let readExec2 = try await pod.execInContainer("container2", processID: "read-file-2") { config in
+                config.arguments = ["cat", "/tmp/container1-secret.txt"]
+            }
+            try await readExec2.start()
+            status = try await readExec2.wait()
+            try await readExec2.delete()
+
+            // File should NOT exist in container2, so cat should fail
+            guard status.exitCode != 0 else {
+                throw IntegrationError.assert(msg: "file should NOT be accessible from container2")
+            }
+
+            try await pod.stop()
+        } catch {
+            try? await pod.stop()
+            throw error
+        }
+    }
+
+    func testPodContainerPIDNamespaceIsolation() async throws {
+        let id = "test-pod-container-pid-isolation"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        try await pod.addContainer("container1", rootfs: try cloneRootfs(bs.rootfs, testID: id, containerID: "container1")) { config in
+            config.process.arguments = ["/bin/sleep", "infinity"]
+        }
+
+        try await pod.addContainer("container2", rootfs: try cloneRootfs(bs.rootfs, testID: id, containerID: "container2")) { config in
+            config.process.arguments = ["/bin/sleep", "infinity"]
+        }
+
+        do {
+            try await pod.create()
+            try await pod.startContainer("container1")
+            try await pod.startContainer("container2")
+
+            // Start a unique process in container1
+            let sleepExec1 = try await pod.execInContainer("container1", processID: "unique-sleep-1") { config in
+                config.arguments = ["/bin/sleep", "9999"]
+            }
+            try await sleepExec1.start()
+
+            // List processes in container1 - should see sleep 9999
+            let ps1Buffer = BufferWriter()
+            let psExec1 = try await pod.execInContainer("container1", processID: "ps-1") { config in
+                config.arguments = ["ps", "aux"]
+                config.stdout = ps1Buffer
+            }
+            try await psExec1.start()
+            var status = try await psExec1.wait()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "ps-1 status \(status) != 0")
+            }
+            try await psExec1.delete()
+
+            guard let ps1Output = String(data: ps1Buffer.data, encoding: .utf8) else {
+                throw IntegrationError.assert(msg: "failed to parse ps output from container1")
+            }
+
+            // Verify sleep 9999 is visible in container1
+            guard ps1Output.contains("sleep 9999") else {
+                throw IntegrationError.assert(msg: "sleep 9999 should be visible in container1")
+            }
+
+            // List processes in container2 - should NOT see sleep 9999
+            let ps2Buffer = BufferWriter()
+            let psExec2 = try await pod.execInContainer("container2", processID: "ps-2") { config in
+                config.arguments = ["ps", "aux"]
+                config.stdout = ps2Buffer
+            }
+            try await psExec2.start()
+            status = try await psExec2.wait()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "ps-2 status \(status) != 0")
+            }
+            try await psExec2.delete()
+
+            guard let ps2Output = String(data: ps2Buffer.data, encoding: .utf8) else {
+                throw IntegrationError.assert(msg: "failed to parse ps output from container2")
+            }
+
+            // Verify sleep 9999 is NOT visible in container2
+            guard !ps2Output.contains("sleep 9999") else {
+                throw IntegrationError.assert(msg: "sleep 9999 should NOT be visible in container2 (PID namespace isolation failed)")
+            }
+
+            try await sleepExec1.delete()
+            try await pod.stop()
+        } catch {
+            try? await pod.stop()
+            throw error
+        }
+    }
+
+    func testPodContainerIndependentResourceLimits() async throws {
+        let id = "test-pod-container-independent-limits"
+
+        let bs = try await bootstrap(id)
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootlog = bs.bootlog
+        }
+
+        // Container1 with 1 CPU and 128 MiB memory
+        try await pod.addContainer("container1", rootfs: try cloneRootfs(bs.rootfs, testID: id, containerID: "container1")) { config in
+            config.process.arguments = ["/bin/sleep", "infinity"]
+            config.cpus = 1
+            config.memoryInBytes = 128.mib()
+        }
+
+        // Container2 with 2 CPUs and 256 MiB memory
+        try await pod.addContainer("container2", rootfs: try cloneRootfs(bs.rootfs, testID: id, containerID: "container2")) { config in
+            config.process.arguments = ["/bin/sleep", "infinity"]
+            config.cpus = 2
+            config.memoryInBytes = 256.mib()
+        }
+
+        do {
+            try await pod.create()
+            try await pod.startContainer("container1")
+            try await pod.startContainer("container2")
+
+            // Verify container1 memory limit
+            let mem1Buffer = BufferWriter()
+            let memExec1 = try await pod.execInContainer("container1", processID: "check-mem-1") { config in
+                config.arguments = ["cat", "/sys/fs/cgroup/memory.max"]
+                config.stdout = mem1Buffer
+            }
+            try await memExec1.start()
+            var status = try await memExec1.wait()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "check-mem-1 status \(status) != 0")
+            }
+            try await memExec1.delete()
+
+            guard let mem1Limit = String(data: mem1Buffer.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+                throw IntegrationError.assert(msg: "failed to parse memory.max from container1")
+            }
+
+            let expectedMem1 = "\(128.mib())"
+            guard mem1Limit == expectedMem1 else {
+                throw IntegrationError.assert(msg: "container1 memory.max \(mem1Limit) != expected \(expectedMem1)")
+            }
+
+            // Verify container1 CPU limit
+            let cpu1Buffer = BufferWriter()
+            let cpuExec1 = try await pod.execInContainer("container1", processID: "check-cpu-1") { config in
+                config.arguments = ["cat", "/sys/fs/cgroup/cpu.max"]
+                config.stdout = cpu1Buffer
+            }
+            try await cpuExec1.start()
+            status = try await cpuExec1.wait()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "check-cpu-1 status \(status) != 0")
+            }
+            try await cpuExec1.delete()
+
+            guard let cpu1Limit = String(data: cpu1Buffer.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+                throw IntegrationError.assert(msg: "failed to parse cpu.max from container1")
+            }
+
+            let expectedCpu1 = "100000 100000"  // 1 CPU
+            guard cpu1Limit == expectedCpu1 else {
+                throw IntegrationError.assert(msg: "container1 cpu.max '\(cpu1Limit)' != expected '\(expectedCpu1)'")
+            }
+
+            // Verify container2 memory limit
+            let mem2Buffer = BufferWriter()
+            let memExec2 = try await pod.execInContainer("container2", processID: "check-mem-2") { config in
+                config.arguments = ["cat", "/sys/fs/cgroup/memory.max"]
+                config.stdout = mem2Buffer
+            }
+            try await memExec2.start()
+            status = try await memExec2.wait()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "check-mem-2 status \(status) != 0")
+            }
+            try await memExec2.delete()
+
+            guard let mem2Limit = String(data: mem2Buffer.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+                throw IntegrationError.assert(msg: "failed to parse memory.max from container2")
+            }
+
+            let expectedMem2 = "\(256.mib())"
+            guard mem2Limit == expectedMem2 else {
+                throw IntegrationError.assert(msg: "container2 memory.max \(mem2Limit) != expected \(expectedMem2)")
+            }
+
+            // Verify container2 CPU limit
+            let cpu2Buffer = BufferWriter()
+            let cpuExec2 = try await pod.execInContainer("container2", processID: "check-cpu-2") { config in
+                config.arguments = ["cat", "/sys/fs/cgroup/cpu.max"]
+                config.stdout = cpu2Buffer
+            }
+            try await cpuExec2.start()
+            status = try await cpuExec2.wait()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "check-cpu-2 status \(status) != 0")
+            }
+            try await cpuExec2.delete()
+
+            guard let cpu2Limit = String(data: cpu2Buffer.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+                throw IntegrationError.assert(msg: "failed to parse cpu.max from container2")
+            }
+
+            let expectedCpu2 = "200000 100000"  // 2 CPUs
+            guard cpu2Limit == expectedCpu2 else {
+                throw IntegrationError.assert(msg: "container2 cpu.max '\(cpu2Limit)' != expected '\(expectedCpu2)'")
+            }
+
+            try await pod.stop()
+        } catch {
+            try? await pod.stop()
+            throw error
+        }
+    }
+}

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -268,6 +268,7 @@ struct IntegrationSuite: AsyncParsableCommand {
         log.info("starting integration suite\n")
 
         let tests: [Test] = [
+            // Containers
             Test("process true", testProcessTrue),
             Test("process false", testProcessFalse),
             Test("process echo hi", testProcessEchoHi),
@@ -290,6 +291,22 @@ struct IntegrationSuite: AsyncParsableCommand {
             Test("container /dev/console", testContainerDevConsole),
             Test("container statistics", testContainerStatistics),
             Test("container cgroup limits", testCgroupLimits),
+
+            // Pods
+            Test("pod single container", testPodSingleContainer),
+            Test("pod multiple containers", testPodMultipleContainers),
+            Test("pod container output", testPodContainerOutput),
+            Test("pod concurrent containers", testPodConcurrentContainers),
+            Test("pod exec in container", testPodExecInContainer),
+            Test("pod container hostname", testPodContainerHostname),
+            Test("pod pause resume", testPodPauseResume),
+            Test("pod stop container idempotency", testPodStopContainerIdempotency),
+            Test("pod list containers", testPodListContainers),
+            Test("pod container statistics", testPodContainerStatistics),
+            Test("pod container resource limits", testPodContainerResourceLimits),
+            Test("pod container filesystem isolation", testPodContainerFilesystemIsolation),
+            Test("pod container PID namespace isolation", testPodContainerPIDNamespaceIsolation),
+            Test("pod container independent resource limits", testPodContainerIndependentResourceLimits),
         ]
 
         let passed: Atomic<Int> = Atomic(0)


### PR DESCRIPTION
Closes #319

Introduces a new type capable of running > 1 container in the guest. The API mostly follows LinuxContainer, and each individual container can be addressed via any of the methods that require you to pass the containerID as the first param. Today there's no support for namespace sharing, but that shouldn't be terrible to support.