### PR TITLE
vminitd (client): Turn off idle timeout

### DIFF
--- a/Sources/Containerization/Vminitd.swift
+++ b/Sources/Containerization/Vminitd.swift
@@ -108,6 +108,7 @@ public struct Vminitd: Sendable {
             .withConnectedSocket(connection.fileDescriptor).wait()
         let transport = HTTP2ClientTransport.WrappedChannel.wrapping(
             channel: channel,
+            config: .defaults { $0.connection.maxIdleTime = nil }
         )
         let grpcClient = GRPCClient(transport: transport)
         self.grpcClient = grpcClient


### PR DESCRIPTION
Closes: #678

There's no reason to have an idle timeout per connection as users may use this library in many different ways. The grpc lib defaults to a 30 min idle timeout which could be trivially reached if instead of waiting on the init process, you were waiting on a bunch of execs. NIO under the hood asserts on ebadfs (which is good, but bad for this scenario..), so lets turn off the timeout altogether.