### PR TITLE
Support read only rootfs

### DIFF
--- a/Sources/Containerization/ContainerManager.swift
+++ b/Sources/Containerization/ContainerManager.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Containerization project authors.
+// Copyright © 2025-2026 Apple Inc. and the Containerization project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -352,10 +352,12 @@ public struct ContainerManager: Sendable {
     ///   - id: The container ID.
     ///   - reference: The image reference.
     ///   - rootfsSizeInBytes: The size of the root filesystem in bytes. Defaults to 8 GiB.
+    ///   - readOnly: Whether to mount the root filesystem as read-only.
     public mutating func create(
         _ id: String,
         reference: String,
         rootfsSizeInBytes: UInt64 = 8.gib(),
+        readOnly: Bool = false,
         configuration: (inout LinuxContainer.Configuration) throws -> Void
     ) async throws -> LinuxContainer {
         let image = try await imageStore.get(reference: reference, pull: true)
@@ -363,6 +365,7 @@ public struct ContainerManager: Sendable {
             id,
             image: image,
             rootfsSizeInBytes: rootfsSizeInBytes,
+            readOnly: readOnly,
             configuration: configuration
         )
     }
@@ -372,19 +375,24 @@ public struct ContainerManager: Sendable {
     ///   - id: The container ID.
     ///   - image: The image.
     ///   - rootfsSizeInBytes: The size of the root filesystem in bytes. Defaults to 8 GiB.
+    ///   - readOnly: Whether to mount the root filesystem as read-only.
     public mutating func create(
         _ id: String,
         image: Image,
         rootfsSizeInBytes: UInt64 = 8.gib(),
+        readOnly: Bool = false,
         configuration: (inout LinuxContainer.Configuration) throws -> Void
     ) async throws -> LinuxContainer {
         let path = try createContainerRoot(id)
 
-        let rootfs = try await unpack(
+        var rootfs = try await unpack(
             image: image,
             destination: path.appendingPathComponent("rootfs.ext4"),
             size: rootfsSizeInBytes
         )
+        if readOnly {
+            rootfs.options.append("ro")
+        }
         return try await create(
             id,
             image: image,

--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -235,25 +235,22 @@ public final class LinuxContainer: Container, Sendable {
     ///   - vmm: The virtual machine manager that will handle launching the VM for the container.
     ///   - logger: Optional logger for container operations.
     ///   - configuration: A closure that configures the container by modifying the Configuration instance.
-    public init(
+    public convenience init(
         _ id: String,
         rootfs: Mount,
         vmm: VirtualMachineManager,
         logger: Logger? = nil,
         configuration: (inout Configuration) throws -> Void
     ) throws {
-        self.id = id
-        self.vmm = vmm
-        self.hostVsockPorts = Atomic<UInt32>(0x1000_0000)
-        self.guestVsockPorts = Atomic<UInt32>(0x1000_0000)
-        self.rootfs = rootfs
-        self.logger = logger
-
         var config = Configuration()
         try configuration(&config)
-
-        self.config = config
-        self.state = AsyncMutex(.initialized)
+        self.init(
+            id,
+            rootfs: rootfs,
+            vmm: vmm,
+            configuration: config,
+            logger: logger
+        )
     }
 
     /// Create a new `LinuxContainer`.
@@ -275,11 +272,10 @@ public final class LinuxContainer: Container, Sendable {
         self.vmm = vmm
         self.hostVsockPorts = Atomic<UInt32>(0x1000_0000)
         self.guestVsockPorts = Atomic<UInt32>(0x1000_0000)
-        self.rootfs = rootfs
         self.logger = logger
-
         self.config = configuration
         self.state = AsyncMutex(.initialized)
+        self.rootfs = rootfs
     }
 
     private static func createDefaultRuntimeSpec(_ id: String) -> Spec {
@@ -308,6 +304,10 @@ public final class LinuxContainer: Container, Sendable {
 
         // Linux toggles.
         spec.linux?.sysctl = config.sysctl
+
+        // If the rootfs was requested as read-only, set it in the OCI spec.
+        // We let the OCI runtime remount as ro, instead of doing it originally.
+        spec.root?.readonly = self.rootfs.options.contains("ro")
 
         // Resource limits.
         // CPU: quota/period model where period is 100ms (100,000µs) and quota is cpus * period
@@ -394,11 +394,21 @@ extension LinuxContainer {
         try await self.state.withLock { state in
             try state.validateForCreate()
 
+            // This is a bit of an annoyance, but because the type we use for the rootfs is simply
+            // the same Mount type we use for non-rootfs mounts, it's possible someone passed 'ro'
+            // in the options (which should be perfectly valid). However, the problem is when we go to
+            // setup /etc/hosts and /etc/resolv.conf, as we'd get EROFS if they did supply 'ro'.
+            // To remedy this, remove any "ro" options before passing to VZ. Having the OCI runtime
+            // remount "ro" (which is what we do later in the guest) is truthfully the right thing,
+            // but this bit here is just a tad awkward.
+            var modifiedRootfs = self.rootfs
+            modifiedRootfs.options.removeAll(where: { $0 == "ro" })
+
             let vmConfig = VMConfiguration(
                 cpus: self.cpus,
                 memoryInBytes: self.memoryInBytes,
                 interfaces: self.interfaces,
-                mountsByID: [self.id: [self.rootfs] + self.config.mounts],
+                mountsByID: [self.id: [modifiedRootfs] + self.config.mounts],
                 bootLog: self.config.bootLog,
                 nestedVirtualization: self.config.virtualization
             )

--- a/Sources/Integration/PodTests.swift
+++ b/Sources/Integration/PodTests.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Containerization project authors.
+// Copyright © 2025-2026 Apple Inc. and the Containerization project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -744,6 +744,73 @@ extension IntegrationSuite {
         let output = String(data: psBuffer.data, encoding: .utf8) ?? ""
         guard output.contains("sleep 300") else {
             throw IntegrationError.assert(msg: "ps output should contain 'sleep 300', got: '\(output)'")
+        }
+    }
+
+    func testPodReadOnlyRootfs() async throws {
+        let id = "test-pod-readonly-rootfs"
+
+        let bs = try await bootstrap(id)
+        var rootfs = bs.rootfs
+        rootfs.options.append("ro")
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootLog = bs.bootLog
+        }
+
+        try await pod.addContainer("container1", rootfs: rootfs) { config in
+            config.process.arguments = ["touch", "/testfile"]
+        }
+
+        try await pod.create()
+        try await pod.startContainer("container1")
+
+        let status = try await pod.waitContainer("container1")
+        try await pod.stop()
+
+        // touch should fail on a read-only rootfs
+        guard status.exitCode != 0 else {
+            throw IntegrationError.assert(msg: "touch should have failed on read-only rootfs")
+        }
+    }
+
+    func testPodReadOnlyRootfsDNSConfigured() async throws {
+        let id = "test-pod-readonly-rootfs-dns"
+
+        let bs = try await bootstrap(id)
+        var rootfs = bs.rootfs
+        rootfs.options.append("ro")
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootLog = bs.bootLog
+            config.dns = DNS(nameservers: ["8.8.8.8", "8.8.4.4"])
+        }
+
+        let buffer = BufferWriter()
+        try await pod.addContainer("container1", rootfs: rootfs) { config in
+            // Verify /etc/resolv.conf was written before rootfs was remounted read-only
+            config.process.arguments = ["cat", "/etc/resolv.conf"]
+            config.process.stdout = buffer
+        }
+
+        try await pod.create()
+        try await pod.startContainer("container1")
+
+        let status = try await pod.waitContainer("container1")
+        try await pod.stop()
+
+        guard status.exitCode == 0 else {
+            throw IntegrationError.assert(msg: "cat /etc/resolv.conf failed with status \(status)")
+        }
+
+        guard let output = String(data: buffer.data, encoding: .utf8) else {
+            throw IntegrationError.assert(msg: "failed to convert stdout to UTF8")
+        }
+
+        guard output.contains("8.8.8.8") && output.contains("8.8.4.4") else {
+            throw IntegrationError.assert(msg: "expected /etc/resolv.conf to contain DNS servers, got: \(output)")
         }
     }
 }

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -308,6 +308,9 @@ struct IntegrationSuite: AsyncParsableCommand {
             Test("container copy in", testCopyIn),
             Test("container copy out", testCopyOut),
             Test("container copy large file", testCopyLargeFile),
+            Test("container read-only rootfs", testReadOnlyRootfs),
+            Test("container read-only rootfs hosts file", testReadOnlyRootfsHostsFileWritten),
+            Test("container read-only rootfs DNS", testReadOnlyRootfsDNSConfigured),
 
             // Pods
             Test("pod single container", testPodSingleContainer),
@@ -324,6 +327,8 @@ struct IntegrationSuite: AsyncParsableCommand {
             Test("pod container PID namespace isolation", testPodContainerPIDNamespaceIsolation),
             Test("pod container independent resource limits", testPodContainerIndependentResourceLimits),
             Test("pod shared PID namespace", testPodSharedPIDNamespace),
+            Test("pod read-only rootfs", testPodReadOnlyRootfs),
+            Test("pod read-only rootfs DNS", testPodReadOnlyRootfsDNSConfigured),
         ]
 
         let passed: Atomic<Int> = Atomic(0)

--- a/Sources/cctl/RunCommand.swift
+++ b/Sources/cctl/RunCommand.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Containerization project authors.
+// Copyright © 2025-2026 Apple Inc. and the Containerization project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -62,6 +62,9 @@ extension Application {
         @Option(name: .long, help: "Path to OCI runtime to use for spawning the container")
         var ociRuntimePath: String?
 
+        @Flag(name: .long, help: "Make rootfs readonly")
+        var readOnly: Bool = false
+
         @Option(
             name: [.customLong("kernel"), .customShort("k")], help: "Kernel binary path", completion: .file(),
             transform: { str in
@@ -94,7 +97,8 @@ extension Application {
             let container = try await manager.create(
                 id,
                 reference: imageReference,
-                rootfsSizeInBytes: fsSizeInMB.mib()
+                rootfsSizeInBytes: fsSizeInMB.mib(),
+                readOnly: readOnly
             ) { config in
                 config.cpus = cpus
                 config.memoryInBytes = memory.mib()


### PR DESCRIPTION
We sort of do today, unless you ask for dns/host settings. The problem is we can't write the files if the rootfs is ro. What other runtimes do is to delay the ro application, bind mount in some host/resolv.conf files they made, and then the OCI runtime eventually remounts the rootfs ro. We can do the same here (minus the bind mounts)