### PR TITLE
vminitd: Add ability to set log level

### DIFF
--- a/vminitd/Package.swift
+++ b/vminitd/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
         .executableTarget(
             name: "vminitd",
             dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Containerization", package: "containerization"),
                 .product(name: "ContainerizationNetlink", package: "containerization"),

--- a/vminitd/Sources/vminitd/PauseCommand.swift
+++ b/vminitd/Sources/vminitd/PauseCommand.swift
@@ -14,12 +14,22 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ArgumentParser
 import Dispatch
 import Logging
 import Musl
 
-struct PauseCommand {
-    static func run(log: Logger) throws {
+struct PauseCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "pause",
+        abstract: "Run the pause container"
+    )
+
+    @OptionGroup var options: LogLevelOption
+
+    mutating func run() throws {
+        let log = makeLogger(label: "pause", level: options.resolvedLogLevel())
+
         if getpid() != 1 {
             log.warning("pause should be the first process")
         }


### PR DESCRIPTION
This adds a small flag named --log-level to be able to set the log level of vminitd and the pause command. I imagine this won't be the last time we'll have to add flags to vminitd so I went ahead and converted vminitd to be a Argument Parser based binary as well.