### PR TITLE
Check for wildcard when determining if proxy should be bypassed

### DIFF
--- a/Sources/ContainerizationExtras/ProxyUtils.swift
+++ b/Sources/ContainerizationExtras/ProxyUtils.swift
@@ -66,6 +66,10 @@ public enum ProxyUtils {
             if entry.isEmpty { continue }
             if entry == "*" { return true }
             if host == entry { return true }
+            if entry.hasPrefix("*.") {
+                let suffix = String(entry.dropFirst())
+                if host.hasSuffix(suffix) { return true }
+            }
             if entry.hasPrefix(".") && host.hasSuffix(entry) { return true }
         }
         return false

--- a/Tests/ContainerizationExtrasTests/ProxyUtilsTests.swift
+++ b/Tests/ContainerizationExtrasTests/ProxyUtilsTests.swift
@@ -109,4 +109,14 @@ struct ProxyUtilsTests {
         #expect(proxyFoo != nil)
         #expect(proxyBar == nil)
     }
+
+    @Test("NO_PROXY with wildcard")
+    func testComplexNoProxy() {
+        let env = [
+            "HTTP_PROXY": "http://proxy.example.com",
+            "NO_PROXY": "localhost,127.0.0.1,*.bar.com",
+        ]
+        let proxy = ProxyUtils.proxyFromEnvironment(scheme: "http", host: "foo.bar.com", env: env)
+        #expect(proxy == nil)
+    }
 }


### PR DESCRIPTION
The `shouldBypassProxy` method from `ProxyUtils.swift` did not account for `NO_PROXY` entries of the form `*.host.com`
This PR adds an additional check to determine if the proxy should be bypassed for a given host.