### PR TITLE
make default goal compile on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,14 @@ KATA_BINARY_PACKAGE := https://github.com/kata-containers/kata-containers/releas
 include Protobuf.Makefile
 .DEFAULT_GOAL := all
 
+.PHONY: deps
+deps:
+ifeq ($(UNAME_S),Linux)
+	sudo apt-get install -y libarchive-dev libbz2-dev liblzma-dev libssl-dev
+else
+	@echo "No additional dependencies required on $(UNAME_S)"
+endif
+
 .PHONY: all
 all: containerization
 all: init
@@ -57,11 +65,13 @@ containerization:
 	@echo Copying containerization binaries...
 	@mkdir -p bin
 	@install "$(BUILD_BIN_DIR)/cctl" ./bin/
+ifeq ($(UNAME_S),Darwin)
 	@install "$(BUILD_BIN_DIR)/containerization-integration" ./bin/
 
 	@echo Signing containerization binaries...
 	@codesign --force --sign - --timestamp=none --entitlements=signing/vz.entitlements bin/cctl
 	@codesign --force --sign - --timestamp=none --entitlements=signing/vz.entitlements bin/containerization-integration
+endif
 
 .PHONY: init
 init: containerization vminitd

--- a/Package.swift
+++ b/Package.swift
@@ -84,15 +84,6 @@ let package = Package(
                 "ContainerizationOS",
             ]
         ),
-        .executableTarget(
-            name: "containerization-integration",
-            dependencies: [
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                "Containerization",
-            ],
-            path: "Sources/Integration"
-        ),
         .testTarget(
             name: "ContainerizationUnitTests",
             dependencies: ["Containerization"],
@@ -266,3 +257,17 @@ let package = Package(
         ),
     ]
 )
+
+#if os(macOS)
+package.targets.append(
+    .executableTarget(
+        name: "containerization-integration",
+        dependencies: [
+            .product(name: "Logging", package: "swift-log"),
+            .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            "Containerization",
+        ],
+        path: "Sources/Integration"
+    )
+)
+#endif

--- a/Sources/Containerization/Image/Unpacker/EXT4Unpacker.swift
+++ b/Sources/Containerization/Image/Unpacker/EXT4Unpacker.swift
@@ -14,16 +14,13 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerizationArchive
+import ContainerizationEXT4
 import ContainerizationError
 import ContainerizationExtras
 import ContainerizationOCI
 import Foundation
-
-#if os(macOS)
-import ContainerizationArchive
-import ContainerizationEXT4
 import SystemPackage
-#endif
 
 public struct EXT4Unpacker: Unpacker {
     let blockSizeInBytes: UInt64
@@ -32,7 +29,6 @@ public struct EXT4Unpacker: Unpacker {
         self.blockSizeInBytes = blockSizeInBytes
     }
 
-    #if os(macOS)
     /// Performs the unpacking of a tar archive into a filesystem.
     /// - Parameters:
     ///   - archive: The archive to unpack.
@@ -56,7 +52,6 @@ public struct EXT4Unpacker: Unpacker {
             compression: compression
         )
     }
-    #endif
 
     /// Returns a `Mount` point after unpacking the image into a filesystem.
     /// - Parameters:
@@ -70,9 +65,6 @@ public struct EXT4Unpacker: Unpacker {
         at path: URL,
         progress: ProgressHandler? = nil
     ) async throws -> Mount {
-        #if !os(macOS)
-        throw ContainerizationError(.unsupported, message: "cannot unpack an image on current platform")
-        #else
         let cleanedPath = try prepareUnpackPath(path: path)
         let manifest = try await image.manifest(for: platform)
         let filesystem = try EXT4.Formatter(
@@ -144,7 +136,6 @@ public struct EXT4Unpacker: Unpacker {
             destination: "/",
             options: []
         )
-        #endif
     }
 
     private func prepareUnpackPath(path: URL) throws -> String {
@@ -155,7 +146,6 @@ public struct EXT4Unpacker: Unpacker {
         return blockPath
     }
 
-    #if os(macOS)
     private func compressionFilter(for mediaType: String) throws -> ContainerizationArchive.Filter {
         switch mediaType {
         case MediaTypes.imageLayer, MediaTypes.dockerImageLayer:
@@ -168,5 +158,4 @@ public struct EXT4Unpacker: Unpacker {
             throw ContainerizationError(.unsupported, message: "media type \(mediaType) not supported.")
         }
     }
-    #endif
 }

--- a/Sources/Integration/ContainerTests.swift
+++ b/Sources/Integration/ContainerTests.swift
@@ -1294,12 +1294,12 @@ extension IntegrationSuite {
                 config.stderr = stderrBuffer
             }
 
-            let started = CFAbsoluteTimeGetCurrent()
+            let started = Date().timeIntervalSinceReferenceDate
 
             try await exec.start()
             let status = try await exec.wait()
 
-            let lasted = CFAbsoluteTimeGetCurrent() - started
+            let lasted = Date().timeIntervalSinceReferenceDate - started
             print("Test \(id) finished process ingesting stdio in \(lasted)")
 
             guard status.exitCode == 0 else {

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -282,7 +282,7 @@ struct IntegrationSuite: AsyncParsableCommand {
     // Hopefully this improves over time.
     func run() async throws {
         try Self.adjustLimits()
-        let suiteStarted = CFAbsoluteTimeGetCurrent()
+        let suiteStarted = Date().timeIntervalSinceReferenceDate
         log.info("starting integration suite\n")
 
         let tests: [Test] =
@@ -439,9 +439,9 @@ struct IntegrationSuite: AsyncParsableCommand {
                         do {
                             log.info("test \(job.name) started...")
 
-                            let started = CFAbsoluteTimeGetCurrent()
+                            let started = Date().timeIntervalSinceReferenceDate
                             try await job.work()
-                            let lasted = CFAbsoluteTimeGetCurrent() - started
+                            let lasted = Date().timeIntervalSinceReferenceDate - started
 
                             log.info("✅ test \(job.name) complete in \(lasted)s.")
                             passed.add(1, ordering: .relaxed)
@@ -460,7 +460,7 @@ struct IntegrationSuite: AsyncParsableCommand {
         let passedCount = passed.load(ordering: .acquiring)
         let skippedCount = skipped.load(ordering: .acquiring)
 
-        let ended = CFAbsoluteTimeGetCurrent() - suiteStarted
+        let ended = Date().timeIntervalSinceReferenceDate - suiteStarted
         var finishingText = "\n\nIntegration suite completed in \(ended)s with \(passedCount)/\(filteredTests.count) passed"
         if skipped.load(ordering: .acquiring) > 0 {
             finishingText += " and \(skippedCount)/\(filteredTests.count) skipped"

--- a/Sources/cctl/ImageCommand.swift
+++ b/Sources/cctl/ImageCommand.swift
@@ -22,6 +22,7 @@ import ContainerizationExtras
 import ContainerizationOCI
 import Foundation
 
+#if os(macOS)
 extension Application {
     struct Images: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
@@ -292,3 +293,4 @@ extension Application {
         }
     }
 }
+#endif

--- a/Sources/cctl/LoginCommand.swift
+++ b/Sources/cctl/LoginCommand.swift
@@ -21,6 +21,7 @@ import ContainerizationExtras
 import ContainerizationOCI
 import Foundation
 
+#if os(macOS)
 extension Application {
     struct Login: AsyncParsableCommand {
 
@@ -84,3 +85,4 @@ extension Application {
         }
     }
 }
+#endif

--- a/Sources/cctl/RunCommand.swift
+++ b/Sources/cctl/RunCommand.swift
@@ -22,6 +22,7 @@ import ContainerizationOCI
 import ContainerizationOS
 import Foundation
 
+#if os(macOS)
 extension Application {
     struct Run: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
@@ -192,3 +193,4 @@ extension Application {
         }()
     }
 }
+#endif

--- a/Sources/cctl/cctl.swift
+++ b/Sources/cctl/cctl.swift
@@ -61,12 +61,19 @@ struct Application: AsyncParsableCommand {
         commandName: "cctl",
         abstract: "Utility CLI for Containerization",
         version: "2.0.0",
-        subcommands: [
-            Images.self,
-            Login.self,
-            Rootfs.self,
-            Run.self,
-        ]
+        subcommands: {
+            var commands: [any ParsableCommand.Type] = [
+                Rootfs.self
+            ]
+            #if os(macOS)
+            commands += [
+                Images.self,
+                Login.self,
+                Run.self,
+            ]
+            #endif
+            return commands
+        }()
     )
 }
 

--- a/Tests/ContainerizationExtrasTests/TestIPv6Address+Parse.swift
+++ b/Tests/ContainerizationExtrasTests/TestIPv6Address+Parse.swift
@@ -161,7 +161,7 @@ struct IPv6AddressParseTests {
         let testInput = "FFFF"
 
         // Measure performance of parsing operation
-        let startTime = CFAbsoluteTimeGetCurrent()
+        let startTime = Date().timeIntervalSinceReferenceDate
         let count = 10000
         for _ in 0..<count {
             let utf8 = testInput.utf8
@@ -171,7 +171,7 @@ struct IPv6AddressParseTests {
             )
         }
 
-        let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
+        let timeElapsed = Date().timeIntervalSinceReferenceDate - startTime
 
         // Expect parsing to be reasonably fast (less than 1ms per operation on average)
         print("Parsed \(count) IPv6 addresses in \(timeElapsed)s")

--- a/vminitd/Makefile
+++ b/vminitd/Makefile
@@ -18,19 +18,32 @@ export GIT_COMMIT := $(shell git rev-parse HEAD)
 export GIT_TAG := $(shell git describe --tags --exact-match 2>/dev/null || echo "")
 export BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 SWIFT_WARNING_CONFIG := $(if $(filter-out false,$(WARNINGS_AS_ERRORS)),-Xswiftc -warnings-as-errors)
-SWIFT_CONFIGURATION := --swift-sdk aarch64-swift-linux-musl $(SWIFT_WARNING_CONFIG) -Xlinker -s --disable-automatic-resolution
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_M),arm64)
+MUSL_ARCH := aarch64
+else ifeq ($(UNAME_M),aarch64)
+MUSL_ARCH := aarch64
+else
+MUSL_ARCH := x86_64
+endif
+
+SWIFT_CONFIGURATION := --swift-sdk $(MUSL_ARCH)-swift-linux-musl $(SWIFT_WARNING_CONFIG) -Xlinker -s --disable-automatic-resolution
 
 SWIFT_VERSION := 6.3
 SWIFT_SDK_URL := https://download.swift.org/swift-6.3-release/static-sdk/swift-6.3-RELEASE/swift-6.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz
 SWIFT_SDK_PATH := /tmp/$(notdir $(SWIFT_SDK_URL))
 
+SYSTEM_TYPE := $(shell uname -s)
+ifeq ($(SYSTEM_TYPE),Darwin)
 SWIFTLY_URL := https://download.swift.org/swiftly/darwin/swiftly.pkg
 SWIFTLY_FILENAME := $(notdir $(SWIFTLY_URL))
 SWIFTLY_BIN_DIR ?= ~/.swiftly/bin
 SWIFT := $(SWIFTLY_BIN_DIR)/swift
+else
+SWIFT ?= swift
+endif
 BUILD_BIN_DIR := $(shell $(SWIFT) build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --show-bin-path)
 
-SYSTEM_TYPE := $(shell uname -s)
 ifeq ($(SYSTEM_TYPE),Darwin)
 MACOS_VERSION := $(shell sw_vers -productVersion)
 MACOS_MAJOR := $(shell echo $(MACOS_VERSION) | cut -d. -f1)


### PR DESCRIPTION
To be able to test vminitd/vmexec/linux specific packages on ci it'd be a heck of a lot easier if `make` just worked. This should be the last bit needed. The default goal currently compiles just fine after the linux specific `make deps` is ran. Next in line would be adding decent unit tests/actually getting ci setup for the linux bits.