### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -53,7 +53,7 @@ jobs:
             exit 1
           fi 
       - name: Checkout repository
-        uses: actions/checkout@v4 
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/containerization-build-template.yml
+++ b/.github/workflows/containerization-build-template.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4 
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6 
         with:
           fetch-depth: 0
 
@@ -86,13 +86,13 @@ jobs:
 
       - name: Save vminit artifact
         if: ${{ !inputs.release }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: vminit
           path: vminit.tar
 
       - name: Save documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: api-docs
           path: "./_site.tgz"
@@ -111,7 +111,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Download a single artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
         with:
           name: api-docs
 


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | New Version | Release |
|--------|-------------|---------|
| `actions/checkout` | [`8e8c483`](https://github.com/actions/checkout/commit/8e8c483db84b4bee98b60c0593521ed34d9990e8) (v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |
| `actions/upload-artifact` | [`b7c566a`](https://github.com/actions/upload-artifact/commit/b7c566a772e6b6bfb58ed0dc250532a479d7789f) (v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) |
| `actions/download-artifact` | [`37930b1`](https://github.com/actions/download-artifact/commit/37930b1c2abaa49bbe596cd826c3c89aef350131) (v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

All actions are pinned to commit SHAs for security, with version tags noted in comments for reference.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality.