### PR TITLE
fix: incorrect API usage for symlink entry

### DIFF
--- a/Sources/cctl/RootfsCommand.swift
+++ b/Sources/cctl/RootfsCommand.swift
@@ -172,7 +172,7 @@ extension Application {
                 entry.path = "proc/self/exe"
                 entry.symlinkTarget = "sbin/vminitd"
                 entry.size = nil
-                try writer.writeEntry(entry: entry, data: data)
+                try writer.writeEntry(entry: entry, data: nil)
                 try writer.finishEncoding()
             }
         }


### PR DESCRIPTION
### Summary

`rootfs` create writes proc/self/exe as a symlink, but currently passes the previous regular file buffer to `ArchiveWriter.writeEntry`. This change switches that symlink entry to nil, which matches archive writer expectations.

### Test

Archive tests pass. 