### PR TITLE
vminitd client: Remove connection backoff

### DIFF
--- a/Sources/Containerization/Vminitd.swift
+++ b/Sources/Containerization/Vminitd.swift
@@ -438,25 +438,13 @@ extension Hosts {
 }
 
 extension Vminitd.Client {
-    public init(socket: String, group: EventLoopGroup) {
-        var config = ClientConnection.Configuration.default(
-            target: .unixDomainSocket(socket),
-            eventLoopGroup: group
-        )
-        config.maximumReceiveMessageLength = Int(64.mib())
-        config.connectionBackoff = ConnectionBackoff(retries: .upTo(5))
-
-        self = .init(channel: ClientConnection(configuration: config))
-    }
-
     public init(connection: FileHandle, group: EventLoopGroup) {
         var config = ClientConnection.Configuration.default(
             target: .connectedSocket(connection.fileDescriptor),
             eventLoopGroup: group
         )
+        config.connectionBackoff = nil
         config.maximumReceiveMessageLength = Int(64.mib())
-        config.connectionBackoff = ConnectionBackoff(retries: .upTo(5))
-
         self = .init(channel: ClientConnection(configuration: config))
     }
 


### PR DESCRIPTION
For the constructor we're using where we pass an already connected socket, I'm not sure this even does anything, and if it does that's a bug I'd rather just avoid altogether.

Also gets rid of the unused constructor we have to pass in a UDS.