### PR TITLE
Integration: Add stdio ingest test

### DIFF
--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -295,6 +295,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             Test("container no serial console", testNoSerialConsole),
             Test("unix socket into guest", testUnixSocketIntoGuest),
             Test("container non-closure constructor", testNonClosureConstructor),
+            Test("container test large stdio ingest", testLargeStdioOutput),
 
             // Pods
             Test("pod single container", testPodSingleContainer),


### PR DESCRIPTION
Add a test to ingest 200MiB of data across stdout/stderr. Useful to test how fast we can ingest stdio. The timing will always be a tad off as it times between start and wait returning, and there's quite a lot in the way.. but it's a good enough metric.