### PR TITLE
EXT4: Rework Ptr

### DIFF
--- a/Sources/ContainerizationEXT4/EXT4+FileTree.swift
+++ b/Sources/ContainerizationEXT4/EXT4+FileTree.swift
@@ -69,8 +69,7 @@ extension EXT4 {
         var root: Ptr<FileTreeNode>
 
         init(_ root: InodeNumber, _ name: String) {
-            self.root = Ptr<FileTreeNode>.allocate(capacity: 1)
-            self.root.initialize(to: FileTreeNode(inode: root, name: name, parent: nil))
+            self.root = Ptr(FileTreeNode(inode: root, name: name, parent: nil))
         }
 
         func lookup(path: FilePath) -> Ptr<FileTreeNode>? {

--- a/Sources/ContainerizationEXT4/EXT4+Formatter.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Formatter.swift
@@ -114,17 +114,12 @@ extension EXT4 {
             try self.handle.write(contentsOf: zero)
             // step #1
             self.inodes = [
-                Ptr<Inode>.allocate(capacity: 1),  // defective block inode
-                {
-                    let root = Inode.Root()
-                    let rootPtr = Ptr<Inode>.allocate(capacity: 1)
-                    rootPtr.initialize(to: root)
-                    return rootPtr
-                }(),
+                Ptr(Inode()),  // defective block inode
+                Ptr(Inode.Root()),
             ]
             // reserved inodes
             for _ in 2..<EXT4.FirstInode - 1 {
-                inodes.append(Ptr<Inode>.allocate(capacity: 1))
+                inodes.append(Ptr(Inode()))
             }
             // step #2
             self.tree = FileTree(EXT4.RootInode, "/")
@@ -159,7 +154,7 @@ extension EXT4 {
                 throw Error.cannotCreateHardlinksToDirTarget(link)
             }
             targetInode.linksCount += 1
-            targetInodePtr.initialize(to: targetInode)
+            targetInodePtr.pointee = targetInode
             let parentPath: FilePath = link.dir
             if self.tree.lookup(path: link) != nil {
                 try self.unlink(path: link)
@@ -173,18 +168,17 @@ extension EXT4 {
             guard parentInode.linksCount < EXT4.MaxLinks else {
                 throw Error.maximumLinksExceeded(parentPath)
             }
-            let linkTreeNodePtr = Ptr<FileTree.FileTreeNode>.allocate(capacity: 1)
-            let linkTreeNode = FileTree.FileTreeNode(
-                inode: InodeNumber(2),  // this field is ignored, using 2 so array operations dont panic
-                name: link.base,
-                parent: parentTreeNodePtr,
-                children: [],
-                blocks: nil,
-                link: targetNode.inode
-            )
-            linkTreeNodePtr.initialize(to: linkTreeNode)
+            let linkTreeNodePtr = Ptr(
+                FileTree.FileTreeNode(
+                    inode: InodeNumber(2),  // this field is ignored, using 2 so array operations dont panic
+                    name: link.base,
+                    parent: parentTreeNodePtr,
+                    children: [],
+                    blocks: nil,
+                    link: targetNode.inode
+                ))
             parentTreeNode.children.append(linkTreeNodePtr)
-            parentTreeNodePtr.initialize(to: parentTreeNode)
+            parentTreeNodePtr.pointee = parentTreeNode
         }
 
         // Deletes the file or directory at the specified path from the filesystem.
@@ -228,11 +222,11 @@ extension EXT4 {
                         parentInode.linksCount -= 1
                     }
                 }
-                parentInodePtr.initialize(to: parentInode)
+                parentInodePtr.pointee = parentInode
                 parentNode.children.removeAll { childPtr in
                     childPtr.pointee.name == path.base
                 }
-                parentNodePtr.initialize(to: parentNode)
+                parentNodePtr.pointee = parentNode
             }
 
             if let hardlink = pathNode.link {
@@ -241,7 +235,7 @@ extension EXT4 {
                 var linkedInode = linkedInodePtr.pointee
                 if linkedInode.linksCount > 1 {
                     linkedInode.linksCount -= 1
-                    linkedInodePtr.initialize(to: linkedInode)
+                    linkedInodePtr.pointee = linkedInode
                 }
             }
 
@@ -260,7 +254,7 @@ extension EXT4 {
             let now = Date().fs()
             pathInode = Inode()
             pathInode.dtime = now.lo
-            pathInodePtr.initialize(to: pathInode)
+            pathInodePtr.pointee = pathInode
         }
 
         //  Creates a file, directory, or symlink at the specified path, recursively creating parent directories if they don't already exist.
@@ -341,7 +335,7 @@ extension EXT4 {
                             inode.gid = gid.lo
                             inode.gidHigh = gid.hi
                         }
-                        inodePtr.initialize(to: inode)
+                        inodePtr.pointee = inode
                         return
                     }
                 } else if let _ = node.link {  // ok to overwrite links
@@ -368,25 +362,24 @@ extension EXT4 {
                 throw Error.maximumLinksExceeded(parentPath)
             }
 
-            let childInodePtr = Ptr<Inode>.allocate(capacity: 1)
+            let childInodePtr = Ptr(Inode())
             var childInode = Inode()
             var startBlock: UInt32 = 0
             var endBlock: UInt32 = 0
             defer {  // update metadata
-                childInodePtr.initialize(to: childInode)
-                parentInodePtr.initialize(to: parentInode)
+                childInodePtr.pointee = childInode
+                parentInodePtr.pointee = parentInode
                 self.inodes.append(childInodePtr)
-                let childTreeNodePtr = Ptr<FileTree.FileTreeNode>.allocate(capacity: 1)
-                let childTreeNode = FileTree.FileTreeNode(
-                    inode: InodeNumber(self.inodes.count),
-                    name: path.base,
-                    parent: parentTreeNodePtr,
-                    children: [],
-                    blocks: (startBlock, endBlock)
-                )
-                childTreeNodePtr.initialize(to: childTreeNode)
+                let childTreeNodePtr = Ptr(
+                    FileTree.FileTreeNode(
+                        inode: InodeNumber(self.inodes.count),
+                        name: path.base,
+                        parent: parentTreeNodePtr,
+                        children: [],
+                        blocks: (startBlock, endBlock)
+                    ))
                 parentTreeNode.children.append(childTreeNodePtr)
-                parentTreeNodePtr.initialize(to: parentTreeNode)
+                parentTreeNodePtr.pointee = parentTreeNode
             }
             childInode.mode = mode
             // uid,gid
@@ -997,14 +990,14 @@ extension EXT4 {
                 let size: UInt64 = UInt64(endBlock - startBlock) * self.blockSize
                 inode.sizeLow = size.lo
                 inode.sizeHigh = size.hi
-                inodePtr.initialize(to: inode)
+                inodePtr.pointee = inode
                 node.blocks = (startBlock, endBlock)
-                nodePtr.initialize(to: node)
+                nodePtr.pointee = node
                 if self.pos % self.blockSize != 0 {
                     try self.seek(block: self.currentBlock + 1)
                 }
                 inode = try self.writeExtents(inode, (startBlock, endBlock))
-                inodePtr.initialize(to: inode)
+                inodePtr.pointee = inode
             }
         }
 
@@ -1272,10 +1265,6 @@ extension EXT4 {
         }
 
         deinit {
-            for inode in inodes {
-                inode.deinitialize(count: 1)
-                inode.deallocate()
-            }
             self.inodes.removeAll()
         }
     }

--- a/Sources/ContainerizationEXT4/EXT4+Ptr.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Ptr.swift
@@ -17,67 +17,20 @@
 extension EXT4 {
     class Ptr<T> {
         let underlying: UnsafeMutablePointer<T>
-        private var capacity: Int
-        private var initialized: Bool
-        private var allocated: Bool
 
         var pointee: T {
-            underlying.pointee
+            get { underlying.pointee }
+            set { underlying.pointee = newValue }
         }
 
-        init(capacity: Int) {
-            self.underlying = UnsafeMutablePointer<T>.allocate(capacity: capacity)
-            self.capacity = capacity
-            self.allocated = true
-            self.initialized = false
-        }
-
-        static func allocate(capacity: Int) -> Ptr<T> {
-            Ptr<T>(capacity: capacity)
-        }
-
-        func initialize(to value: T) {
-            guard self.allocated else {
-                return
-            }
-            if self.initialized {
-                self.underlying.deinitialize(count: self.capacity)
-            }
+        init(_ value: T) {
+            self.underlying = .allocate(capacity: 1)
             self.underlying.initialize(to: value)
-            self.allocated = true
-            self.initialized = true
-        }
-
-        func deallocate() {
-            guard self.allocated else {
-                return
-            }
-            self.underlying.deallocate()
-            self.allocated = false
-            self.initialized = false
-        }
-
-        func deinitialize(count: Int) {
-            guard self.allocated else {
-                return
-            }
-            guard self.initialized else {
-                return
-            }
-            self.underlying.deinitialize(count: count)
-            self.initialized = false
-            self.allocated = true
-        }
-
-        func move() -> T {
-            self.initialized = false
-            self.allocated = true
-            return self.underlying.move()
         }
 
         deinit {
-            self.deinitialize(count: self.capacity)
-            self.deallocate()
+            underlying.deinitialize(count: 1)
+            underlying.deallocate()
         }
     }
 }

--- a/Sources/ContainerizationEXT4/EXT4+Reader.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Reader.swift
@@ -89,7 +89,6 @@ extension EXT4 {
                     }
 
                     let blocks = try self.getExtents(inode: itemInodeNum)
-                    let itemTreeNodePtr = Ptr<FileTree.FileTreeNode>.allocate(capacity: 1)
                     let itemTreeNode = FileTree.FileTreeNode(
                         inode: itemInodeNum,
                         name: itemName,
@@ -102,9 +101,9 @@ extension EXT4 {
                         }
                         itemTreeNode.blocks = blocks.first
                     }
-                    itemTreeNodePtr.initialize(to: itemTreeNode)
+                    let itemTreeNodePtr = Ptr(itemTreeNode)
                     root.children.append(itemTreeNodePtr)
-                    itemPtr.initialize(to: root)
+                    itemPtr.pointee = root
                     let itemInode = try self.getInode(number: itemInodeNum)
                     if itemInode.mode.isDir() {
                         items.append((itemTreeNodePtr, itemInodeNum))

--- a/Tests/ContainerizationEXT4Tests/TestEXT4Reader+IO.swift
+++ b/Tests/ContainerizationEXT4Tests/TestEXT4Reader+IO.swift
@@ -616,12 +616,10 @@ struct EXT4PathIOTests {
     func fileTreeNodePathWithAbsoluteRoot() {
         let tree = EXT4.FileTree(EXT4.RootInode, "/")
 
-        let dirPtr = EXT4.Ptr<EXT4.FileTree.FileTreeNode>.allocate(capacity: 1)
-        dirPtr.initialize(to: EXT4.FileTree.FileTreeNode(inode: 3, name: "dir", parent: tree.root))
+        let dirPtr = EXT4.Ptr(EXT4.FileTree.FileTreeNode(inode: 3, name: "dir", parent: tree.root))
         tree.root.pointee.children.append(dirPtr)
 
-        let filePtr = EXT4.Ptr<EXT4.FileTree.FileTreeNode>.allocate(capacity: 1)
-        filePtr.initialize(to: EXT4.FileTree.FileTreeNode(inode: 4, name: "file", parent: dirPtr))
+        let filePtr = EXT4.Ptr(EXT4.FileTree.FileTreeNode(inode: 4, name: "file", parent: dirPtr))
         dirPtr.pointee.children.append(filePtr)
 
         #expect(dirPtr.pointee.path == FilePath("/dir"))
@@ -632,12 +630,10 @@ struct EXT4PathIOTests {
     func fileTreeNodePathWithRelativeRoot() {
         let tree = EXT4.FileTree(EXT4.RootInode, ".")
 
-        let dirPtr = EXT4.Ptr<EXT4.FileTree.FileTreeNode>.allocate(capacity: 1)
-        dirPtr.initialize(to: EXT4.FileTree.FileTreeNode(inode: 3, name: "dir", parent: tree.root))
+        let dirPtr = EXT4.Ptr(EXT4.FileTree.FileTreeNode(inode: 3, name: "dir", parent: tree.root))
         tree.root.pointee.children.append(dirPtr)
 
-        let filePtr = EXT4.Ptr<EXT4.FileTree.FileTreeNode>.allocate(capacity: 1)
-        filePtr.initialize(to: EXT4.FileTree.FileTreeNode(inode: 4, name: "file", parent: dirPtr))
+        let filePtr = EXT4.Ptr(EXT4.FileTree.FileTreeNode(inode: 4, name: "file", parent: dirPtr))
         dirPtr.pointee.children.append(filePtr)
 
         #expect(dirPtr.pointee.path == FilePath("dir"))
@@ -648,8 +644,7 @@ struct EXT4PathIOTests {
     func fileTreeNodePathWithNamedRoot() {
         let tree = EXT4.FileTree(EXT4.RootInode, "dir")
 
-        let filePtr = EXT4.Ptr<EXT4.FileTree.FileTreeNode>.allocate(capacity: 1)
-        filePtr.initialize(to: EXT4.FileTree.FileTreeNode(inode: 3, name: "file", parent: tree.root))
+        let filePtr = EXT4.Ptr(EXT4.FileTree.FileTreeNode(inode: 3, name: "file", parent: tree.root))
         tree.root.pointee.children.append(filePtr)
 
         #expect(filePtr.pointee.path == FilePath("dir/file"))


### PR DESCRIPTION
Ptr<T> allowed allocation without initialization, which left memory contents undefined in some cases if you didn't call initialize. Reserved inodes (3-10) were allocated but never initialized, causing the dir-count logic to read garbage mode bits depending on the allocator. This came out when trying to get the unit tests to run on an x86 linux box.

This change redesigns Ptr<T> to take a value in init, to circumvent this. All of our uses of Ptr would only allocate memory for 1 item as well, so the capacity field seems unneccessary today. Additionally, most of the methods on the type were unused today so we can clean up quite a few things there too.