### PR TITLE
Make IP/CIDR types conform to Codable

### DIFF
--- a/Sources/ContainerizationExtras/CIDRv4.swift
+++ b/Sources/ContainerizationExtras/CIDRv4.swift
@@ -16,7 +16,7 @@
 
 /// Describes an IPv4 CIDR address block.
 @frozen
-public struct CIDRv4: CustomStringConvertible, Equatable, Sendable, Hashable {
+public struct CIDRv4: CustomStringConvertible, Equatable, Sendable, Hashable, Codable {
     /// The IP component of this CIDR address.
     public let address: IPv4Address
 

--- a/Sources/ContainerizationExtras/CIDRv6.swift
+++ b/Sources/ContainerizationExtras/CIDRv6.swift
@@ -16,7 +16,7 @@
 
 /// Describes an IPv4 or IPv6 CIDR address block.
 @frozen
-public struct CIDRv6: CustomStringConvertible, Equatable, Sendable, Hashable {
+public struct CIDRv6: CustomStringConvertible, Equatable, Sendable, Hashable, Codable {
 
     /// The IP component of this CIDR address.
     public let address: IPv6Address

--- a/Sources/ContainerizationExtras/IPv4Address.swift
+++ b/Sources/ContainerizationExtras/IPv4Address.swift
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 @frozen
-public struct IPv4Address: Sendable, Hashable, CustomStringConvertible, Equatable, Comparable {
+public struct IPv4Address: Sendable, Hashable, CustomStringConvertible, Equatable, Comparable, Codable {
     public let value: UInt32
 
     @inlinable

--- a/Sources/ContainerizationExtras/IPv6Address.swift
+++ b/Sources/ContainerizationExtras/IPv6Address.swift
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Represents an IPv6 network address conforming to RFC 5952 and RFC 4291.
-public struct IPv6Address: Sendable, Hashable, CustomStringConvertible, Equatable, Comparable {
+public struct IPv6Address: Sendable, Hashable, CustomStringConvertible, Equatable, Comparable, Codable {
     @usableFromInline
     internal let value: UInt128
 

--- a/Sources/ContainerizationExtras/Prefix.swift
+++ b/Sources/ContainerizationExtras/Prefix.swift
@@ -16,7 +16,7 @@
 
 /// CIDR prefix length (e.g., `/24` for a 24-bit network mask).
 @frozen
-public struct Prefix: Sendable, CustomStringConvertible, Hashable {
+public struct Prefix: Sendable, CustomStringConvertible, Hashable, Codable {
     public let length: UInt8
 
     /// Create a prefix (0-128). Use `ipv4(_:)` or `ipv6(_:)` for version-specific validation.


### PR DESCRIPTION
These types can benefit from swift's automatic
synthesis as the properties already conform to Codable. This will give some flexibility for clients using these types to not have to add extension and implement the encoding / decoding separately.