### PR TITLE
VirtualMachineInstance: Make default impls public

### DIFF
--- a/Sources/Containerization/VirtualMachineInstance.swift
+++ b/Sources/Containerization/VirtualMachineInstance.swift
@@ -52,10 +52,10 @@ public protocol VirtualMachineInstance: Sendable {
 }
 
 extension VirtualMachineInstance {
-    func pause() async throws {
+    public func pause() async throws {
         throw ContainerizationError(.unsupported, message: "pause")
     }
-    func resume() async throws {
+    public func resume() async throws {
         throw ContainerizationError(.unsupported, message: "resume")
     }
 }


### PR DESCRIPTION
The pause and resume methods need to be public if someone wants to make their own VirtualMachineInstance