### PR TITLE
Don't ignore possible errors from dup(2)

### DIFF
--- a/Sources/Containerization/VZVirtualMachine+Helpers.swift
+++ b/Sources/Containerization/VZVirtualMachine+Helpers.swift
@@ -139,8 +139,11 @@ extension VZVirtualMachine {
 }
 
 extension VZVirtioSocketConnection {
-    func dupHandle() -> FileHandle {
+    func dupHandle() throws -> FileHandle {
         let fd = dup(self.fileDescriptor)
+        if fd == -1 {
+            throw POSIXError.fromErrno()
+        }
         self.close()
         return FileHandle(fileDescriptor: fd, closeOnDealloc: false)
     }


### PR DESCRIPTION
Everytime we grab a vsock connection we dup the conn and close the original, otherwise we'd need to carry around the vsock connection type everywhere as it closes the fd in its destructor. We weren't checking the return value of dup however, so if it did fail we'd have a useless filehandle with an fd of -1.