### PR TITLE
Add `LocalizedError` conformance to `ContainerizationError`

### DIFF
--- a/Sources/ContainerizationError/ContainerizationError.swift
+++ b/Sources/ContainerizationError/ContainerizationError.swift
@@ -14,11 +14,13 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import Foundation
+
 /// The core error type for Containerization.
 ///
 /// Most API surfaces for the core container/process/agent types will
 /// return a ContainerizationError.
-public struct ContainerizationError: Swift.Error, Sendable {
+public struct ContainerizationError: Swift.Error, LocalizedError, Sendable {
     /// A code describing the error encountered.
     public var code: Code
     /// A description of the error.
@@ -64,6 +66,10 @@ public struct ContainerizationError: Swift.Error, Sendable {
     /// Checks if the given error has the provided code.
     public func isCode(_ code: Code) -> Bool {
         self.code == code
+    }
+
+    public var errorDescription: String? {
+        message
     }
 }
 


### PR DESCRIPTION
Without `LocalizedError` conformance, calling `localizedDescription` on a `ContainerizationError` falls back to the default representation (e.g., "ContainerizationError.ContainerizationError error 1.") instead of returning the actual error message. This makes it difficult to show meaningful errors in a UI, where `localizedDescription` is the standard way to get a user-facing string.