### PR TITLE
Adds access group to keychain helper APIs.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -76,6 +76,10 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "Containerization",
+                "ContainerizationArchive",
+                "ContainerizationEXT4",
+                "ContainerizationExtras",
+                "ContainerizationOCI",
                 "ContainerizationOS",
             ]
         ),


### PR DESCRIPTION
- Will be used by the fix for apple/container#1253.
- We use a common keychain ID between the `container CLI and `container-core-images`, but right now keychain entries created by the CLI must be opted-in for `container-core-images`.
- Using an access group with a notarized application should give both apps automatic access to the keychain.