### PR TITLE
EXT4: Optimize unpack

### DIFF
--- a/Sources/cctl/ImageCommand.swift
+++ b/Sources/cctl/ImageCommand.swift
@@ -123,6 +123,7 @@ extension Application {
                     print("Reference resolved to \(reference.description)")
                 }
 
+                var startTime = ContinuousClock.now
                 let image = try await Images.withAuthentication(ref: normalizedReference) { auth in
                     try await imageStore.pull(reference: normalizedReference, platform: platform, insecure: http, auth: auth)
                 }
@@ -132,7 +133,9 @@ extension Application {
                     Application.exit(withError: POSIXError(.EACCES))
                 }
 
-                print("image pulled")
+                var duration = ContinuousClock.now - startTime
+                print("Image pull took: \(duration)\n")
+
                 guard let unpackPath else {
                     return
                 }
@@ -144,6 +147,7 @@ extension Application {
 
                 let unpacker = EXT4Unpacker.init(blockSizeInBytes: 2.gib())
 
+                startTime = ContinuousClock.now
                 if let platform {
                     let name = platform.description.replacingOccurrences(of: "/", with: "-")
                     let _ = try await unpacker.unpack(image, for: platform, at: unpackUrl.appending(component: name))
@@ -160,6 +164,8 @@ extension Application {
                         print("created snapshot for platform \(descPlatform.description)")
                     }
                 }
+                duration = ContinuousClock.now - startTime
+                print("\nUnpacking took: \(duration)")
             }
         }
 


### PR DESCRIPTION
Optimize unpack a little by trying to reduce allocations in the hot path. Today for every file we read the entire file into memory and then pass the data blob to the ext4 writer to eventually be written to the sparse file. Before being written to the sparse file the data is copied *again* to a temp buffer before finally hitting write(2) in FileHandle.

This change moves things around such that we can pass an optional buffer to the ext4 create() (so we can reuse a buffer for file writes), as well as stops reading entire files into memory by passing the archive entry itself (wrapped in a ReaderStream object albeit) down to the writer.

Testing with unpacking every platform for `docker.io/jenkins/jenkins:lts` on an M1 Max:

Old Avg (5 runs): 7.43s
New Avg (5 runs): 5.31s