### PR TITLE
VsockConnectionStream: Conform to AsyncSequence

### DIFF
--- a/Sources/Containerization/UnixSocketRelay.swift
+++ b/Sources/Containerization/UnixSocketRelay.swift
@@ -201,7 +201,7 @@ extension SocketRelay {
             $0.t = Task {
                 do {
                     defer { connectionStream.finish() }
-                    for await connection in connectionStream.connections {
+                    for await connection in connectionStream {
                         try await self.handleGuestVsockConn(
                             vsockConn: connection,
                             hostConnectionPath: hostPath,


### PR DESCRIPTION
I didn't like how we expose the asyncstream via a public connections field. We should have the type conform to AsyncSequence and then hide the underlying stream. This also stops listening on the stdio ports after we get the initial connection.