### PR TITLE
vminitd: Make everything libc agnostic

### DIFF
--- a/vminitd/Sources/vmexec/Console.swift
+++ b/vminitd/Sources/vmexec/Console.swift
@@ -15,7 +15,14 @@
 //===----------------------------------------------------------------------===//
 
 import FoundationEssentials
+
+#if canImport(Musl)
 import Musl
+private let _close = Musl.close
+#elseif canImport(Glibc)
+import Glibc
+private let _close = Glibc.close
+#endif
 
 class Console {
     let master: Int32
@@ -45,7 +52,7 @@ class Console {
         guard slaveFD != -1 else {
             throw App.Errno(stage: "open_pts")
         }
-        defer { Musl.close(slaveFD) }
+        defer { _ = _close(slaveFD) }
 
         for fd: Int32 in 0...2 {
             guard dup3(slaveFD, fd, 0) != -1 else {
@@ -55,7 +62,7 @@ class Console {
     }
 
     func close() throws {
-        guard Musl.close(self.master) == 0 else {
+        guard _close(self.master) == 0 else {
             throw App.Errno(stage: "close")
         }
     }

--- a/vminitd/Sources/vmexec/ExecCommand.swift
+++ b/vminitd/Sources/vmexec/ExecCommand.swift
@@ -20,8 +20,13 @@ import ContainerizationOS
 import FoundationEssentials
 import LCShim
 import Logging
-import Musl
 import SystemPackage
+
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 struct ExecCommand: ParsableCommand {
     static let configuration = CommandConfiguration(

--- a/vminitd/Sources/vmexec/Mount.swift
+++ b/vminitd/Sources/vmexec/Mount.swift
@@ -17,7 +17,12 @@
 import ContainerizationOCI
 import ContainerizationOS
 import FoundationEssentials
+
+#if canImport(Musl)
 import Musl
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 struct ContainerMount {
     private let mounts: [ContainerizationOCI.Mount]

--- a/vminitd/Sources/vmexec/RunCommand.swift
+++ b/vminitd/Sources/vmexec/RunCommand.swift
@@ -20,8 +20,13 @@ import ContainerizationOCI
 import ContainerizationOS
 import FoundationEssentials
 import LCShim
-import Musl
 import SystemPackage
+
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 struct RunCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
@@ -152,7 +157,7 @@ struct RunCommand: ParsableCommand {
 
         if !spec.hostname.isEmpty {
             let errCode = spec.hostname.withCString { ptr in
-                Musl.sethostname(ptr, spec.hostname.count)
+                sethostname(ptr, spec.hostname.count)
             }
             guard errCode == 0 else {
                 throw App.Errno(stage: "sethostname()")

--- a/vminitd/Sources/vmexec/vmexec.swift
+++ b/vminitd/Sources/vmexec/vmexec.swift
@@ -26,8 +26,13 @@ import ContainerizationOS
 import FoundationEssentials
 import LCShim
 import Logging
-import Musl
 import SystemPackage
+
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 @main
 struct App: ParsableCommand {

--- a/vminitd/Sources/vminitd/AgentCommand.swift
+++ b/vminitd/Sources/vminitd/AgentCommand.swift
@@ -26,7 +26,11 @@ import NIOCore
 import NIOPosix
 
 #if os(Linux)
+#if canImport(Musl)
 import Musl
+#elseif canImport(Glibc)
+import Glibc
+#endif
 import LCShim
 #endif
 
@@ -157,13 +161,13 @@ struct AgentCommand: AsyncParsableCommand {
             log.info("vminitd API returned, syncing filesystems")
 
             #if os(Linux)
-            Musl.sync()
+            sync()
             #endif
         } catch {
             log.error("vminitd boot error \(error)")
 
             #if os(Linux)
-            Musl.sync()
+            sync()
             #endif
 
             _exit(1)

--- a/vminitd/Sources/vminitd/InitCommand.swift
+++ b/vminitd/Sources/vminitd/InitCommand.swift
@@ -17,7 +17,16 @@
 import ArgumentParser
 import ContainerizationOS
 import LCShim
+
+#if canImport(Musl)
 import Musl
+private let _exit = Musl.exit
+private let _kill = Musl.kill
+#elseif canImport(Glibc)
+import Glibc
+private let _exit = Glibc.exit
+private let _kill = Glibc.kill
+#endif
 
 /// A minimal init process that:
 /// - Spawns and monitors a child process
@@ -78,7 +87,7 @@ struct InitCommand: ParsableCommand {
             let sig = sigtimedwait(&allSignals, &siginfo, &timeout)
 
             if sig > 0 && !Self.ignoredSignals.contains(sig) {
-                _ = Musl.kill(signalTarget, sig)
+                _ = _kill(signalTarget, sig)
             }
 
             while true {
@@ -93,6 +102,6 @@ struct InitCommand: ParsableCommand {
             }
         }
 
-        Musl.exit(childExitStatus ?? 1)
+        _exit(childExitStatus ?? 1)
     }
 }

--- a/vminitd/Sources/vminitd/PauseCommand.swift
+++ b/vminitd/Sources/vminitd/PauseCommand.swift
@@ -17,7 +17,14 @@
 import ArgumentParser
 import Dispatch
 import Logging
+
+#if canImport(Musl)
 import Musl
+private let _exit = Musl.exit
+#elseif canImport(Glibc)
+import Glibc
+private let _exit = Glibc.exit
+#endif
 
 struct PauseCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
@@ -39,14 +46,14 @@ struct PauseCommand: ParsableCommand {
         let sigintSource = DispatchSource.makeSignalSource(signal: SIGINT)
         sigintSource.setEventHandler {
             log.info("Shutting down, got SIGINT")
-            Musl.exit(0)
+            _exit(0)
         }
         sigintSource.resume()
 
         let sigtermSource = DispatchSource.makeSignalSource(signal: SIGTERM)
         sigtermSource.setEventHandler {
             log.info("Shutting down, got SIGTERM")
-            Musl.exit(0)
+            _exit(0)
         }
         sigtermSource.resume()
 
@@ -60,10 +67,10 @@ struct PauseCommand: ParsableCommand {
         log.info("pause container running, waiting for signals...")
 
         while true {
-            Musl.pause()
+            _ = pause()
         }
 
         log.error("Error: infinite loop terminated")
-        Musl.exit(42)
+        _exit(42)
     }
 }


### PR DESCRIPTION
Remove the last (as far as I can see..) of the musl specific imports we had.