### PR TITLE
Chore: Use guestVsockPorts

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -678,13 +678,15 @@ extension LinuxContainer {
         var socket = socket
         let rootInGuest = URL(filePath: self.root)
 
+        let port: UInt32
         if socket.direction == .into {
+            port = self.hostVsockPorts.wrappingAdd(1, ordering: .relaxed).oldValue
             socket.destination = rootInGuest.appending(path: socket.destination.path)
         } else {
+            port = self.guestVsockPorts.wrappingAdd(1, ordering: .relaxed).oldValue
             socket.source = rootInGuest.appending(path: socket.source.path)
         }
 
-        let port = self.hostVsockPorts.wrappingAdd(1, ordering: .relaxed).oldValue
         try await relayManager.start(port: port, socket: socket)
         try await relayAgent.relaySocket(port: port, configuration: socket)
     }

--- a/Sources/Containerization/LinuxPod.swift
+++ b/Sources/Containerization/LinuxPod.swift
@@ -705,13 +705,15 @@ extension LinuxPod {
         // Adjust paths to be relative to the container's rootfs
         let rootInGuest = URL(filePath: Self.guestRootfsPath(containerID))
 
+        let port: UInt32
         if socket.direction == .into {
+            port = self.hostVsockPorts.wrappingAdd(1, ordering: .relaxed).oldValue
             socket.destination = rootInGuest.appending(path: socket.destination.path)
         } else {
+            port = self.guestVsockPorts.wrappingAdd(1, ordering: .relaxed).oldValue
             socket.source = rootInGuest.appending(path: socket.source.path)
         }
 
-        let port = self.hostVsockPorts.wrappingAdd(1, ordering: .relaxed).oldValue
         try await relayManager.start(port: port, socket: socket)
         try await relayAgent.relaySocket(port: port, configuration: socket)
     }


### PR DESCRIPTION
This was a funny oversight. We have two port spaces, one for listening sockets on the host, and one for vsock proxies in the guest, but only the host "allocator" was being used. This didn't really matter as the ports in the guest would still be unique, but would still be good to fix.