### PR TITLE
LinuxContainer: Add bootlog as configuration field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ ifeq (,$(wildcard bin/vmlinux))
 	@exit 1
 endif
 	@echo Running the integration tests...
-	@./bin/containerization-integration --bootlog ./bin/boot.log
+	@./bin/containerization-integration
 
 .PHONY: fetch-default-kernel
 fetch-default-kernel:

--- a/Sources/Containerization/ContainerManager.swift
+++ b/Sources/Containerization/ContainerManager.swift
@@ -213,7 +213,6 @@ public struct ContainerManager: Sendable {
         self.vmm = VZVirtualMachineManager(
             kernel: kernel,
             initialFilesystem: initfs,
-            bootlog: imageStore.path.appendingPathComponent("bootlog.log").absolutePath(),
             rosetta: rosetta,
             nestedVirtualization: nestedVirtualization
         )
@@ -240,7 +239,6 @@ public struct ContainerManager: Sendable {
         self.vmm = VZVirtualMachineManager(
             kernel: kernel,
             initialFilesystem: initfs,
-            bootlog: imageStore.path.appendingPathComponent("bootlog.log").absolutePath(),
             rosetta: rosetta,
             nestedVirtualization: nestedVirtualization
         )
@@ -282,7 +280,6 @@ public struct ContainerManager: Sendable {
         self.vmm = VZVirtualMachineManager(
             kernel: kernel,
             initialFilesystem: initfs,
-            bootlog: self.imageStore.path.appendingPathComponent("bootlog.log").absolutePath(),
             rosetta: rosetta,
             nestedVirtualization: nestedVirtualization
         )
@@ -327,7 +324,6 @@ public struct ContainerManager: Sendable {
         self.vmm = VZVirtualMachineManager(
             kernel: kernel,
             initialFilesystem: initfs,
-            bootlog: self.imageStore.path.appendingPathComponent("bootlog.log").absolutePath(),
             rosetta: rosetta,
             nestedVirtualization: nestedVirtualization
         )
@@ -421,43 +417,8 @@ public struct ContainerManager: Sendable {
                 config.interfaces = [interface]
                 config.dns = .init(nameservers: [interface.gateway!])
             }
+            config.bootlog = self.containerRoot.appendingPathComponent(id).appendingPathComponent("bootlog.log")
             try configuration(&config)
-        }
-    }
-
-    /// Returns an existing container from the provided image and root filesystem mount.
-    /// - Parameters:
-    ///   - id: The container ID.
-    ///   - image: The image.
-    public mutating func get(
-        _ id: String,
-        image: Image,
-    ) async throws -> LinuxContainer {
-        let path = containerRoot.appendingPathComponent(id)
-        guard FileManager.default.fileExists(atPath: path.absolutePath()) else {
-            throw ContainerizationError(.notFound, message: "\(id) does not exist")
-        }
-
-        let rootfs: Mount = .block(
-            format: "ext4",
-            source: path.appendingPathComponent("rootfs.ext4").absolutePath(),
-            destination: "/",
-            options: []
-        )
-
-        let imageConfig = try await image.config(for: .current).config
-        return try LinuxContainer(
-            id,
-            rootfs: rootfs,
-            vmm: self.vmm
-        ) { config in
-            if let imageConfig {
-                config.process = .init(from: imageConfig)
-            }
-            if let interface = try self.network?.create(id) {
-                config.interfaces = [interface]
-                config.dns = .init(nameservers: [interface.gateway!])
-            }
         }
     }
 

--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -60,6 +60,8 @@ public final class LinuxContainer: Container, Sendable {
         public var hosts: Hosts?
         /// Enable nested virtualization support.
         public var virtualization: Bool = false
+        /// Optional file path to store serial boot logs.
+        public var bootlog: URL?
 
         public init() {}
     }
@@ -306,6 +308,7 @@ extension LinuxContainer {
                 memoryInBytes: self.memoryInBytes,
                 interfaces: self.interfaces,
                 mountsByID: [self.id: [self.rootfs] + self.config.mounts],
+                bootlog: self.config.bootlog,
                 nestedVirtualization: self.config.virtualization
             )
             let creationConfig = StandardVMConfig(configuration: vmConfig)

--- a/Sources/Containerization/VZVirtualMachineManager.swift
+++ b/Sources/Containerization/VZVirtualMachineManager.swift
@@ -24,7 +24,6 @@ import Logging
 public struct VZVirtualMachineManager: VirtualMachineManager {
     private let kernel: Kernel
     private let initialFilesystem: Mount
-    private let bootlog: String?
     private let rosetta: Bool
     private let nestedVirtualization: Bool
     private let logger: Logger?
@@ -32,14 +31,12 @@ public struct VZVirtualMachineManager: VirtualMachineManager {
     public init(
         kernel: Kernel,
         initialFilesystem: Mount,
-        bootlog: String? = nil,
         rosetta: Bool = false,
         nestedVirtualization: Bool = false,
         logger: Logger? = nil
     ) {
         self.kernel = kernel
         self.initialFilesystem = initialFilesystem
-        self.bootlog = bootlog
         self.rosetta = rosetta
         self.nestedVirtualization = nestedVirtualization
         self.logger = logger
@@ -60,12 +57,11 @@ public struct VZVirtualMachineManager: VirtualMachineManager {
                 instanceConfig.kernel = self.kernel
                 instanceConfig.initialFilesystem = self.initialFilesystem
 
-                instanceConfig.interfaces = vmConfig.interfaces
                 if let bootlog = vmConfig.bootlog {
                     instanceConfig.bootlog = bootlog
-                } else if let bootlog = self.bootlog {
-                    instanceConfig.bootlog = URL(filePath: bootlog)
                 }
+
+                instanceConfig.interfaces = vmConfig.interfaces
                 instanceConfig.rosetta = self.rosetta
                 instanceConfig.nestedVirtualization = useNestedVirtualization
 

--- a/Sources/Integration/ContainerTests.swift
+++ b/Sources/Integration/ContainerTests.swift
@@ -30,6 +30,7 @@ extension IntegrationSuite {
         let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/true"]
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -49,6 +50,7 @@ extension IntegrationSuite {
         let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/false"]
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -101,6 +103,7 @@ extension IntegrationSuite {
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/echo", "hi"]
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         do {
@@ -130,6 +133,7 @@ extension IntegrationSuite {
         let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/sleep", "1000"]
+            config.bootlog = bs.bootlog
         }
 
         do {
@@ -172,6 +176,7 @@ extension IntegrationSuite {
         let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/sleep", "1000"]
+            config.bootlog = bs.bootlog
         }
 
         do {
@@ -244,6 +249,7 @@ extension IntegrationSuite {
             config.process.arguments = ["/usr/bin/id"]
             config.process.user = .init(uid: 1, gid: 1, additionalGids: [1])
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -268,6 +274,7 @@ extension IntegrationSuite {
             // Try some uid that doesn't exist. This is supported.
             config.process.user = .init(uid: 40000, gid: 40000)
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -292,6 +299,7 @@ extension IntegrationSuite {
             // Try some uid that doesn't exist. This is supported.
             config.process.user = .init(username: "40000:40000")
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -316,6 +324,7 @@ extension IntegrationSuite {
             // Now for our final trick, try and run a username that doesn't exist.
             config.process.user = .init(username: "thisdoesntexist")
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -337,6 +346,7 @@ extension IntegrationSuite {
             config.process.arguments = ["env"]
             config.process.terminal = true
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -371,6 +381,7 @@ extension IntegrationSuite {
             config.process.arguments = ["env"]
             config.process.user = .init(uid: 0, gid: 0)
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -406,6 +417,7 @@ extension IntegrationSuite {
             config.process.environmentVariables.append(customHomeEnvvar)
             config.process.user = .init(uid: 0, gid: 0)
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -436,6 +448,7 @@ extension IntegrationSuite {
             config.process.arguments = ["/bin/hostname"]
             config.hostname = "foo-bar"
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -465,6 +478,7 @@ extension IntegrationSuite {
             config.process.arguments = ["cat", "/etc/hosts"]
             config.hosts = Hosts(entries: [entry])
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -493,6 +507,7 @@ extension IntegrationSuite {
             config.process.arguments = ["cat"]
             config.process.stdin = StdinBuffer(data: "Hello from test".data(using: .utf8)!)
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -522,6 +537,7 @@ extension IntegrationSuite {
             config.process.arguments = ["/bin/cat", "/mnt/hi.txt"]
             config.mounts.append(.share(source: directory.path, destination: "/mnt"))
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -548,6 +564,7 @@ extension IntegrationSuite {
         let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["sleep", "infinity"]
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -569,6 +586,7 @@ extension IntegrationSuite {
         let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["sleep", "2"]
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -601,6 +619,7 @@ extension IntegrationSuite {
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["ping", "-c", "5", "localhost"]
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -634,6 +653,7 @@ extension IntegrationSuite {
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/true"]
             config.virtualization = true
+            config.bootlog = bs.bootlog
         }
 
         do {
@@ -675,6 +695,7 @@ extension IntegrationSuite {
         ) { config in
             config.process.arguments = ["/bin/echo", "ContainerManager test"]
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         // Start the container
@@ -716,6 +737,7 @@ extension IntegrationSuite {
         ) { config in
             config.process.arguments = ["/bin/echo", "please stop me"]
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         // Start the container
@@ -759,6 +781,7 @@ extension IntegrationSuite {
         ) { config in
             config.process.arguments = ["/bin/echo", "ContainerManager test"]
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         // Start the container
@@ -815,6 +838,7 @@ extension IntegrationSuite {
             config.process.arguments = ["mount"]
             config.process.terminal = true
             config.process.stdout = buffer
+            config.bootlog = bs.bootlog
         }
 
         try await container.create()
@@ -844,6 +868,7 @@ extension IntegrationSuite {
         let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["sleep", "infinity"]
+            config.bootlog = bs.bootlog
         }
 
         do {
@@ -889,6 +914,7 @@ extension IntegrationSuite {
             config.process.arguments = ["sleep", "infinity"]
             config.cpus = 2
             config.memoryInBytes = 512.mib()
+            config.bootlog = bs.bootlog
         }
 
         do {


### PR DESCRIPTION
Closes #227

Previously, the bootlog was supplied once in the constructor to VZVirtualMachineManager which meant that if you used this same manager for multiple ctrs that all logs would end up going to the same file, which becomes quite cumbersome to follow..

This change moves bootlog to be a container configuration param and also moves it to be a VMConfiguration param, so it can be threaded through from LinuxContainer -> vmm.create() and be truly container unique now. The largest driver for this was the integration tests which today every single test spits out logs to a singular file, making guest investigations tricky to actually look into.

Result after:
```
➜  containerization git:(bootlog-per-ctr) ✗ ls -alh bin/bootlogs
total 1520
drwxr-xr-x@ 24 dcantah  staff   768B Oct 22 17:34 .
drwxr-xr-x@  8 dcantah  staff   256B Oct 22 17:34 ..
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-cat-mount.log
-rw-------@  1 dcantah  staff    22K Oct 22 17:34 test-cgroup-limits.log
-rw-------@  1 dcantah  staff   249K Oct 22 17:34 test-concurrent-processes-output-stress.log
-rw-------@  1 dcantah  staff   167K Oct 22 17:34 test-concurrent-processes.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-container-devconsole.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-container-hostname.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-container-hosts-file.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-container-manager.log
-rw-------@  1 dcantah  staff    22K Oct 22 17:34 test-container-reuse.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-container-statistics.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-container-stdin.log
-rw-------@  1 dcantah  staff     0B Oct 22 17:34 test-nested-virt.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-pause-resume-io.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-pause-resume-wait.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-pause-resume.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-process-custom-home-envvar.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-process-echo-hi.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-process-false.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-process-home-envvar.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-process-true.log
-rw-------@  1 dcantah  staff    11K Oct 22 17:34 test-process-tty-envvar.log
-rw-------@  1 dcantah  staff    38K Oct 22 17:34 test-process-user.log
```