### PR TITLE
Only load epoll file if we can import musl

### DIFF
--- a/Sources/ContainerizationOS/Linux/Epoll.swift
+++ b/Sources/ContainerizationOS/Linux/Epoll.swift
@@ -14,15 +14,8 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
-
 #if canImport(Musl)
 import Musl
-#elseif canImport(Glibc)
-import Glibc
-#else
-#error("Epoll not supported on this platform")
-#endif
 
 import Foundation
 import Synchronization
@@ -181,4 +174,4 @@ extension Epoll.Mask {
     }
 }
 
-#endif  // os(Linux)
+#endif  // canImport(Musl)


### PR DESCRIPTION
This class does not work for glibc due to missing flags and methods. This PR removes the ability to load the `Epoll` class when using glibc for now. 