### PR TITLE
Set memory.low for vminitd to avoid kernel reclaiming its memory

### DIFF
--- a/vminitd/Sources/Cgroup/Cgroup2Manager.swift
+++ b/vminitd/Sources/Cgroup/Cgroup2Manager.swift
@@ -252,6 +252,21 @@ package struct Cgroup2Manager: Sendable {
         )
     }
 
+    package func setMemoryLow(bytes: UInt64) throws {
+        self.logger?.debug(
+            "setting memory.low",
+            metadata: [
+                "path": "\(self.path.path)",
+                "bytes": "\(bytes)",
+            ]
+        )
+
+        try Self.writeValue(
+            path: self.path,
+            value: String(bytes),
+            fileName: "memory.low")
+    }
+
     package func getMemoryEvents() throws -> MemoryEvents {
         let content = try readFileContent(fileName: "memory.events")
         let values = parseKeyValuePairs(content)

--- a/vminitd/Sources/vminitd/AgentCommand.swift
+++ b/vminitd/Sources/vminitd/AgentCommand.swift
@@ -123,19 +123,23 @@ struct AgentCommand: AsyncParsableCommand {
         try cgManager.toggleAllAvailableControllers(enable: true)
 
         // Set memory.high threshold to 75 MiB
-        let threshold: UInt64 = 75 * 1024 * 1024
-        try cgManager.setMemoryHigh(bytes: threshold)
+        let high: UInt64 = 75 * 1024 * 1024
+        // Set memory.low to 50 MiB to avoid reclaiming vminitd's memory
+        let low: UInt64 = 50 * 1024 * 1024
+
+        try cgManager.setMemoryHigh(bytes: high)
+        try cgManager.setMemoryLow(bytes: low)
         try cgManager.addProcess(pid: getpid())
 
         let memoryMonitor = try MemoryMonitor(
             cgroupManager: cgManager,
-            threshold: threshold,
+            threshold: high,
             logger: log
         ) { [log] (currentUsage, highMark) in
             log.warning(
                 "vminitd memory threshold exceeded",
                 metadata: [
-                    "threshold_bytes": "\(threshold)",
+                    "threshold_bytes": "\(high)",
                     "current_bytes": "\(currentUsage)",
                     "high_events_total": "\(highMark)",
                 ])


### PR DESCRIPTION
Sets `memory.low` for `vminitd` cgroup to make kernel avoid reclaiming its memory under high memory pressure. Even if the container process runs in memory cgroup, consuming lots of page cache can lead to reclaiming `vminitd`'s page cache memory , which hangs the `vminitd`. Setting `memory.low` makes kernel avoid reclaiming `vminitd`'s page so that we can guarantee the proper `vminitd` operation under high memory pressure.