### PR TITLE
vminitd: Scrub envvars printed in debug log

### DIFF
--- a/vminitd/Sources/vminitd/LogRedaction.swift
+++ b/vminitd/Sources/vminitd/LogRedaction.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationOCI
+
+/// Redacts environment variable values from a list of env vars in "KEY=VALUE" format.
+/// Returns the env vars with values replaced by "<redacted>".
+func redactEnvValues(_ env: [String]) -> [String] {
+    env.map { entry in
+        if let equalsIndex = entry.firstIndex(of: "=") {
+            let key = entry[..<equalsIndex]
+            return "\(key)=<redacted>"
+        }
+        return entry
+    }
+}
+
+/// A log-safe representation of a Process that redacts environment variable values.
+struct RedactedProcess: CustomStringConvertible {
+    let process: ContainerizationOCI.Process
+
+    var description: String {
+        var copy = process
+        copy.env = redactEnvValues(copy.env)
+        return "\(copy)"
+    }
+}
+
+/// A log-safe representation of a Spec that redacts environment variable values.
+struct RedactedSpec: CustomStringConvertible {
+    let spec: ContainerizationOCI.Spec
+
+    var description: String {
+        var copy = spec
+        if var process = copy.process {
+            process.env = redactEnvValues(process.env)
+            copy.process = process
+        }
+        return "\(copy)"
+    }
+}
+
+extension ContainerizationOCI.Spec {
+    var redacted: RedactedSpec {
+        RedactedSpec(spec: self)
+    }
+}
+
+extension ContainerizationOCI.Process {
+    var redacted: RedactedProcess {
+        RedactedProcess(process: self)
+    }
+}

--- a/vminitd/Sources/vminitd/ManagedContainer.swift
+++ b/vminitd/Sources/vminitd/ManagedContainer.swift
@@ -53,7 +53,7 @@ actor ManagedContainer {
             path: Self.craftBundlePath(id: id),
             spec: spec
         )
-        log.debug("created bundle with spec \(spec)")
+        log.debug("created bundle with spec \(spec.redacted)")
 
         let cgManager = Cgroup2Manager(
             group: URL(filePath: cgroupsPath),
@@ -163,7 +163,7 @@ extension ManagedContainer {
         stdio: HostStdio,
         process: ContainerizationOCI.Process
     ) throws {
-        log.debug("creating exec process with \(process)")
+        log.debug("creating exec process with \(process.redacted)")
 
         // Write the process config to the bundle, and pass this on
         // over to ManagedProcess to deal with.


### PR DESCRIPTION
Closes #518

We print the OCI spec at debug level, and this can contain sensitive info in envvars specifically. Lets redact the values in the envvars before we print. I went the route of just redacting everything as trying to check against some "possibly sensitive looking vars" seems rife for never getting it fully right.

This is what the envvars look like after the change: `env: ["PATH=<redacted>", "HOME=<redacted>"]`

This does make debugging worse, but that's the tradeoff.