### PR TITLE
vminitd: Strip binaries

### DIFF
--- a/.github/workflows/containerization-build-template.yml
+++ b/.github/workflows/containerization-build-template.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6 
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
         with:
           fetch-depth: 0
 

--- a/Sources/ContainerizationNetlink/NetlinkSession.swift
+++ b/Sources/ContainerizationNetlink/NetlinkSession.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Containerization project authors.
+// Copyright © 2025-2026 Apple Inc. and the Containerization project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ import ContainerizationExtras
 import ContainerizationOS
 import Logging
 
-/// `NetlinkSession` facilitates interacting with netlink via a provided `NetlinkSocket`. This is the
-/// core high-level type offered to perform actions to the netlink surface in the kernel.
+/// `NetlinkSession` facilitates interacting with netlink via a provided `NetlinkSocket`. This is
+/// the core high-level type offered to perform actions to the netlink surface in the kernel.
 public struct NetlinkSession {
     private static let receiveDataLength = 65536
     private static let mtu: UInt32 = 1280

--- a/Sources/ContainerizationNetlink/Types.swift
+++ b/Sources/ContainerizationNetlink/Types.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Containerization project authors.
+// Copyright © 2025-2026 Apple Inc. and the Containerization project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -606,6 +606,7 @@ public struct LinkResponse {
                 return stats
             }
         }
+
         return nil
     }
 }

--- a/Tests/ContainerizationNetlinkTests/NetlinkSessionTest.swift
+++ b/Tests/ContainerizationNetlinkTests/NetlinkSessionTest.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Containerization project authors.
+// Copyright © 2025-2026 Apple Inc. and the Containerization project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -352,6 +352,7 @@ struct NetlinkSessionTest {
             + "08001d0009000000"  // RT attr: IFLA_EXT_MASK (8 B)
 
         // Pack three messages into a single response buffer:
+        //
         // Message 1: loopback interface with one attribute
         let msg1 =
             "28000000100002000000000021436587"  // Netlink header (16 B), len=40

--- a/scripts/check-integration-test-vm-panics.sh
+++ b/scripts/check-integration-test-vm-panics.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright © 2025 Apple Inc. and the Containerization project authors.
+# Copyright © 2025-2026 Apple Inc. and the Containerization project authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 
 # Script to scan the VM boot logs from the integration tests for kernel panics.
 # Looks for common kernel panic messages like "attempted to kill init" or "Kernel panic".

--- a/vminitd/Makefile
+++ b/vminitd/Makefile
@@ -1,4 +1,4 @@
-# Copyright © 2025 Apple Inc. and the Containerization project authors.
+# Copyright © 2025-2026 Apple Inc. and the Containerization project authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BUILD_CONFIGURATION := debug
+BUILD_CONFIGURATION ?= debug
 WARNINGS_AS_ERRORS ?= true
 SWIFT_WARNING_CONFIG := $(if $(filter-out false,$(WARNINGS_AS_ERRORS)),-Xswiftc -warnings-as-errors)
-SWIFT_CONFIGURATION := --swift-sdk aarch64-swift-linux-musl $(SWIFT_WARNING_CONFIG)
+SWIFT_CONFIGURATION := --swift-sdk aarch64-swift-linux-musl $(SWIFT_WARNING_CONFIG) -Xlinker -s
 
 SWIFT_VERSION := 6.2.3
 SWIFT_SDK_URL := https://download.swift.org/swift-6.2.3-release/static-sdk/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz

--- a/vminitd/Package.swift
+++ b/vminitd/Package.swift
@@ -1,6 +1,6 @@
 // swift-tools-version: 6.2
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Containerization project authors.
+// Copyright © 2025-2026 Apple Inc. and the Containerization project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-nio", from: "2.80.0"),
         .package(name: "containerization", path: "../"),
     ],
     targets: [
@@ -48,7 +47,6 @@ let package = Package(
             name: "vminitd",
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "_NIOFileSystem", package: "swift-nio"),
                 .product(name: "Containerization", package: "containerization"),
                 .product(name: "ContainerizationNetlink", package: "containerization"),
                 .product(name: "ContainerizationIO", package: "containerization"),


### PR DESCRIPTION
Swift release builds don't strip, and we don't need the symbols. 240Mi -> 70

```
    FILE SIZE        VM SIZE
 --------------  --------------
  26.9%  64.4Mi  50.7%  37.3Mi    [258604 Others]
  16.8%  40.2Mi   0.0%       0    [section .debug_info]
  13.0%  31.1Mi  42.2%  31.1Mi    icudt74_dat
  11.2%  26.9Mi   0.0%       0    [section .debug_str]
   7.0%  16.7Mi   0.0%       0    [section .debug_loc]
   6.4%  15.4Mi   0.0%       0    [section .debug_ranges]
   4.9%  11.6Mi   0.0%       0    [section .debug_names]
   4.5%  10.7Mi   0.0%       0    [section .debug_line]
   2.4%  5.72Mi   0.0%       0    [section .debug_loclists]
   1.4%  3.28Mi   0.0%       0    [section .debug_str_offsets]
   1.2%  2.80Mi   0.0%       0    [section .debug_abbrev]
   0.7%  1.61Mi   0.0%       0    [section .debug_addr]
```