### PR TITLE
Add per-container networking flag to ContainerManager.create()

### DIFF
--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -261,7 +261,9 @@ struct IntegrationSuite: AsyncParsableCommand {
     private func macOS26Tests() -> [Test] {
         if #available(macOS 26.0, *) {
             return [
-                Test("container interface custom MTU", testInterfaceMTU)
+                Test("container interface custom MTU", testInterfaceMTU),
+                Test("container networking disabled", testNetworkingDisabled),
+                Test("container networking enabled", testNetworkingEnabled),
             ]
         }
         return []

--- a/Tests/ContainerizationTests/ContainerManagerTests.swift
+++ b/Tests/ContainerizationTests/ContainerManagerTests.swift
@@ -88,4 +88,66 @@ struct ContainerManagerTests {
             #expect(Bool(false), "unexpected error: \(error)")
         }
     }
+
+    @Test func testNetworkingFalseSkipsInterfaceCreation() async throws {
+        let fm = FileManager.default
+        let root = fm.uniqueTemporaryDirectory(create: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let kernelPath = root.appendingPathComponent("vmlinux")
+        fm.createFile(atPath: kernelPath.path, contents: Data(), attributes: nil)
+        let initfsPath = root.appendingPathComponent("initfs.ext4")
+        fm.createFile(atPath: initfsPath.path, contents: Data(), attributes: nil)
+
+        let kernel = Kernel(path: kernelPath, platform: .linuxArm)
+        let initfs = Mount.block(format: "ext4", source: initfsPath.path, destination: "/")
+
+        // Use NilGatewayNetwork — with networking: true this would throw invalidState,
+        // but with networking: false the network's create() is never called.
+        var manager = try ContainerManager(
+            kernel: kernel,
+            initfs: initfs,
+            root: root,
+            network: NilGatewayNetwork()
+        )
+
+        let tempDir = fm.uniqueTemporaryDirectory()
+        defer { try? fm.removeItem(at: tempDir) }
+
+        let tarPath = Foundation.Bundle.module.url(forResource: "scratch", withExtension: "tar")!
+        let reader = try ArchiveReader(format: .pax, filter: .none, file: tarPath)
+        let rejectedPaths = try reader.extractContents(to: tempDir)
+        #expect(rejectedPaths.isEmpty)
+
+        let images = try await manager.imageStore.load(from: tempDir)
+        let image = images.first!
+
+        let rootfsPath = root.appendingPathComponent("rootfs.ext4")
+        fm.createFile(atPath: rootfsPath.path, contents: Data(), attributes: nil)
+        let rootfs = Mount.block(format: "ext4", source: rootfsPath.path, destination: "/")
+
+        // With networking: false, NilGatewayNetwork.create() is never called,
+        // so we should not get the "missing ipv4 gateway" error.
+        // The container creation will fail for other reasons (dummy VMM), but the
+        // configuration closure should see empty interfaces.
+        var closureWasCalled = false
+        do {
+            _ = try await manager.create(
+                "test-no-networking",
+                image: image,
+                rootfs: rootfs,
+                networking: false
+            ) { config in
+                closureWasCalled = true
+                #expect(config.interfaces.isEmpty)
+                #expect(config.dns == nil)
+            }
+        } catch {
+            // Container creation may fail due to dummy kernel/VMM — that's expected.
+            // The key assertion is in the configuration closure above.
+            let description = String(describing: error)
+            #expect(!description.contains("missing ipv4 gateway"))
+        }
+        #expect(closureWasCalled, "configuration closure must be invoked to validate interfaces")
+    }
 }


### PR DESCRIPTION
This PR adds a `networking: Bool = true` parameter to `ContainerManager.create()` so callers can opt out of network interface creation on a per-container basis.

## Motivation

Currently, `ContainerManager.create()` unconditionally allocates a vmnet network interface for every container (when the manager has a network configured). Some use cases don't need network access and benefit from having it disabled to reduce attack surface.

There's no way to achieve this today without either:
- Initializing the `ContainerManager` without a network (which disables networking for *all* containers)
- Clearing `config.interfaces` in the configuration closure (which wastes an IP allocation from the vmnet pool since `network.create(id)` has already been called)

## Changes

- Add `networking: Bool = true` to all three `create()` overloads on `ContainerManager`
- When `false`, `self.network?.create(id)` is skipped entirely. No interface is allocated, and no DNS is configured.
- `releaseNetwork`/`delete` remain safe to call regardless, since `Allocator.release` silently ignores unknown IDs.
- Add unit test `testNetworkingFalseSkipsInterfaceCreation` using the existing `NilGatewayNetwork` fixture
- Add integration tests `testNetworkingDisabled` and `testNetworkingEnabled` that create containers through a network-enabled `ContainerManager` and verify the presence/absence of `eth0` via `/sys/class/net/`