### PR TITLE
Downgrade a relay error to a warning

### DIFF
--- a/Sources/ContainerizationOS/Socket/BidirectionalRelay.swift
+++ b/Sources/ContainerizationOS/Socket/BidirectionalRelay.swift
@@ -211,7 +211,14 @@ public final class BidirectionalRelay: Sendable {
                 to: destinationFd
             )
         } catch {
-            log?.warning("file descriptor copy failed \(error)")
+            log?.warning(
+                "file descriptor copy failed",
+                metadata: [
+                    "error": "\(error)",
+                    "sourceFd": "\(sourceFd)",
+                    "destinationFd": "\(destinationFd)",
+                ]
+            )
             if !source.isCancelled {
                 source.cancel()
                 if shutdown(destinationFd, Int32(SHUT_RDWR)) != 0 {


### PR DESCRIPTION
This PR downgrades a relay error that might be logged when a connection is closed to a warning. Related PR in container: https://github.com/apple/container/pull/1238