### PR TITLE
Fix compilation warnings

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -874,7 +874,7 @@ extension LinuxContainer {
                 agent: agent,
                 vm: startedState.vm,
                 logger: self.logger,
-                onDelete: { [weak self] in
+                onDelete: { [weak self = self] in
                     await self?.removeProcess(id: id)
                 }
             )
@@ -911,7 +911,7 @@ extension LinuxContainer {
                 agent: agent,
                 vm: state.vm,
                 logger: self.logger,
-                onDelete: { [weak self] in
+                onDelete: { [weak self = self] in
                     await self?.removeProcess(id: id)
                 }
             )


### PR DESCRIPTION
Fix compilation warnings:

```
.../Sources/Containerization/LinuxContainer.swift:877:35: warning: 'weak' ownership of capture 'self' differs from implicitly-captured strong reference in outer scope [#ImplicitStrongCapture]
 851 |     /// via the `start` method.
 852 |     public func exec(_ id: String, configuration: @Sendable @escaping (inout LinuxProcessConfiguration) throws -> Void) async throws -> LinuxProcess {
 853 |         try await self.state.withLock { state in
     |                                       |- note: 'self' implicitly strongly captured here
     |                                       `- note: add 'self' as a capture list item to silence
 854 |             var startedState = try state.startedState("exec")
 855 | 
     :
 875 |                 vm: startedState.vm,
 876 |                 logger: self.logger,
 877 |                 onDelete: { [weak self] in
     |                                   |- warning: 'weak' ownership of capture 'self' differs from implicitly-captured strong reference in outer scope [#ImplicitStrongCapture]
     |                                   `- note: explicitly assign the capture list item to silence
 878 |                     await self?.removeProcess(id: id)
 879 |                 }

.../Sources/Containerization/LinuxContainer.swift:914:35: warning: 'weak' ownership of capture 'self' differs from implicitly-captured strong reference in outer scope [#ImplicitStrongCapture]
 890 |     /// via the `start` method.
 891 |     public func exec(_ id: String, configuration: LinuxProcessConfiguration) async throws -> LinuxProcess {
 892 |         try await self.state.withLock {
     |                                       |- note: 'self' implicitly strongly captured here
     |                                       `- note: add 'self' as a capture list item to silence
 893 |             var state = try $0.startedState("exec")
 894 | 
     :
 912 |                 vm: state.vm,
 913 |                 logger: self.logger,
 914 |                 onDelete: { [weak self] in
     |                                   |- warning: 'weak' ownership of capture 'self' differs from implicitly-captured strong reference in outer scope [#ImplicitStrongCapture]
     |                                   `- note: explicitly assign the capture list item to silence
 915 |                     await self?.removeProcess(id: id)
 916 |                 }

[#ImplicitStrongCapture]: <https://docs.swift.org/compiler/documentation/diagnostics/implicit-strong-capture>
```