### PR TITLE
Remove libzstd imports from ContainerizationArchive.

### DIFF
--- a/Sources/ContainerizationArchive/CArchive/archive_swift_bridge.c
+++ b/Sources/ContainerizationArchive/CArchive/archive_swift_bridge.c
@@ -15,7 +15,54 @@
  */
 
 #include "archive_bridge.h"
+#include <zstd.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 void archive_set_error_wrapper(struct archive *a, int error_number, const char *error_string) {
     archive_set_error(a, error_number, "%s", error_string);
+}
+
+int zstd_decompress_fd(int src_fd, int dst_fd) {
+    ZSTD_DStream *dstream = ZSTD_createDStream();
+    if (!dstream) return 1;
+
+    size_t init_result = ZSTD_initDStream(dstream);
+    if (ZSTD_isError(init_result)) {
+        ZSTD_freeDStream(dstream);
+        return 1;
+    }
+
+    size_t in_size = ZSTD_DStreamInSize();
+    size_t out_size = ZSTD_DStreamOutSize();
+    void *in_buf = malloc(in_size);
+    void *out_buf = malloc(out_size);
+    if (!in_buf || !out_buf) {
+        free(in_buf);
+        free(out_buf);
+        ZSTD_freeDStream(dstream);
+        return 1;
+    }
+
+    int rc = 0;
+    ssize_t bytes_read;
+    while ((bytes_read = read(src_fd, in_buf, in_size)) > 0) {
+        ZSTD_inBuffer input = { in_buf, (size_t)bytes_read, 0 };
+        while (input.pos < input.size) {
+            ZSTD_outBuffer output = { out_buf, out_size, 0 };
+            size_t result = ZSTD_decompressStream(dstream, &output, &input);
+            if (ZSTD_isError(result)) { rc = 1; goto done; }
+            if (output.pos > 0) {
+                ssize_t written = write(dst_fd, out_buf, output.pos);
+                if (written != (ssize_t)output.pos) { rc = 1; goto done; }
+            }
+        }
+    }
+    if (bytes_read < 0) rc = 1;
+
+done:
+    free(in_buf);
+    free(out_buf);
+    ZSTD_freeDStream(dstream);
+    return rc;
 }

--- a/Sources/ContainerizationArchive/CArchive/include/archive_bridge.h
+++ b/Sources/ContainerizationArchive/CArchive/include/archive_bridge.h
@@ -3,5 +3,10 @@
 #pragma once
 
 #include "archive.h"
+#include <stdint.h>
 
 void archive_set_error_wrapper(struct archive *a, int error_number, const char *error_string);
+
+/// Decompress a zstd-compressed file at \p src_fd into \p dst_fd.
+/// Returns 0 on success, or a non-zero error code on failure.
+int zstd_decompress_fd(int src_fd, int dst_fd);


### PR DESCRIPTION
- Closes #532.
- Relocate all zstd calls down into CArchive, and export a function zstd_decompress_fd(src_fd, dst_fd) that ContainerizationArchive can use. This eliminates problems that can occur when treating Swift warnings as errors in Xcode projects that use ContainerizationArchive.