### PR TITLE
Always provide a serial console

### DIFF
--- a/Sources/Containerization/VZVirtualMachineInstance.swift
+++ b/Sources/Containerization/VZVirtualMachineInstance.swift
@@ -265,8 +265,12 @@ extension VZVirtualMachineInstance.Configuration {
         config.memorySize = self.memoryInBytes
         config.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
         config.socketDevices = [VZVirtioSocketDeviceConfiguration()]
+
         if let bootlog = self.bootlog {
             config.serialPorts = try serialPort(path: bootlog)
+        } else {
+            // We always supply a serial console. If no explicit path was provided just send em to the void.
+            config.serialPorts = try serialPort(path: URL(filePath: "/dev/null"))
         }
 
         config.networkDevices = try self.interfaces.map {

--- a/Sources/Integration/ContainerTests.swift
+++ b/Sources/Integration/ContainerTests.swift
@@ -999,6 +999,25 @@ extension IntegrationSuite {
         }
     }
 
+    func testNoSerialConsole() async throws {
+        let id = "test-no-serial-console"
+
+        let bs = try await bootstrap(id)
+        let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
+            config.process.arguments = ["/bin/true"]
+        }
+
+        try await container.create()
+        try await container.start()
+
+        let status = try await container.wait()
+        try await container.stop()
+
+        guard status.exitCode == 0 else {
+            throw IntegrationError.assert(msg: "process status \(status) != 0")
+        }
+    }
+
     private func createMountDirectory() throws -> URL {
         let dir = FileManager.default.uniqueTemporaryDirectory(create: true)
         try "hello".write(to: dir.appendingPathComponent("hi.txt"), atomically: true, encoding: .utf8)

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -291,6 +291,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             Test("container /dev/console", testContainerDevConsole),
             Test("container statistics", testContainerStatistics),
             Test("container cgroup limits", testCgroupLimits),
+            Test("container no serial console", testNoSerialConsole),
 
             // Pods
             Test("pod single container", testPodSingleContainer),


### PR DESCRIPTION
Just send them to /dev/null otherwise. We by default ask for hvc0 as /dev/console and it'd be a bit to untangle things, so we can just write to /dev/null if no bootlog was provided.