### PR TITLE
vminitd: Implement minimal init process to reap zombies

### DIFF
--- a/Sources/CShim/include/exec_command.h
+++ b/Sources/CShim/include/exec_command.h
@@ -40,6 +40,8 @@ struct exec_command_attrs {
   int mask;
   /// parent death signal (Linux only, 0 to disable)
   int pdeathSignal;
+  /// make the new process group the foreground process group
+  int setfgpgrp;
 };
 
 void exec_command_attrs_init(struct exec_command_attrs *attrs);

--- a/Sources/ContainerizationOS/Command.swift
+++ b/Sources/ContainerizationOS/Command.swift
@@ -54,6 +54,8 @@ public struct Command: Sendable {
     public struct Attrs: Sendable {
         /// Set pgroup for the new process.
         public var setPGroup: Bool
+        /// Make the new process group the foreground process group (requires setPGroup).
+        public var setForegroundPGroup: Bool
         /// Inherit the real uid/gid of the parent.
         public var resetIDs: Bool
         /// Reset the child's signal handlers to the default.
@@ -73,6 +75,7 @@ public struct Command: Sendable {
 
         public init(
             setPGroup: Bool = false,
+            setForegroundPGroup: Bool = false,
             resetIDs: Bool = false,
             setSignalDefault: Bool = true,
             signalMask: UInt32 = 0,
@@ -83,6 +86,7 @@ public struct Command: Sendable {
             pdeathSignal: Int32? = nil
         ) {
             self.setPGroup = setPGroup
+            self.setForegroundPGroup = setForegroundPGroup
             self.resetIDs = resetIDs
             self.setSignalDefault = setSignalDefault
             self.signalMask = signalMask
@@ -195,6 +199,7 @@ extension Command {
         attrs.setsid = self.attrs.setsid ? 1 : 0
         attrs.setctty = self.attrs.setctty ? 1 : 0
         attrs.setpgid = self.attrs.setPGroup ? 1 : 0
+        attrs.setfgpgrp = self.attrs.setForegroundPGroup ? 1 : 0
 
         var cwdPath: UnsafeMutablePointer<CChar>?
         if let chdir = self.directory {

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -347,6 +347,12 @@ struct IntegrationSuite: AsyncParsableCommand {
                 Test("container rlimit exec", testRLimitExec),
                 Test("container duplicate virtiofs mount", testDuplicateVirtiofsMount),
                 Test("container duplicate virtiofs mount via symlink", testDuplicateVirtiofsMountViaSymlink),
+                Test("container useInit basic", testUseInitBasic),
+                Test("container useInit exit code propagation", testUseInitExitCodePropagation),
+                Test("container useInit signal forwarding", testUseInitSignalForwarding),
+                Test("container useInit zombie reaping", testUseInitZombieReaping),
+                Test("container useInit with terminal", testUseInitWithTerminal),
+                Test("container useInit with stdin", testUseInitWithStdin),
 
                 // Pods
                 Test("pod single container", testPodSingleContainer),
@@ -376,6 +382,11 @@ struct IntegrationSuite: AsyncParsableCommand {
                 Test("pod level hosts with container override", testPodLevelHostsWithContainerOverride),
                 Test("pod rlimit open files", testPodRLimitOpenFiles),
                 Test("pod rlimit exec", testPodRLimitExec),
+                Test("pod useInit basic", testPodUseInitBasic),
+                Test("pod useInit exit code propagation", testPodUseInitExitCodePropagation),
+                Test("pod useInit signal forwarding", testPodUseInitSignalForwarding),
+                Test("pod useInit multiple containers", testPodUseInitMultipleContainers),
+                Test("pod useInit with shared PID namespace", testPodUseInitWithSharedPIDNamespace),
             ] + macOS26Tests()
 
         let filteredTests: [Test]

--- a/Sources/cctl/RunCommand.swift
+++ b/Sources/cctl/RunCommand.swift
@@ -59,6 +59,9 @@ extension Application {
         @Flag(name: .long, help: "Make rootfs readonly")
         var readOnly: Bool = false
 
+        @Flag(name: .long, help: "Run with an init process for signal forwarding and zombie reaping")
+        var `init`: Bool = false
+
         @Option(
             name: [.customLong("kernel"), .customShort("k")], help: "Kernel binary path", completion: .file(),
             transform: { str in
@@ -152,6 +155,8 @@ extension Application {
                     config.ociRuntimePath = ociRuntimePath
                     config.mounts = LinuxContainer.defaultOCIMounts()
                 }
+
+                config.useInit = self.`init`
             }
 
             defer {

--- a/vminitd/Sources/vminitd/AgentCommand.swift
+++ b/vminitd/Sources/vminitd/AgentCommand.swift
@@ -1,0 +1,190 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Cgroup
+import Containerization
+import ContainerizationError
+import ContainerizationOS
+import Foundation
+import Logging
+import NIOCore
+import NIOPosix
+
+#if os(Linux)
+import Musl
+import LCShim
+#endif
+
+struct AgentCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "agent",
+        abstract: "Run the vminitd agent daemon"
+    )
+
+    private static let foregroundEnvVar = "FOREGROUND"
+    private static let vsockPort = 1024
+
+    @OptionGroup var options: LogLevelOption
+
+    mutating func run() async throws {
+        let log = makeLogger(label: "vminitd", level: options.resolvedLogLevel())
+        try Self.adjustLimits(log)
+
+        // when running under debug mode, launch vminitd as a sub process of pid1
+        // so that we get a chance to collect better logs and errors before pid1 exists
+        // and the kernel panics.
+        #if DEBUG
+        log.info("DEBUG mode active, checking FOREGROUND env var")
+        let environment = ProcessInfo.processInfo.environment
+        let foreground = environment[Self.foregroundEnvVar]
+        log.info("checking for shim var \(Self.foregroundEnvVar)=\(String(describing: foreground))")
+
+        if foreground == nil {
+            try Self.runInForeground(log, logLevel: options.logLevel)
+            _exit(0)
+        }
+
+        log.info("FOREGROUND is set, running as subprocess, setting subreaper")
+        // since we are not running as pid1 in this mode we must set ourselves
+        // as a subpreaper so that all child processes are reaped by us and not
+        // passed onto our parent.
+        CZ_set_sub_reaper()
+        #endif
+
+        signal(SIGPIPE, SIG_IGN)
+
+        log.info("vminitd booting")
+
+        // Set of mounts necessary to be mounted prior to taking any RPCs.
+        // 1. /proc as the sysctl rpc wouldn't make sense if it wasn't there (NOTE: This is done before this method
+        // due to Swift seemingly requiring /proc to be present for the async runtime to spin up).
+        // 2. /run as that is where we store container state.
+        // 3. /sys as we need it for /sys/fs/cgroup
+        // 4. /sys/fs/cgroup to add the agent to a cgroup, as well as containers later.
+        let mounts = [
+            ContainerizationOS.Mount(
+                type: "tmpfs",
+                source: "tmpfs",
+                target: "/run",
+                options: []
+            ),
+            ContainerizationOS.Mount(
+                type: "sysfs",
+                source: "sysfs",
+                target: "/sys",
+                options: []
+            ),
+            ContainerizationOS.Mount(
+                type: "cgroup2",
+                source: "none",
+                target: "/sys/fs/cgroup",
+                options: []
+            ),
+        ]
+
+        for mnt in mounts {
+            log.info("mounting \(mnt.target)")
+
+            try mnt.mount(createWithPerms: 0o755)
+        }
+        try Binfmt.mount()
+
+        let cgManager = Cgroup2Manager(
+            group: URL(filePath: "/vminitd"),
+            logger: log
+        )
+        try cgManager.create()
+        try cgManager.toggleAllAvailableControllers(enable: true)
+
+        // Set memory.high threshold to 75 MiB
+        let threshold: UInt64 = 75 * 1024 * 1024
+        try cgManager.setMemoryHigh(bytes: threshold)
+        try cgManager.addProcess(pid: getpid())
+
+        let memoryMonitor = try MemoryMonitor(
+            cgroupManager: cgManager,
+            threshold: threshold,
+            logger: log
+        ) { [log] (currentUsage, highMark) in
+            log.warning(
+                "vminitd memory threshold exceeded",
+                metadata: [
+                    "threshold_bytes": "\(threshold)",
+                    "current_bytes": "\(currentUsage)",
+                    "high_events_total": "\(highMark)",
+                ])
+        }
+
+        let t = Thread { [log] in
+            do {
+                try memoryMonitor.run()
+            } catch {
+                log.error("memory monitor failed: \(error)")
+            }
+        }
+        t.start()
+
+        let eg = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        let server = Initd(log: log, group: eg)
+
+        do {
+            log.info("serving vminitd API")
+            try await server.serve(port: Self.vsockPort)
+            log.info("vminitd API returned, syncing filesystems")
+
+            #if os(Linux)
+            Musl.sync()
+            #endif
+        } catch {
+            log.error("vminitd boot error \(error)")
+
+            #if os(Linux)
+            Musl.sync()
+            #endif
+
+            _exit(1)
+        }
+    }
+
+    private static func runInForeground(_ log: Logger, logLevel: String) throws {
+        log.info("running vminitd under pid1")
+
+        var command = Command("/sbin/vminitd", arguments: ["agent", "--log-level", logLevel])
+        command.attrs = .init(setsid: true)
+        command.stdin = .standardInput
+        command.stdout = .standardOutput
+        command.stderr = .standardError
+        command.environment = ["\(foregroundEnvVar)=1"]
+
+        try command.start()
+        let exitCode = try command.wait()
+        log.info("child process exited with code: \(exitCode)")
+    }
+
+    private static func adjustLimits(_ log: Logger) throws {
+        let nrOpen = try String(contentsOfFile: "/proc/sys/fs/nr_open", encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let max = rlim_t(nrOpen) else {
+            throw POSIXError(.EINVAL)
+        }
+        log.debug("setting RLIMIT_NOFILE to \(max)")
+        var limits = rlimit(rlim_cur: max, rlim_max: max)
+        guard setrlimit(RLIMIT_NOFILE, &limits) == 0 else {
+            throw POSIXError(.init(rawValue: errno)!)
+        }
+    }
+}


### PR DESCRIPTION
There are some workloads that benefit from having a "true" init process that reaps zombies. This change implements a minimal init as part of vminitd and exposes an API to be able to use this init process in our containers. signals will be forwarded, any child procs will be reaped and the exit code of the actual workload will be propagated. The LinuxContainer/LinuxPod API is a very simple bool to ask to use this as our init process, and the init simply spawns whatever command you want as a child underneath this.

```
➜  ./bin/cctl run --kernel bin/kernel.arm64 --init
/ # ps aux
PID   USER     TIME  COMMAND
    1 root      0:00 /.cz-init -- /bin/sh
    2 root      0:00 /bin/sh
    3 root      0:00 ps aux
```