### PR TITLE
Improve documentation formatting and consistency

### DIFF
--- a/examples/ctr-example/README.md
+++ b/examples/ctr-example/README.md
@@ -22,8 +22,10 @@ You should now see the `vmlinux` image in examples/ctr-example
 
 ### 2. Build/Run ctr-example
 
-From examples/ctr-example run
-`make all`
+From examples/ctr-example run:
+```bash
+make all
+```
 
 > [!WARNING]
 > If you get the following error, try building from the default macOS terminal:

--- a/examples/ctr-example/lab.md
+++ b/examples/ctr-example/lab.md
@@ -14,7 +14,7 @@ This'll install your kernel.
 
 After this start your first container. On first launch, this'll install another artifact for our guest init process:
 
-```
+```bash
 container run alpine uname
 ```
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -3,7 +3,7 @@
 This directory includes an optimized kernel configuration to produce a fast and lightweight kernel for container use.
 
 - `config-arm64` includes the kernel `CONFIG_` options.
-- `Makefile` includes the kernel version and source package url.
+- `Makefile` includes the kernel version and source package URL.
 - `build.sh` scripts the kernel build process.
 - `image/` includes the configuration for an image with build tooling.
 


### PR DESCRIPTION
Small documentation improvements for better consistency:

- Fixed capitalization (url → URL) in kernel README
- Added bash syntax highlighting to code block in lab.md  
- Improved formatting consistency in ctr-example README (added colon + code fence)