### PR TITLE
vminitd: add anonymous memory and inactive file stats

### DIFF
--- a/Sources/Containerization/ContainerStatistics.swift
+++ b/Sources/Containerization/ContainerStatistics.swift
@@ -64,6 +64,8 @@ public struct ContainerStatistics: Sendable {
         public var slabBytes: UInt64
         public var pageFaults: UInt64
         public var majorPageFaults: UInt64
+        public var inactiveFile: UInt64
+        public var anon: UInt64
 
         public init(
             usageBytes: UInt64,
@@ -74,7 +76,9 @@ public struct ContainerStatistics: Sendable {
             kernelStackBytes: UInt64,
             slabBytes: UInt64,
             pageFaults: UInt64,
-            majorPageFaults: UInt64
+            majorPageFaults: UInt64,
+            inactiveFile: UInt64,
+            anon: UInt64
         ) {
             self.usageBytes = usageBytes
             self.limitBytes = limitBytes
@@ -85,6 +89,8 @@ public struct ContainerStatistics: Sendable {
             self.slabBytes = slabBytes
             self.pageFaults = pageFaults
             self.majorPageFaults = majorPageFaults
+            self.inactiveFile = inactiveFile
+            self.anon = anon
         }
     }
 

--- a/Sources/Containerization/SandboxContext/SandboxContext.pb.swift
+++ b/Sources/Containerization/SandboxContext/SandboxContext.pb.swift
@@ -1329,6 +1329,10 @@ public struct Com_Apple_Containerization_Sandbox_V3_MemoryStats: Sendable {
 
   public var majorPageFaults: UInt64 = 0
 
+  public var inactiveFile: UInt64 = 0
+
+  public var anon: UInt64 = 0
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -3847,6 +3851,8 @@ extension Com_Apple_Containerization_Sandbox_V3_MemoryStats: SwiftProtobuf.Messa
     7: .standard(proto: "slab_bytes"),
     8: .standard(proto: "page_faults"),
     9: .standard(proto: "major_page_faults"),
+    10: .standard(proto: "inactive_file"),
+    11: .same(proto: "anon"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -3864,6 +3870,8 @@ extension Com_Apple_Containerization_Sandbox_V3_MemoryStats: SwiftProtobuf.Messa
       case 7: try { try decoder.decodeSingularUInt64Field(value: &self.slabBytes) }()
       case 8: try { try decoder.decodeSingularUInt64Field(value: &self.pageFaults) }()
       case 9: try { try decoder.decodeSingularUInt64Field(value: &self.majorPageFaults) }()
+      case 10: try { try decoder.decodeSingularUInt64Field(value: &self.inactiveFile) }()
+      case 11: try { try decoder.decodeSingularUInt64Field(value: &self.anon) }()
       default: break
       }
     }
@@ -3897,6 +3905,12 @@ extension Com_Apple_Containerization_Sandbox_V3_MemoryStats: SwiftProtobuf.Messa
     if self.majorPageFaults != 0 {
       try visitor.visitSingularUInt64Field(value: self.majorPageFaults, fieldNumber: 9)
     }
+    if self.inactiveFile != 0 {
+      try visitor.visitSingularUInt64Field(value: self.inactiveFile, fieldNumber: 10)
+    }
+    if self.anon != 0 {
+      try visitor.visitSingularUInt64Field(value: self.anon, fieldNumber: 11)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -3910,6 +3924,8 @@ extension Com_Apple_Containerization_Sandbox_V3_MemoryStats: SwiftProtobuf.Messa
     if lhs.slabBytes != rhs.slabBytes {return false}
     if lhs.pageFaults != rhs.pageFaults {return false}
     if lhs.majorPageFaults != rhs.majorPageFaults {return false}
+    if lhs.inactiveFile != rhs.inactiveFile {return false}
+    if lhs.anon != rhs.anon {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Containerization/SandboxContext/SandboxContext.proto
+++ b/Sources/Containerization/SandboxContext/SandboxContext.proto
@@ -185,7 +185,7 @@ message DeleteProcessRequest {
 
 message DeleteProcessResponse {}
 
-message StartProcessRequest { 
+message StartProcessRequest {
   string id = 1;
   optional string containerID = 2;
 }
@@ -376,6 +376,8 @@ message MemoryStats {
   uint64 slab_bytes = 7;
   uint64 page_faults = 8;
   uint64 major_page_faults = 9;
+  uint64 inactive_file = 10;
+  uint64 anon = 11;
 }
 
 message CPUStats {

--- a/Sources/Containerization/Vminitd.swift
+++ b/Sources/Containerization/Vminitd.swift
@@ -106,7 +106,9 @@ extension Vminitd: VirtualMachineAgent {
                         kernelStackBytes: protoStats.memory.kernelStackBytes,
                         slabBytes: protoStats.memory.slabBytes,
                         pageFaults: protoStats.memory.pageFaults,
-                        majorPageFaults: protoStats.memory.majorPageFaults
+                        majorPageFaults: protoStats.memory.majorPageFaults,
+                        inactiveFile: protoStats.memory.inactiveFile,
+                        anon: protoStats.memory.anon
                     ) : nil,
                 cpu: categories.contains(.cpu) && protoStats.hasCpu
                     ? .init(

--- a/vminitd/Sources/vminitd/Server+GRPC.swift
+++ b/vminitd/Sources/vminitd/Server+GRPC.swift
@@ -1356,6 +1356,8 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContextAsyncProvid
                     $0.slabBytes = memory.slab
                     $0.pageFaults = memory.pgfault
                     $0.majorPageFaults = memory.pgmajfault
+                    $0.inactiveFile = memory.inactiveFile
+                    $0.anon = memory.anon
                 }
             }
 


### PR DESCRIPTION
These two stats are import to calculate the following
- wss bytes (memory usage - inactive files)
- rss bytes (anonymous memory)
- available bytes (limit - wss bytes)

Just exposing these two in `SandboxContext.proto` as we already collect them in `readMemoryStats()` in `Cgroup2Manager`