### PR TITLE
LinuxPod: Wire up pid namespace sharing

### DIFF
--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -315,6 +315,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             Test("pod container filesystem isolation", testPodContainerFilesystemIsolation),
             Test("pod container PID namespace isolation", testPodContainerPIDNamespaceIsolation),
             Test("pod container independent resource limits", testPodContainerIndependentResourceLimits),
+            Test("pod shared PID namespace", testPodSharedPIDNamespace),
         ]
 
         let passed: Atomic<Int> = Atomic(0)

--- a/vminitd/Sources/vminitd/Server+GRPC.swift
+++ b/vminitd/Sources/vminitd/Server+GRPC.swift
@@ -428,7 +428,6 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContextAsyncProvid
                 "stdin": "Port: \(request.stdin)",
                 "stdout": "Port: \(request.stdout)",
                 "stderr": "Port: \(request.stderr)",
-                "configuration": "\(request.configuration.count)",
             ])
 
         if !request.hasContainerID {


### PR DESCRIPTION
In a prior change I'd added a way for vminitd to double as a simple pause container. This change wires this up by adding a new bool to the pod config to ask for pid ns sharing.