### PR TITLE
Add a public constructor to `HTTP2ConnectBufferingHandler`

### DIFF
--- a/Sources/Containerization/HTTP2ConnectBufferingHandler.swift
+++ b/Sources/Containerization/HTTP2ConnectBufferingHandler.swift
@@ -48,6 +48,8 @@ public final class HTTP2ConnectBufferingHandler: ChannelDuplexHandler, Removable
     private var removalScheduled = false
     private var bufferedReads: [NIOAny] = []
 
+    public init() {}
+
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         bufferedReads.append(data)
     }


### PR DESCRIPTION
Adds a public constructor to `HTTP2ConnectBufferingHandler`. This is a follow-up to https://github.com/apple/containerization/pull/694.