### PR TITLE
Use an explicit path to Swift from Swiftly

### DIFF
--- a/vminitd/Makefile
+++ b/vminitd/Makefile
@@ -97,4 +97,4 @@ clean:
 	@echo Cleaning the vminitd build files...
 	@rm -f ./bin/vminitd
 	@rm -f ./bin/vmexec
-	@$(SWIFT) package clean $(SWIFT_CONFIGURATION)
+	@rm -rf .build


### PR DESCRIPTION
Prior to this change, `make vmintid` failed with `which swift` equals to `/usr/bin/swift`:

> /Users/Dmitry/Apple/containerization/vminitd/.build/checkouts/swift-protobuf/Sources/SwiftProtobuf/AnyMessageStorage.swift:16:8: error: compiled module was created by an older version of the compiler; rebuild 'Foundation' and try again: /Users/Dmitry/Library/org.swift.swiftpm/swift-sdks/swift-6.3-DEVELOPMENT-SNAPSHOT-2026-02-27-a_static-linux-0.1.0.artifactbundle/swift-6.3-DEVELOPMENT-SNAPSHOT-2026-02-27-a_static-linux-0.1.0/swift-linux-musl/musl-1.2.5.sdk/aarch64/usr/lib/swift_static/linux-static/Foundation.swiftmodule/aarch64-swift-linux-musl.swiftmodule

With an explicit path to Swift from Swiftly, `make vminitd` works both with `which swift` equals to `~/.swiftly/bin/swift` or `/usr/bin/swift`.