### PR TITLE
Start converting libraries to use FoundationEssentials

### DIFF
--- a/Sources/ContainerizationOS/AsyncSignalHandler.swift
+++ b/Sources/ContainerizationOS/AsyncSignalHandler.swift
@@ -14,8 +14,16 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import Foundation
+import Dispatch
 import Synchronization
+
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
 
 /// Async friendly wrapper around `DispatchSourceSignal`. Provides an `AsyncStream`
 /// interface to get notified of received signals.

--- a/Sources/ContainerizationOS/File.swift
+++ b/Sources/ContainerizationOS/File.swift
@@ -14,7 +14,19 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import Foundation
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
+
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.URL
+#else
+import struct Foundation.URL
+#endif
 
 /// Trivial type to discover information about a given file (uid, gid, mode...).
 public struct File: Sendable {
@@ -52,7 +64,7 @@ public struct File: Sendable {
 /// `FileInfo` holds and provides easy access to stat(2) data
 /// for a file.
 public struct FileInfo: Sendable {
-    private let _stat_t: Foundation.stat
+    private let _stat_t: stat
     private let _path: String
 
     init(_ path: String, stat: stat) {

--- a/Sources/ContainerizationOS/Keychain/KeychainQuery.swift
+++ b/Sources/ContainerizationOS/Keychain/KeychainQuery.swift
@@ -15,7 +15,11 @@
 //===----------------------------------------------------------------------===//
 
 #if os(macOS)
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// Holds the result of a query to the keychain.
 public struct KeychainQueryResult {

--- a/Sources/ContainerizationOS/Keychain/RegistryInfo.swift
+++ b/Sources/ContainerizationOS/Keychain/RegistryInfo.swift
@@ -14,7 +14,11 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// Holds the stored attributes for a registry.
 public struct RegistryInfo: Sendable {

--- a/Sources/ContainerizationOS/Linux/Binfmt.swift
+++ b/Sources/ContainerizationOS/Linux/Binfmt.swift
@@ -14,7 +14,11 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 #if canImport(Musl)
 import Musl

--- a/Sources/ContainerizationOS/Linux/Capabilities.swift
+++ b/Sources/ContainerizationOS/Linux/Capabilities.swift
@@ -15,7 +15,12 @@
 //===----------------------------------------------------------------------===//
 
 import CShim
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 // MARK: - Configuration Types
 

--- a/Sources/ContainerizationOS/Linux/Epoll.swift
+++ b/Sources/ContainerizationOS/Linux/Epoll.swift
@@ -15,7 +15,11 @@
 //===----------------------------------------------------------------------===//
 
 #if os(Linux)
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 #if canImport(Musl)
 import Musl

--- a/Sources/ContainerizationOS/Mount/Mount.swift
+++ b/Sources/ContainerizationOS/Mount/Mount.swift
@@ -15,7 +15,12 @@
 //===----------------------------------------------------------------------===//
 
 import CShim
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 #if canImport(Musl)
 import Musl

--- a/Sources/ContainerizationOS/POSIXError+Helpers.swift
+++ b/Sources/ContainerizationOS/POSIXError+Helpers.swift
@@ -14,7 +14,19 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 extension POSIXError {
     public static func fromErrno() -> POSIXError {

--- a/Sources/ContainerizationOS/Path.swift
+++ b/Sources/ContainerizationOS/Path.swift
@@ -14,7 +14,11 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// `Path` provides utilities to look for binaries in the current PATH,
 /// or to return the current PATH.

--- a/Sources/ContainerizationOS/Reaper.swift
+++ b/Sources/ContainerizationOS/Reaper.swift
@@ -14,7 +14,18 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// A process reaper that returns exited processes along
 /// with their exit status.

--- a/Sources/ContainerizationOS/Socket/BidirectionalRelay.swift
+++ b/Sources/ContainerizationOS/Socket/BidirectionalRelay.swift
@@ -15,9 +15,23 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerizationError
-import Foundation
+import Dispatch
 import Logging
 import Synchronization
+
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Manages bidirectional data relay between two file descriptors using `DispatchSource`.
 public final class BidirectionalRelay: Sendable {

--- a/Sources/ContainerizationOS/Sysctl.swift
+++ b/Sources/ContainerizationOS/Sysctl.swift
@@ -14,7 +14,14 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+#if canImport(Darwin)
+import Darwin
+#endif
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// Helper type to deal with system control functionalities.
 public struct Sysctl {

--- a/Sources/ContainerizationOS/URL+Extensions.swift
+++ b/Sources/ContainerizationOS/URL+Extensions.swift
@@ -14,7 +14,19 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
+
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
 
 /// The `resolvingSymlinksInPath` method of the `URL` struct does not resolve the symlinks
 /// for directories under `/private` which include`tmp`, `var` and `etc`
@@ -34,9 +46,11 @@ extension URL {
         let parts = url.pathComponents
         if parts.count > 1 {
             if (parts.first == "/") && ["tmp", "var", "etc"].contains(parts[1]) {
-                if let resolved = NSURL.fileURL(withPathComponents: ["/", "private"] + parts[1...]) {
-                    return resolved
+                var resolved = URL(filePath: "/private")
+                for part in parts[1...] {
+                    resolved.append(path: part)
                 }
+                return resolved
             }
         }
         #endif
@@ -44,10 +58,14 @@ extension URL {
     }
 
     public var isDirectory: Bool {
-        (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+        var st = stat()
+        guard stat(self.path, &st) == 0 else { return false }
+        return (st.st_mode & S_IFMT) == S_IFDIR
     }
 
     public var isSymlink: Bool {
-        (try? resourceValues(forKeys: [.isSymbolicLinkKey]))?.isSymbolicLink == true
+        var st = stat()
+        guard lstat(self.path, &st) == 0 else { return false }
+        return (st.st_mode & S_IFMT) == S_IFLNK
     }
 }

--- a/Sources/ContainerizationOS/User.swift
+++ b/Sources/ContainerizationOS/User.swift
@@ -15,7 +15,12 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerizationError
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// `User` provides utilities to ensure that a given username exists in
 /// /etc/passwd (and /etc/group). Largely inspired by runc (and moby's)


### PR DESCRIPTION
This helps on binary size if we can successfully get all Foundation imports out of our dep chain. It seems Foundation brings in a 30MiB ICU blob, which bloats vmexec and vminitd.