### PR TITLE
Fix a force-unwrap crash on the last leaf of an extent tree

### DIFF
--- a/Sources/ContainerizationEXT4/EXT4+Formatter.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Formatter.swift
@@ -1101,7 +1101,7 @@ extension EXT4 {
                     }
                 }
             case 5..<4 * UInt32(extentsPerBlock) + 1:
-                let extentBlocks = numExtents / extentsPerBlock + 1
+                let extentBlocks = (numExtents + extentsPerBlock - 1) / extentsPerBlock
                 usedBlocks += extentBlocks
                 let extentHeader = ExtentHeader(
                     magic: EXT4.ExtentHeaderMagic,


### PR DESCRIPTION
Fixes a force-unwrap crash on the last leaf of an extent tree:

> ContainerizationEXT4/EXT4+Formatter.swift:1148: Fatal error: Unexpectedly found nil while unwrapping an Optional value