### PR TITLE
fix: use readlink(2) instead of realpath(3) to avoid autofs stalls invirtiofs paths

### DIFF
--- a/Sources/ContainerizationOS/URL+Extensions.swift
+++ b/Sources/ContainerizationOS/URL+Extensions.swift
@@ -50,4 +50,13 @@ extension URL {
     public var isSymlink: Bool {
         (try? resourceValues(forKeys: [.isSymbolicLinkKey]))?.isSymbolicLink == true
     }
+
+    #if os(macOS)
+    public func rawSymlinkTarget() -> String? {
+        var buf = [CChar](repeating: 0, count: Int(PATH_MAX))
+        let len = Darwin.readlink(self.path(percentEncoded: false), &buf, buf.count - 1)
+        guard len > 0 else { return nil }
+        return String(decoding: buf[0..<len].map { UInt8(bitPattern: $0) }, as: UTF8.self)
+    }
+    #endif
 }


### PR DESCRIPTION
When a host directory under `/home/<user>/` is bind-mounted into a container, any code that called `URL.resolvingSymlinksInPath()` on a path inside that directory would stall for 5–10 seconds. macOS intercepts filesystem lookups under `/home/` through its autofs automounter when the code tried to resolve a symlink pointing there, macOS would attempt an automount that never succeeds, timing out after 5–10 seconds.

The fix introduces a `rawSymlinkTarget()` helper on `URL` that uses `readlink(2)` directly. This reads only the raw value stored in the symlink inode — no filesystem traversal, no autofs trigger.