### PR TITLE
fix: explicit cast SHUT_WR and SHUT_RDWR to Int32

### DIFF
--- a/Sources/ContainerizationOS/Socket/BidirectionalRelay.swift
+++ b/Sources/ContainerizationOS/Socket/BidirectionalRelay.swift
@@ -181,7 +181,7 @@ public final class BidirectionalRelay: Sendable {
                     ]
                 )
                 source.cancel()
-                if shutdown(destinationFd, SHUT_WR) != 0 {
+                if shutdown(destinationFd, Int32(SHUT_WR)) != 0 {
                     log?.debug(
                         "failed to shut down writes",
                         metadata: [
@@ -214,7 +214,7 @@ public final class BidirectionalRelay: Sendable {
             log?.error("file descriptor copy failed \(error)")
             if !source.isCancelled {
                 source.cancel()
-                if shutdown(destinationFd, SHUT_RDWR) != 0 {
+                if shutdown(destinationFd, Int32(SHUT_RDWR)) != 0 {
                     log?.warning(
                         "failed to shut down destination after I/O error",
                         metadata: [


### PR DESCRIPTION
This is needed in order to make sure containerization compiles successfully in linux