### PR TITLE
LinuxContainer/LinuxPod: Support duplicate virtiofs mounts

### DIFF
--- a/Sources/Containerization/Hash.swift
+++ b/Sources/Containerization/Hash.swift
@@ -18,9 +18,12 @@
 
 import Crypto
 import ContainerizationError
+import Foundation
 
 public func hashMountSource(source: String) throws -> String {
-    guard let data = source.data(using: .utf8) else {
+    // Resolve symlinks so different paths to the same directory get the same hash.
+    let resolvedSource = URL(fileURLWithPath: source).resolvingSymlinksInPath().path
+    guard let data = resolvedSource.data(using: .utf8) else {
         throw ContainerizationError(.invalidArgument, message: "\(source) could not be converted to Data")
     }
     return String(SHA256.hash(data: data).encoded.prefix(36))

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -339,6 +339,8 @@ struct IntegrationSuite: AsyncParsableCommand {
                 Test("container rlimit open files", testRLimitOpenFiles),
                 Test("container rlimit multiple", testRLimitMultiple),
                 Test("container rlimit exec", testRLimitExec),
+                Test("container duplicate virtiofs mount", testDuplicateVirtiofsMount),
+                Test("container duplicate virtiofs mount via symlink", testDuplicateVirtiofsMountViaSymlink),
 
                 // Pods
                 Test("pod single container", testPodSingleContainer),


### PR DESCRIPTION
If we have the same source we should dedupe these. Previously virt.framework would yell at us for a duplicate tag because we derive the tag from hashing the mount source.