### PR TITLE
Epoll: Close epoll fd if pipe registration fails during init

### DIFF
--- a/Sources/ContainerizationOS/Linux/Epoll.swift
+++ b/Sources/ContainerizationOS/Linux/Epoll.swift
@@ -36,7 +36,12 @@ public final class Epoll: Sendable {
             throw POSIXError.fromErrno()
         }
         self.epollFD = efd
-        try self.add(pipe.fileHandleForReading.fileDescriptor) { _ in }
+        do {
+            try self.add(pipe.fileHandleForReading.fileDescriptor) { _ in }
+        } catch {
+            close(efd)
+            throw error
+        }
     }
 
     public func add(


### PR DESCRIPTION
If epoll_create1 succeeds but the subsequent self.add() throws (e.g. fcntl or epoll_ctl fails), the initializer throws without closing the epoll fd. Swift does not call deinit on partially-initialized objects, so the fd leaks.