### PR TITLE
linux pod: exec process should inherit container's process config

### DIFF
--- a/Sources/Containerization/LinuxPod.swift
+++ b/Sources/Containerization/LinuxPod.swift
@@ -778,7 +778,14 @@ extension LinuxPod {
             }
 
             var spec = self.generateRuntimeSpec(containerID: containerID, config: container.config, rootfs: container.rootfs)
-            var config = LinuxProcessConfiguration()
+            // Inherit environment variables, working directory, user, capabilities, rlimits from container process.
+            // Reset: process arguments, terminal, stdio as these are not supposed to be inherited.
+            var config = container.config.process
+            config.arguments = []
+            config.terminal = false
+            config.stdin = nil
+            config.stdout = nil
+            config.stderr = nil
             try configuration(&config)
             spec.process = config.toOCI()
 

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -365,6 +365,7 @@ struct IntegrationSuite: AsyncParsableCommand {
                 Test("pod container output", testPodContainerOutput),
                 Test("pod concurrent containers", testPodConcurrentContainers),
                 Test("pod exec in container", testPodExecInContainer),
+                Test("pod exec in container env", testPodExecInContainerEnv),
                 Test("pod container hostname", testPodContainerHostname),
                 Test("pod container hostname defaults to container id", testPodContainerHostnameDefaultsToContainerID),
                 Test("pod stop container idempotency", testPodStopContainerIdempotency),


### PR DESCRIPTION
This change fixes an issue in linux pod where the exec process
does not inherit the container process config which means any
environment variables, working directory, user, rlimits,
capabilities would be different for the exec process.

This change ensures that exec process would inherit
environment variables, working directory, user, rlimits,
and capabilities from the container process config but
resets arguments, terminal, and stdio as those should not
be inherited.

This change also adds an integration test to exercise this.