### PR TITLE
Remove a double-counted offset in large files

### DIFF
--- a/Sources/ContainerizationEXT4/EXT4+Formatter.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Formatter.swift
@@ -1135,7 +1135,7 @@ extension EXT4 {
                     let offset = i * extentsPerBlock * EXT4.MaxBlocksPerExtent
                     fillExtents(
                         node: &leafNode, numExtents: extentsInBlock, numBlocks: dataBlocks,
-                        start: blocks.start + offset,
+                        start: blocks.start,
                         offset: offset)
                     try withUnsafeLittleEndianBytes(of: leafNode.header) { bytes in
                         try self.handle.write(contentsOf: bytes)


### PR DESCRIPTION
Removes a double-counted offset in large files.

Inside `fillExtents()`, `offset` is already added to `extentStart` in `extentBlock` - no need to have it in `start`:
```
                let extentBlock: UInt32 = offset + i * EXT4.MaxBlocksPerExtent
                let extentStart: UInt32 = start + extentBlock
```

This is the same fix as was suggested previously in https://github.com/apple/containerization/pull/462.