### PR TITLE
LinuxContainer: Keep reference to vended execs

### DIFF
--- a/Sources/Containerization/LinuxProcess.swift
+++ b/Sources/Containerization/LinuxProcess.swift
@@ -77,6 +77,7 @@ public final class LinuxProcess: Sendable {
         var stdio: StdioHandles
         var stdinRelay: Task<(), Never>?
         var ioTracker: IoTracker?
+        var deletionTask: Task<Void, Error>?
 
         struct IoTracker {
             let stream: AsyncStream<Void>
@@ -96,6 +97,7 @@ public final class LinuxProcess: Sendable {
     private let agent: any VirtualMachineAgent
     private let vm: any VirtualMachineInstance
     private let logger: Logger?
+    private let onDelete: (@Sendable () async -> Void)?
 
     init(
         _ id: String,
@@ -104,7 +106,8 @@ public final class LinuxProcess: Sendable {
         io: Stdio,
         agent: any VirtualMachineAgent,
         vm: any VirtualMachineInstance,
-        logger: Logger?
+        logger: Logger?,
+        onDelete: (@Sendable () async -> Void)? = nil
     ) {
         self.id = id
         self.owningContainer = containerID
@@ -113,6 +116,7 @@ public final class LinuxProcess: Sendable {
         self.agent = agent
         self.vm = vm
         self.logger = logger
+        self.onDelete = onDelete
     }
 }
 
@@ -393,6 +397,28 @@ extension LinuxProcess {
 
     /// Cleans up guest state and waits on and closes any host resources (stdio handles).
     public func delete() async throws {
+        try await self._delete()
+        await self.onDelete?()
+    }
+
+    func _delete() async throws {
+        let task = self.state.withLock { state in
+            if let existingTask = state.deletionTask {
+                // Deletion already in progress or finished.
+                return existingTask
+            }
+
+            let task = Task<Void, Error> {
+                try await self.performDeletion()
+            }
+            state.deletionTask = task
+            return task
+        }
+
+        try await task.value
+    }
+
+    private func performDeletion() async throws {
         do {
             try await self.agent.deleteProcess(
                 id: self.id,

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -296,6 +296,8 @@ struct IntegrationSuite: AsyncParsableCommand {
             Test("unix socket into guest", testUnixSocketIntoGuest),
             Test("container non-closure constructor", testNonClosureConstructor),
             Test("container test large stdio ingest", testLargeStdioOutput),
+            Test("process delete idempotency", testProcessDeleteIdempotency),
+            Test("multiple execs without delete", testMultipleExecsWithoutDelete),
 
             // Pods
             Test("pod single container", testPodSingleContainer),


### PR DESCRIPTION
This change is aimed at making forgetting to call .delete() on a LinuxProcess less destructive than it can be. Because Virt.framework invalidates any vsock fds it vended if the vm is stopped, trying to perform some operations on the grpc client through any of the process methods could trigger an ebadf, which NIO asserts on. This keeps a reference to the execs and deletes all of them for you once the container dies. I still think leaving .delete a public method is useful as otherwise the stdio fds are left open, but cleanup should occur all in one place now if you don't care about this.

This additionally:

1. Fixes two of our tests that forgot to delete() an exec.
2. Adds two new tests to verify that process.delete() is now idempotent, and we don't need to call delete().