### PR TITLE
Epoll: Replace Mask typealias with OptionSet struct

### DIFF
--- a/Sources/ContainerizationOS/Linux/Epoll.swift
+++ b/Sources/ContainerizationOS/Linux/Epoll.swift
@@ -23,7 +23,30 @@ import Synchronization
 /// Register file descriptors to receive events via Linux's
 /// epoll syscall surface.
 public final class Epoll: Sendable {
-    public typealias Mask = Int32
+    public struct Mask: OptionSet, Sendable {
+        public let rawValue: UInt32
+        public init(rawValue: UInt32) { self.rawValue = rawValue }
+
+        public static let input = Mask(rawValue: UInt32(bitPattern: EPOLLIN))
+        public static let output = Mask(rawValue: UInt32(bitPattern: EPOLLOUT))
+
+        public var isHangup: Bool {
+            !isDisjoint(with: Mask(rawValue: UInt32(bitPattern: EPOLLHUP) | UInt32(bitPattern: EPOLLERR)))
+        }
+
+        public var isRemoteHangup: Bool {
+            !isDisjoint(with: Mask(rawValue: UInt32(bitPattern: EPOLLRDHUP)))
+        }
+
+        public var readyToRead: Bool {
+            contains(.input)
+        }
+
+        public var readyToWrite: Bool {
+            contains(.output)
+        }
+    }
+
     public typealias Handler = (@Sendable (Mask) -> Void)
 
     private let epollFD: Int32
@@ -41,14 +64,14 @@ public final class Epoll: Sendable {
 
     public func add(
         _ fd: Int32,
-        mask: Int32 = EPOLLIN | EPOLLOUT,  // HUP is always added
+        mask: Mask = [.input, .output],  // HUP is always added
         handler: @escaping Handler
     ) throws {
         guard fcntl(fd, F_SETFL, O_NONBLOCK) == 0 else {
             throw POSIXError.fromErrno()
         }
 
-        let events = EPOLLET | UInt32(bitPattern: mask)
+        let events = EPOLLET | mask.rawValue
 
         var event = epoll_event()
         event.events = events
@@ -106,7 +129,7 @@ public final class Epoll: Sendable {
                 guard let handler = handlers.get(fd) else {
                     continue
                 }
-                handler(Int32(bitPattern: mask))
+                handler(Mask(rawValue: mask))
             }
         }
     }
@@ -157,24 +180,6 @@ public final class Epoll: Sendable {
                 _ = $0.removeValue(forKey: key)
             }
         }
-    }
-}
-
-extension Epoll.Mask {
-    public var isHangup: Bool {
-        (self & (EPOLLHUP | EPOLLERR)) != 0
-    }
-
-    public var isRhangup: Bool {
-        (self & EPOLLRDHUP) != 0
-    }
-
-    public var readyToRead: Bool {
-        (self & EPOLLIN) != 0
-    }
-
-    public var readyToWrite: Bool {
-        (self & EPOLLOUT) != 0
     }
 }
 

--- a/vminitd/Sources/vminitd/IOPair.swift
+++ b/vminitd/Sources/vminitd/IOPair.swift
@@ -118,7 +118,7 @@ final class IOPair: Sendable {
         let readFrom = OSFile(fd: readFromFd)
         let writeTo = OSFile(fd: writeToFd)
 
-        try ProcessSupervisor.default.poller.add(readFromFd, mask: EPOLLIN) { mask in
+        try ProcessSupervisor.default.poller.add(readFromFd, mask: .input) { mask in
             self.io.withLock { io in
                 if io.closed {
                     return

--- a/vminitd/Sources/vminitd/VsockProxy.swift
+++ b/vminitd/Sources/vminitd/VsockProxy.swift
@@ -243,7 +243,7 @@ extension VsockProxy {
                     c.resume()
                 }
 
-                try! ProcessSupervisor.default.poller.add(clientFile.fileDescriptor, mask: EPOLLIN | EPOLLOUT) { mask in
+                try! ProcessSupervisor.default.poller.add(clientFile.fileDescriptor, mask: [.input, .output]) { mask in
                     if mask.readyToRead && !eofFromClient {
                         let (fromEof, toEof) = Self.transferData(
                             fromFile: &clientFile,
@@ -269,7 +269,7 @@ extension VsockProxy {
                     if mask.isHangup {
                         eofFromClient = true
                         eofFromServer = true
-                    } else if mask.isRhangup && !eofFromClient {
+                    } else if mask.isRemoteHangup && !eofFromClient {
                         // half close, shut down client to server transfer
                         // we should see no more EPOLLIN events on the client fd
                         // and no more EPOLLOUT events on the server fd
@@ -295,7 +295,7 @@ extension VsockProxy {
                     }
                 }
 
-                try! ProcessSupervisor.default.poller.add(serverFile.fileDescriptor, mask: EPOLLIN | EPOLLOUT) { mask in
+                try! ProcessSupervisor.default.poller.add(serverFile.fileDescriptor, mask: [.input, .output]) { mask in
                     if mask.readyToRead && !eofFromServer {
                         let (fromEof, toEof) = Self.transferData(
                             fromFile: &serverFile,
@@ -321,7 +321,7 @@ extension VsockProxy {
                     if mask.isHangup {
                         eofFromClient = true
                         eofFromServer = true
-                    } else if mask.isRhangup && !eofFromServer {
+                    } else if mask.isRemoteHangup && !eofFromServer {
                         // half close, shut down server to client transfer
                         // we should see no more EPOLLIN events on the server fd
                         // and no more EPOLLOUT events on the client fd


### PR DESCRIPTION
Mask was a typealias for Int32, which meant the extension properties (isHangup, readyToRead, etc.) polluted every Int32 in the program and provided no type safety. Replace with a proper OptionSet struct.

Also rename isRhangup to isRemoteHangup for clarity.