### PR TITLE
Epoll: Remove spurious EINTR/EAGAIN retry loop around epoll_ctl

### DIFF
--- a/Sources/ContainerizationOS/Linux/Epoll.swift
+++ b/Sources/ContainerizationOS/Linux/Epoll.swift
@@ -55,14 +55,8 @@ public final class Epoll: Sendable {
         event.data.fd = fd
 
         try withUnsafeMutablePointer(to: &event) { ptr in
-            while true {
-                if epoll_ctl(self.epollFD, EPOLL_CTL_ADD, fd, ptr) == -1 {
-                    if errno == EAGAIN || errno == EINTR {
-                        continue
-                    }
-                    throw POSIXError.fromErrno()
-                }
-                break
+            guard epoll_ctl(self.epollFD, EPOLL_CTL_ADD, fd, ptr) == 0 else {
+                throw POSIXError.fromErrno()
             }
         }
 


### PR DESCRIPTION
epoll_ctl is not an interruptible syscall, it does not return EINTR or EAGAIN per the man page. The while-true retry loop was dead code modeled after read/write retry patterns that don't apply here.