### PR TITLE
Socket: Return Int32 and not FileHandle for uds receives

### DIFF
--- a/Sources/ContainerizationOS/Socket/Socket.swift
+++ b/Sources/ContainerizationOS/Socket/Socket.swift
@@ -306,7 +306,7 @@ extension Socket {
 
     /// Receive a file descriptor via SCM_RIGHTS control message.
     /// This is commonly used for passing file descriptors between processes via Unix domain sockets.
-    public func receiveFileDescriptor() throws -> FileHandle {
+    public func receiveFileDescriptor() throws -> Int32 {
         let handle = try state.withLock { currentState in
             guard currentState.socketState == .connected else {
                 throw SocketError.invalidOperationOnSocket("receiveFileDescriptor")
@@ -361,7 +361,7 @@ extension Socket {
             throw SocketError.invalidFileDescriptor
         }
 
-        return FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+        return fd
     }
 
     public func read(buffer: inout Data) throws -> Int {

--- a/Tests/ContainerizationOSTests/SocketTests.swift
+++ b/Tests/ContainerizationOSTests/SocketTests.swift
@@ -106,7 +106,8 @@ final class SocketTests {
         let originalFD = testFileHandle.fileDescriptor
 
         try sendFileDescriptor(socket: sendSocket, fd: originalFD)
-        let receivedFileHandle = try recvSocket.receiveFileDescriptor()
+        let receivedFd = try recvSocket.receiveFileDescriptor()
+        let receivedFileHandle = FileHandle(fileDescriptor: receivedFd)
         defer { try? receivedFileHandle.close() }
 
         try #require(receivedFileHandle.fileDescriptor != originalFD, "Received FD should be different")

--- a/vminitd/Sources/vminitd/Runc/ConsoleSocket.swift
+++ b/vminitd/Sources/vminitd/Runc/ConsoleSocket.swift
@@ -65,7 +65,7 @@ public final class ConsoleSocket: Sendable {
     }
 
     /// Receive the PTY master file descriptor from runc
-    public func receiveMaster() throws -> FileHandle {
+    public func receiveMaster() throws -> Int32 {
         let connection = try socket.accept()
         defer { try? connection.close() }
 


### PR DESCRIPTION
Gives more flexibility. The caller doesn't need to carry around this FileHandle object if they don't really need it.