### PR TITLE
Cgroup2Manager: Fix cgroup deletions

### DIFF
--- a/vminitd/Sources/vminitd/ManagedContainer.swift
+++ b/vminitd/Sources/vminitd/ManagedContainer.swift
@@ -110,6 +110,45 @@ actor ManagedContainer {
 }
 
 extension ManagedContainer {
+    // removeCgroupWithRetry will remove a cgroup path handling EAGAIN and EBUSY errors and
+    // retrying the remove after an exponential timeout
+    private func removeCgroupWithRetry() async throws {
+        var delay = 10  // 10ms
+        let maxRetries = 5
+
+        for i in 0..<maxRetries {
+            if i != 0 {
+                try await Task.sleep(for: .milliseconds(delay))
+                delay *= 2
+            }
+
+            do {
+                try self.cgroupManager.delete(force: true)
+                return
+            } catch let error as Cgroup2Manager.Error {
+                guard case .errno(let errnoValue, let message) = error,
+                    errnoValue == EBUSY || errnoValue == EAGAIN
+                else {
+                    throw error
+                }
+                self.log.warning(
+                    "cgroup deletion failed with EBUSY/EAGAIN, retrying",
+                    metadata: [
+                        "attempt": "\(i + 1)",
+                        "delay": "\(delay)",
+                        "errno": "\(errnoValue)",
+                        "context": "\(message)",
+                    ])
+                continue
+            }
+        }
+
+        throw ContainerizationError(
+            .internalError,
+            message: "cgroups: unable to remove cgroup after \(maxRetries) retries"
+        )
+    }
+
     private func ensureExecExists(_ id: String) throws {
         if self.execs[id] == nil {
             throw ContainerizationError(
@@ -184,7 +223,7 @@ extension ManagedContainer {
         // Delete the bundle and cgroup
         try self.bundle.delete()
         if self.needsCgroupCleanup {
-            try self.cgroupManager.delete(force: true)
+            try await self.removeCgroupWithRetry()
         }
     }
 


### PR DESCRIPTION
If there's any nested cgroups in the one we made for the container (commonly seen for systemd images) removeItem didn't seem to be having a grand time, even though it states it should do recursive removals. Lets roll our own, and have a small EBUSY/EAGAIN retry loop as well. This fixes LinuxContainer.stop() for any containers with nested cgs.

Context: https://github.com/apple/container/issues/928