### PR TITLE
VirtualMachineManager: Take in EventLoopGroup directly

### DIFF
--- a/Sources/Containerization/VZVirtualMachineManager.swift
+++ b/Sources/Containerization/VZVirtualMachineManager.swift
@@ -19,6 +19,7 @@ import ContainerizationError
 import ContainerizationOCI
 import Foundation
 import Logging
+import NIOCore
 
 /// A virtualization.framework backed `VirtualMachineManager` implementation.
 public struct VZVirtualMachineManager: VirtualMachineManager {
@@ -26,6 +27,7 @@ public struct VZVirtualMachineManager: VirtualMachineManager {
     private let initialFilesystem: Mount
     private let rosetta: Bool
     private let nestedVirtualization: Bool
+    private let group: EventLoopGroup?
     private let logger: Logger?
 
     public init(
@@ -33,12 +35,14 @@ public struct VZVirtualMachineManager: VirtualMachineManager {
         initialFilesystem: Mount,
         rosetta: Bool = false,
         nestedVirtualization: Bool = false,
+        group: EventLoopGroup? = nil,
         logger: Logger? = nil
     ) {
         self.kernel = kernel
         self.initialFilesystem = initialFilesystem
         self.rosetta = rosetta
         self.nestedVirtualization = nestedVirtualization
+        self.group = group
         self.logger = logger
     }
 
@@ -49,6 +53,7 @@ public struct VZVirtualMachineManager: VirtualMachineManager {
         let useNestedVirtualization = vmConfig.nestedVirtualization || self.nestedVirtualization
 
         return try VZVirtualMachineInstance(
+            group: self.group,
             logger: self.logger,
             with: { instanceConfig in
                 instanceConfig.cpus = vmConfig.cpus

--- a/Sources/Containerization/Vminitd.swift
+++ b/Sources/Containerization/Vminitd.swift
@@ -19,6 +19,7 @@ import ContainerizationOCI
 import ContainerizationOS
 import Foundation
 import GRPC
+import NIOCore
 import NIOPosix
 
 /// A remote connection into the vminitd Linux guest agent via a port (vsock).
@@ -35,7 +36,7 @@ public struct Vminitd: Sendable {
         self.client = client
     }
 
-    public init(connection: FileHandle, group: MultiThreadedEventLoopGroup) {
+    public init(connection: FileHandle, group: EventLoopGroup) {
         self.client = .init(connection: connection, group: group)
     }
 
@@ -450,7 +451,7 @@ extension Hosts {
 }
 
 extension Vminitd.Client {
-    public init(socket: String, group: MultiThreadedEventLoopGroup) {
+    public init(socket: String, group: EventLoopGroup) {
         var config = ClientConnection.Configuration.default(
             target: .unixDomainSocket(socket),
             eventLoopGroup: group
@@ -461,7 +462,7 @@ extension Vminitd.Client {
         self = .init(channel: ClientConnection(configuration: config))
     }
 
-    public init(connection: FileHandle, group: MultiThreadedEventLoopGroup) {
+    public init(connection: FileHandle, group: EventLoopGroup) {
         var config = ClientConnection.Configuration.default(
             target: .connectedSocket(connection.fileDescriptor),
             eventLoopGroup: group

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -23,6 +23,7 @@ import ContainerizationOS
 import Foundation
 import Logging
 import NIOCore
+import NIOPosix
 import Synchronization
 
 actor UnpackCoordinator {
@@ -159,6 +160,8 @@ struct IntegrationSuite: AsyncParsableCommand {
             .appendingPathComponent(name)
     }
 
+    static let eventLoop = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+
     func bootstrap(_ testID: String) async throws -> (rootfs: Containerization.Mount, vmm: VirtualMachineManager, image: Containerization.Image, bootlog: URL) {
         let reference = "ghcr.io/linuxcontainers/alpine:3.20"
         let store = Self.imageStore
@@ -221,6 +224,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             VZVirtualMachineManager(
                 kernel: testKernel,
                 initialFilesystem: initfs,
+                group: Self.eventLoop
             ),
             image,
             bootlogURL


### PR DESCRIPTION
We should allow passing in an event loop instead of always creating one for every VM. It seems a bit crazy we were starting a thread pool for every VM. I noticed this when running the integration tests and saw 100+ NIO threads..

This change uses the new functionality to reuse one event loop for all of the integration tests.