### PR TITLE
Make `pid` an optional

### DIFF
--- a/vminitd/Sources/vminitd/ManagedContainer.swift
+++ b/vminitd/Sources/vminitd/ManagedContainer.swift
@@ -30,7 +30,7 @@ actor ManagedContainer {
     private let bundle: ContainerizationOCI.Bundle
     private var execs: [String: ManagedProcess] = [:]
 
-    var pid: Int32 {
+    var pid: Int32? {
         self.initProcess.pid
     }
 

--- a/vminitd/Sources/vminitd/ProcessSupervisor.swift
+++ b/vminitd/Sources/vminitd/ProcessSupervisor.swift
@@ -80,8 +80,7 @@ actor ProcessSupervisor {
         }
 
         for proc in exitedProcesses {
-            let pid = proc.pid
-            if pid <= 0 {
+            guard let pid = proc.pid else {
                 continue
             }
 


### PR DESCRIPTION
Makes `pid` an optional to avoid killing the process with pid 0.