### PR TITLE
Update ctr-example to 0.13.0 and clean readme

### DIFF
--- a/examples/ctr-example/Package.resolved
+++ b/examples/ctr-example/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cd7ac494fe7fa2a2cfce363b22465655c22b89b79250dab0a17e78fd6778e0a8",
+  "originHash" : "7a034ba9a7869752d94fd5d485de152deef7a29ebf636116693f03ab723806b0",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "254d34096123cd5da4f82e69f52f622ac7526d68",
         "version" : "1.27.0"
-      }
-    },
-    {
-      "identity" : "containerization",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/containerization.git",
-      "state" : {
-        "revision" : "3d7bb7bb5c3b3574fd47d20a97e96309f70122fb",
-        "version" : "0.12.0"
       }
     },
     {

--- a/examples/ctr-example/Package.swift
+++ b/examples/ctr-example/Package.swift
@@ -17,7 +17,7 @@
 
 import PackageDescription
 
-let scVersion = "0.12.0"
+let scVersion = "0.13.0"
 
 let package = Package(
     name: "ctr-example",

--- a/examples/ctr-example/README.md
+++ b/examples/ctr-example/README.md
@@ -2,7 +2,6 @@
 
 Very basic example of launching a Linux container using Containerization.
 
----
 ## Build and Run
 
 ### 1. Fetch Kernel
@@ -17,16 +16,17 @@ You should now see the `vmlinux` image in examples/ctr-example
 From examples/ctr-example run
 `make all`
 
-> [!NOTE]
-> If you get the following error, try building from the default MacOS terminal:
+> [!WARNING]
+> If you get the following error, try building from the default macOS terminal:
 > `error: compiled module was created by a newer version of the compiler`
 
-After the build completes, the example will run. In your terminal you should see
-`Starting container example...`
-`Creating container from docker.io/library/alpine:3.16...`
-`Starting container...`
-`/ #`
+After the build completes, the example will run. In your terminal you should see something like:
+
+```
+Starting container example...
+Creating container from docker.io/library/alpine:3.16...
+Starting container...
+/ #
+```
 
 **Congratulations, you've started the example container!**
-
----


### PR DESCRIPTION
Update containerization dependency in ctr-example to the latest tag of containerization. Additionally make README for ctr-example more clear. 