### PR TITLE
Hash: Make package visibility/remove ifdef

### DIFF
--- a/Sources/Containerization/AttachedFilesystem.swift
+++ b/Sources/Containerization/AttachedFilesystem.swift
@@ -28,7 +28,6 @@ public struct AttachedFilesystem: Sendable {
     /// The options to use when mounting the filesystem.
     public var options: [String]
 
-    #if os(macOS)
     public init(mount: Mount, allocator: any AddressAllocator<Character>) throws {
         switch mount.type {
         case "virtiofs":
@@ -44,7 +43,6 @@ public struct AttachedFilesystem: Sendable {
         self.options = mount.options
         self.destination = mount.destination
     }
-    #endif
 
     public init(type: String, source: String, destination: String, options: [String]) {
         self.type = type

--- a/Sources/Containerization/Hash.swift
+++ b/Sources/Containerization/Hash.swift
@@ -14,13 +14,11 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-#if os(macOS)
-
-import Crypto
 import ContainerizationError
+import Crypto
 import Foundation
 
-public func hashMountSource(source: String) throws -> String {
+package func hashMountSource(source: String) throws -> String {
     // Resolve symlinks so different paths to the same directory get the same hash.
     let resolvedSource = URL(fileURLWithPath: source).resolvingSymlinksInPath().path
     guard let data = resolvedSource.data(using: .utf8) else {
@@ -28,5 +26,3 @@ public func hashMountSource(source: String) throws -> String {
     }
     return String(SHA256.hash(data: data).encoded.prefix(36))
 }
-
-#endif


### PR DESCRIPTION
These build fine on Linux, and I don't honestly know why we had hashMountSource as public API..