### PR TITLE
Add the vminitd version to the logs

### DIFF
--- a/vminitd/Sources/vminitd/AgentCommand.swift
+++ b/vminitd/Sources/vminitd/AgentCommand.swift
@@ -67,7 +67,7 @@ struct AgentCommand: AsyncParsableCommand {
 
         signal(SIGPIPE, SIG_IGN)
 
-        log.info("vminitd booting")
+        log.info("vminitd booting", metadata: ["version": "\(Application.configuration.version)"])
 
         // Set of mounts necessary to be mounted prior to taking any RPCs.
         // 1. /proc as the sysctl rpc wouldn't make sense if it wasn't there (NOTE: This is done before this method


### PR DESCRIPTION
Adds the vminitd version to the logs.

Switching to a local version of vminitd is non-trivial:

```
-                .define("CZ_VERSION", to: "\"\(scVersion)\""),
+                .define("CZ_VERSION", to: "\"latest\""),
```

Having an additional confirmation of the used version in the logs is vital.