### PR TITLE
Make socket proxy logging less chatty.

### DIFF
--- a/vminitd/Sources/vminitd/VsockProxy.swift
+++ b/vminitd/Sources/vminitd/VsockProxy.swift
@@ -268,7 +268,7 @@ extension VsockProxy {
                         // and no more EPOLLOUT events on the server fd
                         eofFromClient = true
                         if shutdown(serverFile.fileDescriptor, SHUT_WR) != 0 {
-                            self.log?.info(
+                            self.log?.warning(
                                 "failed to shut down client reads",
                                 metadata: [
                                     "vport": "\(self.port)",
@@ -320,7 +320,7 @@ extension VsockProxy {
                         // and no more EPOLLOUT events on the client fd
                         eofFromServer = true
                         if shutdown(clientFile.fileDescriptor, SHUT_WR) != 0 {
-                            self.log?.info(
+                            self.log?.warning(
                                 "failed to shut down server reads",
                                 metadata: [
                                     "vport": "\(self.port)",
@@ -353,7 +353,7 @@ extension VsockProxy {
     ) -> (Bool, Bool) {
         do {
             let (readBytes, writeBytes, action) = try OSFile.splice(from: &fromFile, to: &toFile)
-            log?.debug(
+            log?.trace(
                 "transferred data",
                 metadata: [
                     "description": "\(description)",
@@ -369,7 +369,7 @@ extension VsockProxy {
                 // we should see no more EPOLLIN events on the client fd
                 // and no more EPOLLOUT events on the server fd
                 if shutdown(toFile.fileDescriptor, SHUT_WR) != 0 {
-                    log?.info(
+                    log?.warning(
                         "failed to shut down reads",
                         metadata: [
                             "description": "\(description)",


### PR DESCRIPTION
- Move data transfers to trace level.
- Move shutdown errors to warning.
- Only log listen, connect, and cleanup at info.