### PR TITLE
Match Mount default cache/sync to container defaults.

### DIFF
--- a/Sources/Containerization/Mount.swift
+++ b/Sources/Containerization/Mount.swift
@@ -164,7 +164,7 @@ extension Mount {
 extension VZDiskImageStorageDeviceAttachment {
     static func mountToVZAttachment(mount: Mount, options: [String]) throws -> VZDiskImageStorageDeviceAttachment {
         var cachingMode: VZDiskImageCachingMode = .automatic
-        var synchronizationMode: VZDiskImageSynchronizationMode = .none
+        var synchronizationMode: VZDiskImageSynchronizationMode = .fsync
 
         for option in options {
             let split = option.split(separator: "=")


### PR DESCRIPTION
- Use `cache=auto`, `sync=fsync` as default everywhere.