### PR TITLE
LinuxPod: Add back top-level dns/hosts

### DIFF
--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -358,6 +358,10 @@ struct IntegrationSuite: AsyncParsableCommand {
                 Test("pod container hosts config", testPodContainerHostsConfig),
                 Test("pod multiple containers different DNS", testPodMultipleContainersDifferentDNS),
                 Test("pod multiple containers different hosts", testPodMultipleContainersDifferentHosts),
+                Test("pod level DNS", testPodLevelDNS),
+                Test("pod level DNS with container override", testPodLevelDNSWithContainerOverride),
+                Test("pod level hosts", testPodLevelHosts),
+                Test("pod level hosts with container override", testPodLevelHostsWithContainerOverride),
             ] + macOS26Tests()
 
         let filteredTests: [Test]


### PR DESCRIPTION
Upon further thought, we should probably support this at the pod level and allow per container overrides. I've changed my mind on how tedious it is to specify it on a per-container basis.