### PR TITLE
Make IPv6 integer representation public.

### DIFF
--- a/Sources/ContainerizationExtras/IPv6Address.swift
+++ b/Sources/ContainerizationExtras/IPv6Address.swift
@@ -16,11 +16,9 @@
 
 /// Represents an IPv6 network address conforming to RFC 5952 and RFC 4291.
 public struct IPv6Address: Sendable, Hashable, CustomStringConvertible, Equatable, Comparable, Codable {
-    @usableFromInline
-    internal let value: UInt128
+    public let value: UInt128
 
-    @usableFromInline
-    internal let zone: String?
+    public let zone: String?
 
     /// Creates an IPv6Address by parsing a string representation.
     ///


### PR DESCRIPTION
- We did this for IPv4 so we could bit bash addresses, but forgot to make the corresponding change for IPv6.