### PR TITLE
vmexec: Remove the logger setup

### DIFF
--- a/vminitd/Sources/vmexec/ExecCommand.swift
+++ b/vminitd/Sources/vmexec/ExecCommand.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Containerization project authors.
+// Copyright © 2025-2026 Apple Inc. and the Containerization project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,16 +36,13 @@ struct ExecCommand: ParsableCommand {
 
     func run() throws {
         do {
-            LoggingSystem.bootstrap(App.standardError)
-            let log = Logger(label: "vmexec")
-
             let src = URL(fileURLWithPath: processPath)
             let processBytes = try Data(contentsOf: src)
             let process = try JSONDecoder().decode(
                 ContainerizationOCI.Process.self,
                 from: processBytes
             )
-            try execInNamespaces(process: process, log: log)
+            try execInNamespaces(process: process)
         } catch {
             App.writeError(error)
             throw error
@@ -58,10 +55,7 @@ struct ExecCommand: ParsableCommand {
         }
     }
 
-    private func execInNamespaces(
-        process: ContainerizationOCI.Process,
-        log: Logger
-    ) throws {
+    private func execInNamespaces(process: ContainerizationOCI.Process) throws {
         let syncPipe = FileHandle(fileDescriptor: 3)
         let ackPipe = FileHandle(fileDescriptor: 4)
 

--- a/vminitd/Sources/vmexec/vmexec.swift
+++ b/vminitd/Sources/vmexec/vmexec.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Containerization project authors.
+// Copyright © 2025-2026 Apple Inc. and the Containerization project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,15 +41,6 @@ struct App: ParsableCommand {
             RunCommand.self,
         ]
     )
-
-    static let standardErrorLock = NSLock()
-
-    @Sendable
-    static func standardError(label: String) -> StreamLogHandler {
-        standardErrorLock.withLock {
-            StreamLogHandler.standardError(label: label)
-        }
-    }
 }
 
 extension App {


### PR DESCRIPTION
We can't write to stderr because it may be the containers stderr, so this is mostly dead code. We should think about how to do logging from here as there's a couple spots it'd be nice.