### PR TITLE
Cgroup2: Map OCI spec unlimited sentinel values to "max"

### DIFF
--- a/vminitd/Sources/Cgroup/Cgroup2Manager.swift
+++ b/vminitd/Sources/Cgroup/Cgroup2Manager.swift
@@ -206,29 +206,31 @@ package struct Cgroup2Manager: Sendable {
             ])
 
         if let memory = resources.memory, let limit = memory.limit {
+            // The OCI spec defines -1 as unlimited; cgroup v2 expects "max".
+            let value = limit < 0 ? "max" : String(limit)
             try Self.writeValue(
                 path: self.path,
-                value: String(limit),
+                value: value,
                 fileName: "memory.max"
             )
         }
 
-        if let cpu = resources.cpu {
-            if let quota = cpu.quota, let period = cpu.period {
-                // cpu.max format is "quota period"
-                let value = "\(quota) \(period)"
-                try Self.writeValue(
-                    path: self.path,
-                    value: value,
-                    fileName: "cpu.max"
-                )
-            }
+        if let cpu = resources.cpu, let quota = cpu.quota, let period = cpu.period {
+            // cpu.max format is "quota period"
+            let value = "\(quota) \(period)"
+            try Self.writeValue(
+                path: self.path,
+                value: value,
+                fileName: "cpu.max"
+            )
         }
 
         if let pids = resources.pids {
+            // The OCI spec defines -1 as unlimited; cgroup v2 expects "max".
+            let value = pids.limit < 0 ? "max" : String(pids.limit)
             try Self.writeValue(
                 path: self.path,
-                value: String(pids.limit),
+                value: value,
                 fileName: "pids.max"
             )
         }


### PR DESCRIPTION
The OCI runtime spec uses -1 for memory.limit and pids.limit to mean "unlimited". The cgroup v2 kernel interface rejects literal "-1" and expects the string "max" instead, causing EINVAL on container startup. Translate negative values to "max" before writing.

Also flatten a needlessly nested `if let` in the CPU resource block.