### PR TITLE
Throw an error in `StandardIO.resize()`

### DIFF
--- a/vminitd/Sources/vminitd/StandardIO.swift
+++ b/vminitd/Sources/vminitd/StandardIO.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerizationError
 import ContainerizationOS
 import Foundation
 import Logging


### PR DESCRIPTION
Throw an error in `StandardIO.resize()`, which is unsupported.