### PR TITLE
Fix compiler errors in socket types when building with glibc

### DIFF
--- a/Sources/Containerization/UnixSocketRelay.swift
+++ b/Sources/Containerization/UnixSocketRelay.swift
@@ -397,7 +397,7 @@ extension SocketRelay {
                         "dstFd": "\(destinationFd)",
                     ])
                 source.cancel()
-                if shutdown(destinationFd, SHUT_WR) != 0 {
+                if shutdown(destinationFd, Int32(SHUT_WR)) != 0 {
                     log?.warning(
                         "failed to shut down reads",
                         metadata: [
@@ -429,7 +429,7 @@ extension SocketRelay {
             log?.error("file descriptor copy failed \(error)")
             if !source.isCancelled {
                 source.cancel()
-                if shutdown(destinationFd, SHUT_RDWR) != 0 {
+                if shutdown(destinationFd, Int32(SHUT_RDWR)) != 0 {
                     log?.warning(
                         "failed to shut down destination after I/O error",
                         metadata: [

--- a/Sources/ContainerizationOS/Socket/Socket.swift
+++ b/Sources/ContainerizationOS/Socket/Socket.swift
@@ -329,7 +329,12 @@ extension Socket {
 
         var cmsgBuf = [UInt8](repeating: 0, count: Int(CZ_CMSG_SPACE(Int(MemoryLayout<Int32>.size))))
         msg.msg_control = withUnsafeMutablePointer(to: &cmsgBuf[0]) { UnsafeMutableRawPointer($0) }
+
+        #if canImport(Glibc)
+        msg.msg_controllen = size_t(cmsgBuf.count)
+        #else
         msg.msg_controllen = socklen_t(cmsgBuf.count)
+        #endif
 
         let recvResult = withUnsafeMutablePointer(to: &msg) { msgPtr in
             sysRecvmsg(handle.fileDescriptor, msgPtr, 0)


### PR DESCRIPTION
* on glibc, swift expects that the msg_controllen is type Int
* on glibc, socket shutdown options should be an Int32