### PR TITLE
EXT4: Remove advertising inline data

### DIFF
--- a/Sources/ContainerizationEXT4/EXT4+Formatter.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Formatter.swift
@@ -441,7 +441,6 @@ extension EXT4 {
                         buffer[89],
                         buffer[90], buffer[91], buffer[92], buffer[93], buffer[94], buffer[95]
                     )
-                    childInode.flags |= InodeFlag.inlineData.rawValue
                 }
                 if !state.blockAttributes.isEmpty {
                     var buffer: [UInt8] = .init(repeating: 0, count: Int(blockSize))
@@ -902,7 +901,7 @@ extension EXT4 {
             superblock.inodeSize = UInt16(EXT4.InodeSize)
             superblock.featureCompat = CompatFeature.sparseSuper2 | CompatFeature.extAttr
             superblock.featureIncompat =
-                IncompatFeature.filetype | IncompatFeature.extents | IncompatFeature.flexBg | IncompatFeature.inlineData
+                IncompatFeature.filetype | IncompatFeature.extents | IncompatFeature.flexBg
             superblock.featureRoCompat =
                 RoCompatFeature.largeFile | RoCompatFeature.hugeFile | RoCompatFeature.extraIsize
             superblock.minExtraIsize = EXT4.ExtraIsize


### PR DESCRIPTION
We've seen issues arising from us advertising inlinedata on our inodes. It doesn't seem like we actually do support this at all, I think it was a mistake in mixing up inline xattrs and data. So, stop advertising this feature on the superblock, and stop setting the flag on inodes.