### PR TITLE
Vminitd: Sync(2) on shutdown

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -563,6 +563,8 @@ extension LinuxContainer {
                         path: Self.guestRootfsPath(self.id),
                         flags: 0
                     )
+
+                    try await agent.sync()
                 }
 
                 // Lets free up the init procs resources, as this includes the open agent conn.

--- a/Sources/Containerization/VirtualMachineAgent.swift
+++ b/Sources/Containerization/VirtualMachineAgent.swift
@@ -42,6 +42,7 @@ public protocol VirtualMachineAgent: Sendable {
     func mkdir(path: String, all: Bool, perms: UInt32) async throws
     @discardableResult
     func kill(pid: Int32, signal: Int32) async throws -> Int32
+    func sync() async throws
     func writeFile(path: String, data: Data, flags: WriteFileFlags, mode: UInt32) async throws
 
     // Process lifecycle
@@ -88,5 +89,9 @@ extension VirtualMachineAgent {
 
     public func containerStatistics(containerIDs: [String]) async throws -> [ContainerStatistics] {
         throw ContainerizationError(.unsupported, message: "containerStatistics")
+    }
+
+    public func sync() async throws {
+        throw ContainerizationError(.unsupported, message: "sync")
     }
 }

--- a/vminitd/Sources/vminitd/Application.swift
+++ b/vminitd/Sources/vminitd/Application.swift
@@ -114,7 +114,11 @@ struct Application {
         do {
             log.info("serving vminitd API")
             try await server.serve(port: vsockPort)
-            log.info("vminitd API returned")
+            log.info("vminitd API returned, syncing filesystems")
+
+            #if os(Linux)
+            Musl.sync()
+            #endif
         } catch {
             log.error("vminitd boot error \(error)")
             exit(1)


### PR DESCRIPTION
We should definitely be doing this to flush writes before terminating the guest.