### PR TITLE
LinuxContainer: Give 1 vcpu of overhead for guest

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -530,6 +530,9 @@ extension LinuxContainer {
             let mib: UInt64 = 1.mib()
             let vmMemory = (self.memoryInBytes + guestAgentOverhead + mib - 1) & ~(mib - 1)
 
+            // Give the guest agent a core to play with outside of the container.
+            let vmCpus = self.cpus + 1
+
             // Prepare file mounts. This transforms single-file mounts into directory shares.
             let fileMountContext = try FileMountContext.prepare(mounts: self.config.mounts)
             // This is dumb, but alas.
@@ -542,7 +545,7 @@ extension LinuxContainer {
             }
 
             let vmConfig = VMConfiguration(
-                cpus: self.cpus,
+                cpus: vmCpus,
                 memoryInBytes: vmMemory,
                 interfaces: self.interfaces,
                 mountsByID: [self.id: containerMounts],

--- a/Sources/Containerization/VZVirtualMachineManager.swift
+++ b/Sources/Containerization/VZVirtualMachineManager.swift
@@ -55,11 +55,14 @@ public struct VZVirtualMachineManager: VirtualMachineManager {
         // Clamp to system RAM as Virtualization.framework bounds us to this.
         let memoryInBytes = min(vmConfig.memoryInBytes, ProcessInfo.processInfo.physicalMemory)
 
+        // Clamp to system CPU count as Virtualization.framework bounds us to this.
+        let cpus = min(vmConfig.cpus, ProcessInfo.processInfo.activeProcessorCount)
+
         return try VZVirtualMachineInstance(
             group: self.group,
             logger: self.logger,
             with: { instanceConfig in
-                instanceConfig.cpus = vmConfig.cpus
+                instanceConfig.cpus = cpus
                 instanceConfig.memoryInBytes = memoryInBytes
 
                 instanceConfig.kernel = self.kernel


### PR DESCRIPTION
We should've done this likely awhile ago, but today the cgroup core restrictions we place on the container matches the amount of cores the guest has. This means under high cpu load vminitd may respond to rpcs a tad slower than we'd like. We should give some overhead to the guest so vminitd has an extra core to play with. Ideally in the future these values should be configurable.