### PR TITLE
LinuxContainer/LinuxPod: Fix UDS proxy if target is symlink

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -413,6 +413,10 @@ public final class LinuxContainer: Container, Sendable {
     private static func guestRootfsPath(_ id: String) -> String {
         "/run/container/\(id)/rootfs"
     }
+
+    private static func guestSocketStagingPath(_ containerID: String, socketID: String) -> String {
+        "/run/container/\(containerID)/sockets/\(socketID).sock"
+    }
 }
 
 extension LinuxContainer {
@@ -647,6 +651,19 @@ extension LinuxContainer {
                             source: "/sbin/vminitd",
                             destination: "/.cz-init",
                             options: ["bind", "ro"]
+                        ))
+                }
+
+                // Bind mount staged sockets into the container. Sockets relayed
+                // .into the container are created in a staging directory outside
+                // the rootfs to avoid symlink traversal and mount shadowing.
+                for socket in self.config.sockets where socket.direction == .into {
+                    mounts.append(
+                        ContainerizationOCI.Mount(
+                            type: "bind",
+                            source: Self.guestSocketStagingPath(self.id, socketID: socket.id),
+                            destination: socket.destination.path,
+                            options: ["bind"]
                         ))
                 }
 
@@ -995,22 +1012,6 @@ extension LinuxContainer {
         }
     }
 
-    /// Relay a unix socket from in the container to the host, or from the host
-    /// to inside the container.
-    public func relayUnixSocket(socket: UnixSocketConfiguration) async throws {
-        try await self.state.withLock {
-            let state = try $0.startedState("relayUnixSocket")
-
-            try await state.vm.withAgent { agent in
-                try await self.relayUnixSocket(
-                    socket: socket,
-                    relayManager: state.relayManager,
-                    agent: agent
-                )
-            }
-        }
-    }
-
     private func relayUnixSocket(
         socket: UnixSocketConfiguration,
         relayManager: UnixSocketRelayManager,
@@ -1029,7 +1030,7 @@ extension LinuxContainer {
         let port: UInt32
         if socket.direction == .into {
             port = self.hostVsockPorts.wrappingAdd(1, ordering: .relaxed).oldValue
-            socket.destination = rootInGuest.appending(path: socket.destination.path)
+            socket.destination = URL(filePath: Self.guestSocketStagingPath(self.id, socketID: socket.id))
         } else {
             port = self.guestVsockPorts.wrappingAdd(1, ordering: .relaxed).oldValue
             socket.source = rootInGuest.appending(path: socket.source.path)

--- a/Sources/Containerization/LinuxPod.swift
+++ b/Sources/Containerization/LinuxPod.swift
@@ -254,6 +254,10 @@ public final class LinuxPod: Sendable {
     private static func guestRootfsPath(_ containerID: String) -> String {
         "/run/container/\(containerID)/rootfs"
     }
+
+    private static func guestSocketStagingPath(_ containerID: String, socketID: String) -> String {
+        "/run/container/\(containerID)/sockets/\(socketID).sock"
+    }
 }
 
 extension LinuxPod {
@@ -538,6 +542,19 @@ extension LinuxPod {
                             source: "/sbin/vminitd",
                             destination: "/.cz-init",
                             options: ["bind", "ro"]
+                        ))
+                }
+
+                // Bind mount staged sockets into the container. Sockets relayed
+                // .into the container are created in a staging directory outside
+                // the rootfs to avoid symlink traversal and mount shadowing.
+                for socket in container.config.sockets where socket.direction == .into {
+                    mounts.append(
+                        ContainerizationOCI.Mount(
+                            type: "bind",
+                            source: Self.guestSocketStagingPath(containerID, socketID: socket.id),
+                            destination: socket.destination.path,
+                            options: ["bind"]
                         ))
                 }
 
@@ -897,7 +914,7 @@ extension LinuxPod {
         let port: UInt32
         if socket.direction == .into {
             port = self.hostVsockPorts.wrappingAdd(1, ordering: .relaxed).oldValue
-            socket.destination = rootInGuest.appending(path: socket.destination.path)
+            socket.destination = URL(filePath: Self.guestSocketStagingPath(containerID, socketID: socket.id))
         } else {
             port = self.guestVsockPorts.wrappingAdd(1, ordering: .relaxed).oldValue
             socket.source = rootInGuest.appending(path: socket.source.path)

--- a/Sources/ContainerizationOS/Mount/Mount.swift
+++ b/Sources/ContainerizationOS/Mount/Mount.swift
@@ -156,7 +156,7 @@ extension Mount {
         if isBindMount {
             var sourceStat = stat()
             if stat(self.source, &sourceStat) == 0 {
-                leafIsFile = (sourceStat.st_mode & S_IFMT) == S_IFREG
+                leafIsFile = (sourceStat.st_mode & S_IFMT) != S_IFDIR
             }
         }
 
@@ -317,13 +317,13 @@ extension Mount {
             // For bind mounts, check if the source is a file and create the target accordingly.
             let isBindMount = (originalFlags & Int32(MS_BIND)) != 0
             if isBindMount {
-                var sourceIsFile = false
+                var sourceIsNonDir = false
                 var sourceStat = stat()
                 if stat(self.source, &sourceStat) == 0 {
-                    sourceIsFile = (sourceStat.st_mode & S_IFMT) == S_IFREG
+                    sourceIsNonDir = (sourceStat.st_mode & S_IFMT) != S_IFDIR
                 }
 
-                if sourceIsFile {
+                if sourceIsNonDir {
                     // Create parent directories and touch the target file
                     try mkdirAll(targetParent, 0o755)
                     let fd = open(target, O_WRONLY | O_CREAT, 0o644)

--- a/Sources/Integration/ContainerTests.swift
+++ b/Sources/Integration/ContainerTests.swift
@@ -1161,6 +1161,63 @@ extension IntegrationSuite {
         return dir
     }
 
+    func testUnixSocketIntoGuestSymlink() async throws {
+        let id = "test-unixsocket-into-guest-symlink"
+
+        let bs = try await bootstrap(id)
+
+        let hostSocketPath = try createHostUnixSocket()
+
+        let buffer = BufferWriter()
+        // Use /var/run/test.sock. Alpine has /var/run -> /run symlink
+        let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
+            config.process.arguments = ["sleep", "100"]
+            config.sockets = [
+                UnixSocketConfiguration(
+                    source: URL(filePath: hostSocketPath),
+                    destination: URL(filePath: "/var/run/test.sock"),
+                    direction: .into
+                )
+            ]
+            config.bootLog = bs.bootLog
+        }
+
+        do {
+            try await container.create()
+            try await container.start()
+
+            let lsExec = try await container.exec("ls-socket") { config in
+                config.arguments = ["ls", "-l", "/var/run/test.sock"]
+                config.stdout = buffer
+            }
+
+            try await lsExec.start()
+            let status = try await lsExec.wait()
+            try await lsExec.delete()
+
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "ls command failed with status \(status)")
+            }
+
+            guard let output = String(data: buffer.data, encoding: .utf8) else {
+                throw IntegrationError.assert(msg: "failed to convert ls output to UTF8")
+            }
+
+            // Socket files in ls -l output start with 's'
+            guard output.hasPrefix("s") else {
+                throw IntegrationError.assert(
+                    msg: "expected socket file (starting with 's'), got: \(output)")
+            }
+
+            try await container.kill(SIGKILL)
+            try await container.wait()
+            try await container.stop()
+        } catch {
+            try? await container.stop()
+            throw error
+        }
+    }
+
     func testBootLogFileHandle() async throws {
         let id = "test-bootlog-filehandle"
 

--- a/Sources/Integration/PodTests.swift
+++ b/Sources/Integration/PodTests.swift
@@ -1858,4 +1858,75 @@ extension IntegrationSuite {
             throw IntegrationError.assert(msg: "ps output should contain 'sleep 300', got: '\(output)'")
         }
     }
+
+    func testPodUnixSocketIntoGuestSymlink() async throws {
+        let id = "test-pod-unixsocket-into-guest-symlink"
+
+        let bs = try await bootstrap(id)
+
+        let hostSocketPath = try createPodHostUnixSocket()
+
+        let pod = try LinuxPod(id, vmm: bs.vmm) { config in
+            config.cpus = 4
+            config.memoryInBytes = 1024.mib()
+            config.bootLog = bs.bootLog
+        }
+
+        // Use /var/run/test.sock. Alpine has /var/run -> /run symlink
+        try await pod.addContainer("container1", rootfs: bs.rootfs) { config in
+            config.process.arguments = ["sleep", "100"]
+            config.sockets = [
+                UnixSocketConfiguration(
+                    source: URL(filePath: hostSocketPath),
+                    destination: URL(filePath: "/var/run/test.sock"),
+                    direction: .into
+                )
+            ]
+        }
+
+        do {
+            try await pod.create()
+            try await pod.startContainer("container1")
+
+            let buffer = BufferWriter()
+            let lsExec = try await pod.execInContainer("container1", processID: "ls-socket") { config in
+                config.arguments = ["ls", "-l", "/var/run/test.sock"]
+                config.stdout = buffer
+            }
+
+            try await lsExec.start()
+            let status2 = try await lsExec.wait()
+            try await lsExec.delete()
+
+            guard status2.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "ls command failed with status \(status2)")
+            }
+
+            guard let lsOutput = String(data: buffer.data, encoding: .utf8) else {
+                throw IntegrationError.assert(msg: "failed to convert ls output to UTF8")
+            }
+
+            guard lsOutput.hasPrefix("s") else {
+                throw IntegrationError.assert(
+                    msg: "expected socket file (starting with 's'), got: \(lsOutput)")
+            }
+
+            try await pod.killContainer("container1", signal: SIGKILL)
+            _ = try await pod.waitContainer("container1")
+            try await pod.stop()
+        } catch {
+            try? await pod.stop()
+            throw error
+        }
+    }
+
+    private func createPodHostUnixSocket() throws -> String {
+        let dir = FileManager.default.uniqueTemporaryDirectory(create: true)
+        let socketPath = dir.appendingPathComponent("test.sock").path
+
+        let socket = try Socket(type: UnixType(path: socketPath))
+        try socket.listen()
+
+        return socketPath
+    }
 }

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -313,6 +313,7 @@ struct IntegrationSuite: AsyncParsableCommand {
                 Test("container memory events OOM kill", testMemoryEventsOOMKill),
                 Test("container no serial console", testNoSerialConsole),
                 Test("unix socket into guest", testUnixSocketIntoGuest),
+                Test("unix socket into guest symlink", testUnixSocketIntoGuestSymlink),
                 Test("container non-closure constructor", testNonClosureConstructor),
                 Test("container test large stdio ingest", testLargeStdioOutput),
                 Test("process delete idempotency", testProcessDeleteIdempotency),
@@ -396,6 +397,7 @@ struct IntegrationSuite: AsyncParsableCommand {
                 Test("pod useInit signal forwarding", testPodUseInitSignalForwarding),
                 Test("pod useInit multiple containers", testPodUseInitMultipleContainers),
                 Test("pod useInit with shared PID namespace", testPodUseInitWithSharedPIDNamespace),
+                Test("pod unix socket into guest symlink", testPodUnixSocketIntoGuestSymlink),
             ] + macOS26Tests()
 
         let filteredTests: [Test]


### PR DESCRIPTION
Closes #256

If the target of the uds proxy goes through a symlink (/var/run) we had the same bug we had with mounts previously where we'd follow this and if the resolved path existed in the root of the VM we'd end up mounting there. Fix this by plopping the sockets in a holding spot and then bind mounting them in (which has the correct resolution logic).