### PR TITLE
LinuxProcess: Start stdin relay after process start

### DIFF
--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -312,6 +312,12 @@ struct IntegrationSuite: AsyncParsableCommand {
             Test("container read-only rootfs", testReadOnlyRootfs),
             Test("container read-only rootfs hosts file", testReadOnlyRootfsHostsFileWritten),
             Test("container read-only rootfs DNS", testReadOnlyRootfsDNSConfigured),
+            Test("large stdin input", testLargeStdinInput),
+            Test("exec large stdin input", testExecLargeStdinInput),
+            Test("stdin explicit close", testStdinExplicitClose),
+            Test("stdin binary data", testStdinBinaryData),
+            Test("stdin multiple chunks", testStdinMultipleChunks),
+            Test("stdin very large", testStdinVeryLarge),
 
             // Pods
             Test("pod single container", testPodSingleContainer),

--- a/vminitd/Sources/vminitd/ManagedProcess.swift
+++ b/vminitd/Sources/vminitd/ManagedProcess.swift
@@ -327,9 +327,8 @@ extension ManagedProcess {
     }
 
     func closeStdin() throws {
-        try self.state.withLock {
-            try $0.io.closeStdin()
-        }
+        let io = self.state.withLock { $0.io }
+        try io.closeStdin()
     }
 
     func delete() async throws {


### PR DESCRIPTION
Fixes #477

Because we start piping stdin before process launch we can fill up the guest pipe buffer before the process even starts. We'd need some backpressure mechanism to handle this and slow consumers (register the other end with epoll and buffer some data etc.), but we should probably just start piping after the process is up and running. This change does exactly that, as well as stops holding the process mutex while draining stdin in the guest for `CloseStdin()`.

This fixes issues where we try and write > pipe_buf bytes through stdin. Today this hangs.