### PR TITLE
Add `releaseNetwork` method to `ContainerManager`

### DIFF
--- a/Sources/Containerization/ContainerManager.swift
+++ b/Sources/Containerization/ContainerManager.swift
@@ -451,14 +451,14 @@ public struct ContainerManager: Sendable {
     /// Releases network resources for a container.
     ///
     /// - Parameter id: The container ID.
-    public mutating func release(_ id: String) throws {
+    public mutating func releaseNetwork(_ id: String) throws {
         try self.network?.release(id)
     }
 
     /// Releases network resources and removes all files for a container.
     /// - Parameter id: The container ID.
     public mutating func delete(_ id: String) throws {
-        try self.release(id)
+        try self.releaseNetwork(id)
         let path = containerRoot.appendingPathComponent(id)
         try FileManager.default.removeItem(at: path)
     }


### PR DESCRIPTION
I've extracted the network cleanup step from `delete` into a new public `releaseNetwork` method. This mirrors the existing `release` on `VmnetNetwork` and enables stop-and-restart workflows where the network allocation needs to be freed without removing the container's rootfs.

## Changes

- Add `ContainerManager.release(_:)` — frees network resources for a container after it has stopped
- Refactor `delete(_:)` to call `releaseNetwork(_:)` before removing files, preserving existing behavior

## Motivation

Currently the only way to free a container's network allocation is `delete`, which also removes its files. This makes it impossible to stop a container (freeing the network so the ID can be re-allocated) and later restart it with its filesystem intact. The new `releaseNetwork ` method fills this gap.