### PR TITLE
fix(dns): validate nameserver addresses are valid IP addresses

### DIFF
--- a/Sources/Containerization/DNSConfiguration.swift
+++ b/Sources/Containerization/DNSConfiguration.swift
@@ -14,6 +14,9 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerizationError
+import ContainerizationExtras
+
 /// DNS configuration for a container. The values will be used to
 /// construct /etc/resolv.conf for a given container.
 public struct DNS: Sendable {
@@ -40,6 +43,26 @@ public struct DNS: Sendable {
         self.domain = domain
         self.searchDomains = searchDomains
         self.options = options
+    }
+
+    /// Validates the DNS configuration.
+    ///
+    /// Ensures that all nameserver entries are valid IPv4 or IPv6 addresses.
+    /// Arbitrary hostnames are not permitted as nameservers.
+    ///
+    /// - Throws: ``ContainerizationError`` with code `.invalidArgument` if
+    ///   any nameserver is not a valid IP address.
+    public func validate() throws {
+        for nameserver in nameservers {
+            let isValidIPv4 = (try? IPv4Address(nameserver)) != nil
+            let isValidIPv6 = (try? IPv6Address(nameserver)) != nil
+            if !isValidIPv4 && !isValidIPv6 {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "nameserver '\(nameserver)' is not a valid IPv4 or IPv6 address"
+                )
+            }
+        }
     }
 }
 

--- a/Sources/Containerization/Vminitd.swift
+++ b/Sources/Containerization/Vminitd.swift
@@ -408,6 +408,7 @@ extension Vminitd {
 
     /// Configure DNS within the sandbox's environment.
     public func configureDNS(config: DNS, location: String) async throws {
+        try config.validate()
         _ = try await client.configureDns(
             .with {
                 $0.location = location

--- a/Tests/ContainerizationTests/DNSTests.swift
+++ b/Tests/ContainerizationTests/DNSTests.swift
@@ -51,4 +51,34 @@ struct DNSTests {
         let expected = "nameserver 8.8.8.8\n"
         #expect(dns.resolvConf == expected)
     }
+
+    @Test func dnsValidateAcceptsValidIPv4Nameservers() throws {
+        let dns = DNS(nameservers: ["8.8.8.8", "1.1.1.1"])
+        #expect(throws: Never.self) { try dns.validate() }
+    }
+
+    @Test func dnsValidateAcceptsValidIPv6Nameservers() throws {
+        let dns = DNS(nameservers: ["2001:4860:4860::8888", "::1"])
+        #expect(throws: Never.self) { try dns.validate() }
+    }
+
+    @Test func dnsValidateAcceptsMixedIPv4AndIPv6Nameservers() throws {
+        let dns = DNS(nameservers: ["8.8.8.8", "2001:4860:4860::8844"])
+        #expect(throws: Never.self) { try dns.validate() }
+    }
+
+    @Test func dnsValidateAcceptsEmptyNameservers() throws {
+        let dns = DNS(nameservers: [])
+        #expect(throws: Never.self) { try dns.validate() }
+    }
+
+    @Test func dnsValidateRejectsHostname() {
+        let dns = DNS(nameservers: ["dns.example.com"])
+        #expect(throws: (any Error).self) { try dns.validate() }
+    }
+
+    @Test func dnsValidateRejectsInvalidAddress() {
+        let dns = DNS(nameservers: ["not-an-ip"])
+        #expect(throws: (any Error).self) { try dns.validate() }
+    }
 }


### PR DESCRIPTION
## What

Add a `DNS.validate()` method that verifies all nameserver entries are valid IPv4 or IPv6 addresses. The method is called from `Vminitd.configureDNS()` before applying the configuration.

## Why

Closes #467. Currently, any arbitrary string can be passed as a nameserver in `DNSConfiguration`, which silently results in an invalid `/etc/resolv.conf` inside the container. Hostname strings like `dns.example.com` would be written to resolv.conf but would not work as nameservers.

## How

- Added `DNS.validate() throws` method in `DNSConfiguration.swift` that iterates over all nameservers and attempts to parse each as either an `IPv4Address` or `IPv6Address` (using the existing parsers in `ContainerizationExtras`)
- Added `import ContainerizationExtras` to `DNSConfiguration.swift` (the `Containerization` target already depends on `ContainerizationExtras`)
- Called `config.validate()` at the start of `Vminitd.configureDNS()` so validation happens before any GRPC call

## Testing

Added 6 new unit tests in `DNSTests.swift`:
- ✅ Valid IPv4 nameservers accepted
- ✅ Valid IPv6 nameservers accepted  
- ✅ Mixed IPv4/IPv6 nameservers accepted
- ✅ Empty nameserver list accepted
- ❌ Hostname rejected
- ❌ Invalid address rejected

## Checklist

- [x] Tests added
- [x] No breaking changes to existing API (validate() is a new method, existing init is unchanged)
- [x] Follows existing patterns (uses ContainerizationExtras IP address types, ContainerizationError for errors)