### PR TITLE
Use the actual path to Swiftly on GitHub runners

### DIFF
--- a/.github/workflows/containerization-build-template.yml
+++ b/.github/workflows/containerization-build-template.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Activate Swiftly
         run: |
-          source /opt/swiftly/env.sh
-          cat /opt/swiftly/env.sh
+          source ~/.swiftly/env.sh
+          cat ~/.swiftly/env.sh
 
       - name: Check formatting
         run: | 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Make vminitd image
         run: |
-          source /opt/swiftly/env.sh
+          source ~/.swiftly/env.sh
           make -C vminitd swift linux-sdk
           make init
         env:


### PR DESCRIPTION
Use the actual path to Swiftly on GitHub runners instead of a link.