### PR TITLE
Fix a potential filesystem corruption on virtio block devices

### DIFF
--- a/Sources/Containerization/Mount.swift
+++ b/Sources/Containerization/Mount.swift
@@ -163,8 +163,8 @@ extension Mount {
 
 extension VZDiskImageStorageDeviceAttachment {
     static func mountToVZAttachment(mount: Mount, options: [String]) throws -> VZDiskImageStorageDeviceAttachment {
-        var cachingMode: VZDiskImageCachingMode = .automatic
         var synchronizationMode: VZDiskImageSynchronizationMode = .fsync
+        var cachingMode: VZDiskImageCachingMode = .cached
 
         for option in options {
             let split = option.split(separator: "=")


### PR DESCRIPTION
Enable the caching mode for virtio block devices to fix a potential filesystem corruption. Also see https://github.com/apple/container/pull/1041.