### PR TITLE
ContainerizationExt4: Remove unneeded os guards

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,7 @@ let package = Package(
                 "ContainerizationOS",
                 "ContainerizationIO",
                 "ContainerizationExtras",
-                .target(name: "ContainerizationEXT4", condition: .when(platforms: [.macOS])),
+                "ContainerizationEXT4",
             ],
             exclude: [
                 "../Containerization/SandboxContext/SandboxContext.proto"
@@ -105,7 +105,7 @@ let package = Package(
         .target(
             name: "ContainerizationEXT4",
             dependencies: [
-                .target(name: "ContainerizationArchive", condition: .when(platforms: [.macOS])),
+                "ContainerizationArchive",
                 .product(name: "SystemPackage", package: "swift-system"),
                 "ContainerizationOS",
             ],

--- a/Sources/ContainerizationEXT4/EXT4+Formatter.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Formatter.swift
@@ -90,7 +90,7 @@ extension EXT4 {
             ///    checker).
 
             if !FileManager.default.fileExists(atPath: devicePath.description) {
-                FileManager.default.createFile(atPath: devicePath.description, contents: nil)
+                _ = FileManager.default.createFile(atPath: devicePath.description, contents: nil)
             }
             guard let fileHandle = FileHandle(forWritingTo: devicePath) else {
                 throw Error.notFound(devicePath)
@@ -952,7 +952,7 @@ extension EXT4 {
                     contentsOf: Array<UInt8>.init(repeating: 0, count: Int(EXT4.InodeSize) - inodeSize))
             }
             let tableSize: UInt64 = UInt64(EXT4.InodeSize) * blockGroups * inodesPerGroup
-            let rest = tableSize - uint32(self.inodes.count) * EXT4.InodeSize
+            let rest = tableSize - UInt64(self.inodes.count) * EXT4.InodeSize
             let zeroBlock = Array<UInt8>.init(repeating: 0, count: Int(self.blockSize))
             for _ in 0..<(rest / self.blockSize) {
                 try self.handle.write(contentsOf: zeroBlock)

--- a/Sources/ContainerizationEXT4/EXT4Reader+Export.swift
+++ b/Sources/ContainerizationEXT4/EXT4Reader+Export.swift
@@ -14,7 +14,6 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-#if os(macOS)
 import ContainerizationArchive
 import Foundation
 import SystemPackage
@@ -36,7 +35,7 @@ extension EXT4.EXT4Reader {
             let entry = WriteEntry()
             let mode = inode.mode
             let size: UInt64 = (UInt64(inode.sizeHigh) << 32) | UInt64(inode.sizeLow)
-            entry.permissions = mode
+            entry.permissions = mode_t(mode)
             guard let path = item.path else {
                 continue
             }
@@ -153,7 +152,7 @@ extension EXT4.EXT4Reader {
             let entry = WriteEntry()
             entry.path = path.description
             entry.hardlink = targetPath.description
-            entry.permissions = inode.mode
+            entry.permissions = mode_t(inode.mode)
             entry.group = gid_t(inode.gid)
             entry.owner = uid_t(inode.uid)
             entry.creationDate = Date(fsTimestamp: UInt64(inode.crtimeExtra) << 32 | UInt64(inode.crtime))
@@ -214,4 +213,3 @@ extension Date {
         self = Date(timeIntervalSince1970: Double(seconds) + nanoseconds)
     }
 }
-#endif

--- a/Sources/ContainerizationEXT4/Formatter+Unpack.swift
+++ b/Sources/ContainerizationEXT4/Formatter+Unpack.swift
@@ -14,12 +14,11 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-#if os(macOS)
 import ContainerizationArchive
-import Foundation
-import ContainerizationOS
-import SystemPackage
 import ContainerizationExtras
+import ContainerizationOS
+import Foundation
+import SystemPackage
 
 private typealias Hardlinks = [FilePath: FilePath]
 
@@ -75,12 +74,12 @@ extension EXT4.Formatter {
             switch entry.fileType {
             case .directory:
                 try self.create(
-                    path: path, mode: EXT4.Inode.Mode(.S_IFDIR, entry.permissions), ts: ts, uid: entry.owner,
+                    path: path, mode: EXT4.Inode.Mode(.S_IFDIR, UInt16(entry.permissions)), ts: ts, uid: entry.owner,
                     gid: entry.group,
                     xattrs: entry.xattrs)
             case .regular:
                 try self.create(
-                    path: path, mode: EXT4.Inode.Mode(.S_IFREG, entry.permissions), ts: ts, buf: streamReader,
+                    path: path, mode: EXT4.Inode.Mode(.S_IFREG, UInt16(entry.permissions)), ts: ts, buf: streamReader,
                     uid: entry.owner,
                     gid: entry.group, xattrs: entry.xattrs, fileBuffer: reusableBuffer)
 
@@ -98,7 +97,7 @@ extension EXT4.Formatter {
                     symlinkTarget = FilePath(target)
                 }
                 try self.create(
-                    path: path, link: symlinkTarget, mode: EXT4.Inode.Mode(.S_IFLNK, entry.permissions), ts: ts,
+                    path: path, link: symlinkTarget, mode: EXT4.Inode.Mode(.S_IFLNK, UInt16(entry.permissions)), ts: ts,
                     uid: entry.owner,
                     gid: entry.group, xattrs: entry.xattrs)
             default:
@@ -193,4 +192,3 @@ extension Hardlinks {
         return next
     }
 }
-#endif


### PR DESCRIPTION
There was some platform (darwin) specific guards in this package that didn't make sense.