### PR TITLE
Updating ctr-example to make setup easier

### DIFF
--- a/examples/ctr-example/Makefile
+++ b/examples/ctr-example/Makefile
@@ -18,7 +18,7 @@ SWIFT = /usr/bin/swift
 
 .PHONY: all build clean run
 
-all: build
+all: containerization run
 
 build:
 	$(SWIFT) build --configuration release
@@ -39,3 +39,10 @@ debug:
 
 fmt:
 	$(SWIFT) format --in-place --recursive Sources/
+
+containerization: 
+	$(MAKE) -C ../.. all
+
+fetch-default-kernel:
+	$(MAKE) -C ../.. fetch-default-kernel
+	cp -L ../../.local/vmlinux ./vmlinux

--- a/examples/ctr-example/README.md
+++ b/examples/ctr-example/README.md
@@ -1,3 +1,32 @@
-# 
+# Container Example
 
 Very basic example of launching a Linux container using Containerization.
+
+---
+## Build and Run
+
+### 1. Fetch Kernel
+
+In your terminal, change directories to examples/ctr-example and run
+`make fetch-default-kernel`
+
+You should now see the `vmlinux` image in examples/ctr-example
+
+### 2. Build/Run ctr-example
+
+From examples/ctr-example run
+`make all`
+
+> [!NOTE]
+> If you get the following error, try building from the default MacOS terminal:
+> `error: compiled module was created by a newer version of the compiler`
+
+After the build completes, the example will run. In your terminal you should see
+`Starting container example...`
+`Creating container from docker.io/library/alpine:3.16...`
+`Starting container...`
+`/ #`
+
+**Congratulations, you've started the example container!**
+
+---


### PR DESCRIPTION
- Example Makefile now supports fetch-default-kernel for easier setup
- added 'make all' to build Containerization and ctr-example in one step
- Updated README to add build and run instructions