### PR TITLE
vmexec: Pass through process env for ExecCommand

### DIFF
--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -334,6 +334,7 @@ struct IntegrationSuite: AsyncParsableCommand {
                 Test("container writable layer DNS and hosts", testWritableLayerWithDNSAndHosts),
                 Test("large stdin input", testLargeStdinInput),
                 Test("exec large stdin input", testExecLargeStdinInput),
+                Test("exec custom path resolution", testExecCustomPathResolution),
                 Test("stdin explicit close", testStdinExplicitClose),
                 Test("stdin binary data", testStdinBinaryData),
                 Test("stdin multiple chunks", testStdinMultipleChunks),

--- a/vminitd/Sources/vmexec/ExecCommand.swift
+++ b/vminitd/Sources/vmexec/ExecCommand.swift
@@ -145,7 +145,7 @@ struct ExecCommand: ParsableCommand {
             // Finish capabilities (after user change)
             try App.finishCapabilities(preparedCaps)
 
-            try App.exec(process: process)
+            try App.exec(process: process, currentEnv: process.env)
         } else {  // parent process
             // Send our child's pid to our parent before we exit.
             var childPid = processID


### PR DESCRIPTION
This mirrors the logic already in place for RunCommand and will allow
the PATH environment variable to get picked up properly.
