### PR TITLE
Preserve error from ManagedProcess

### DIFF
--- a/vminitd/Sources/vminitd/ManagedProcess.swift
+++ b/vminitd/Sources/vminitd/ManagedProcess.swift
@@ -263,7 +263,8 @@ extension ManagedProcess {
             {
                 throw ContainerizationError(
                     .internalError,
-                    message: "vmexec error: \(errorString.trimmingCharacters(in: .whitespacesAndNewlines))"
+                    message: "vmexec error: \(errorString.trimmingCharacters(in: .whitespacesAndNewlines))",
+                    cause: error
                 )
             }
             throw error


### PR DESCRIPTION
This PR changes `ManagedProcess` to throw its own error together with `vexec` error.

apple/container#1250 reports intermittent failure of CI tests, where the system logs report failing `agent.startProcess` due to the `"read ack pipe"` from `vmexec`.

This `"read ack pipe"` is thrown when writing end of `ackPipe` is closed ([ExecCommand.swift#L88](https://github.com/apple/containerization/blob/main/vminitd/Sources/vmexec/ExecCommand.swift#L88)) as EOF is returned from reading `ackPipe`.

It again means `ManagedProcess` throws an error after forking the `vmexec` process ([ManagedProcess.swift#L165](https://github.com/apple/containerization/blob/main/vminitd/Sources/vminitd/ManagedProcess.swift#L165)).

However, current `ManagedProcess` doesn't throw its error if `errorPipe` has data, which, i.e., `"read ack pipe"`, is actually not the root cause in this case ([ManagedProcess.swift#L244](https://github.com/apple/containerization/blob/main/vminitd/Sources/vminitd/ManagedProcess.swift#L244)).