### PR TITLE
LinuxContainer/LinuxPod: Make time sync configurable

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -78,6 +78,9 @@ public final class LinuxContainer: Container, Sendable {
         /// Run the container with a minimal init process that handles signal
         /// forwarding and zombie reaping.
         public var useInit: Bool = false
+        /// Interval for syncing the guest clock with the host. Set to nil
+        /// to disable time synchronization.
+        public var timeSyncInterval: Duration? = .seconds(20)
 
         public init() {}
 
@@ -95,7 +98,8 @@ public final class LinuxContainer: Container, Sendable {
             virtualization: Bool = false,
             bootLog: BootLog? = nil,
             ociRuntimePath: String? = nil,
-            useInit: Bool = false
+            useInit: Bool = false,
+            timeSyncInterval: Duration? = .seconds(20)
         ) {
             self.process = process
             self.cpus = cpus
@@ -111,6 +115,7 @@ public final class LinuxContainer: Container, Sendable {
             self.bootLog = bootLog
             self.ociRuntimePath = ociRuntimePath
             self.useInit = useInit
+            self.timeSyncInterval = timeSyncInterval
         }
     }
 
@@ -145,6 +150,7 @@ public final class LinuxContainer: Container, Sendable {
             let vm: any VirtualMachineInstance
             let relayManager: UnixSocketRelayManager
             var fileMountContext: FileMountContext
+            let timeSyncer: TimeSyncer?
         }
 
         struct StartedState: Sendable {
@@ -153,6 +159,7 @@ public final class LinuxContainer: Container, Sendable {
             let relayManager: UnixSocketRelayManager
             var vendedProcesses: [String: LinuxProcess]
             let fileMountContext: FileMountContext
+            let timeSyncer: TimeSyncer?
 
             init(_ state: CreatedState, process: LinuxProcess) {
                 self.vm = state.vm
@@ -160,6 +167,7 @@ public final class LinuxContainer: Container, Sendable {
                 self.process = process
                 self.vendedProcesses = [:]
                 self.fileMountContext = state.fileMountContext
+                self.timeSyncer = state.timeSyncer
             }
 
             init(_ state: PausedState) {
@@ -168,6 +176,7 @@ public final class LinuxContainer: Container, Sendable {
                 self.process = state.process
                 self.vendedProcesses = state.vendedProcesses
                 self.fileMountContext = state.fileMountContext
+                self.timeSyncer = state.timeSyncer
             }
         }
 
@@ -177,6 +186,7 @@ public final class LinuxContainer: Container, Sendable {
             let process: LinuxProcess
             var vendedProcesses: [String: LinuxProcess]
             let fileMountContext: FileMountContext
+            let timeSyncer: TimeSyncer?
 
             init(_ state: StartedState) {
                 self.vm = state.vm
@@ -184,6 +194,7 @@ public final class LinuxContainer: Container, Sendable {
                 self.process = state.process
                 self.vendedProcesses = state.vendedProcesses
                 self.fileMountContext = state.fileMountContext
+                self.timeSyncer = state.timeSyncer
             }
         }
 
@@ -622,7 +633,16 @@ extension LinuxContainer {
                     }
 
                 }
-                state = .created(.init(vm: vm, relayManager: relayManager, fileMountContext: fileMountContextHolder.withLock { $0 }))
+
+                var timeSyncer: TimeSyncer?
+                if let interval = self.config.timeSyncInterval {
+                    let ts = TimeSyncer(logger: self.logger)
+                    let tsAgent = try await vm.dialAgent()
+                    await ts.start(context: tsAgent, interval: interval)
+                    timeSyncer = ts
+                }
+
+                state = .created(.init(vm: vm, relayManager: relayManager, fileMountContext: fileMountContextHolder.withLock { $0 }, timeSyncer: timeSyncer))
             } catch {
                 try? await relayManager.stopAll()
                 try? await vm.stop()
@@ -719,18 +739,28 @@ extension LinuxContainer {
 
             let vm: any VirtualMachineInstance
             let relayManager: UnixSocketRelayManager
+            let timeSyncer: TimeSyncer?
 
             let startedState = try? state.startedState("stop")
             if let startedState {
                 vm = startedState.vm
                 relayManager = startedState.relayManager
+                timeSyncer = startedState.timeSyncer
             } else {
                 let createdState = try state.createdState("stop")
                 vm = createdState.vm
                 relayManager = createdState.relayManager
+                timeSyncer = createdState.timeSyncer
             }
 
             var firstError: Error?
+            do {
+                try await timeSyncer?.close()
+            } catch {
+                self.logger?.error("failed to close time syncer: \(error)")
+                firstError = firstError ?? error
+            }
+
             do {
                 try await relayManager.stopAll()
             } catch {

--- a/Sources/Containerization/LinuxPod.swift
+++ b/Sources/Containerization/LinuxPod.swift
@@ -59,6 +59,9 @@ public final class LinuxPod: Sendable {
         /// The default hosts file configuration for all containers in the pod.
         /// Individual containers can override this by setting their own `hosts` configuration.
         public var hosts: Hosts?
+        /// Interval for syncing the guest clock with the host. Set to nil
+        /// to disable time synchronization.
+        public var timeSyncInterval: Duration? = .seconds(20)
 
         public init() {}
     }
@@ -134,6 +137,7 @@ public final class LinuxPod: Sendable {
         struct CreatedState: Sendable {
             let vm: any VirtualMachineInstance
             let relayManager: UnixSocketRelayManager
+            let timeSyncer: TimeSyncer?
         }
 
         func createdState(_ operation: String) throws -> CreatedState {
@@ -498,7 +502,15 @@ extension LinuxPod {
                     state.containers[id]?.state = .created
                 }
 
-                state.phase = .created(.init(vm: vm, relayManager: relayManager))
+                var timeSyncer: TimeSyncer?
+                if let interval = self.config.timeSyncInterval {
+                    let ts = TimeSyncer(logger: self.logger)
+                    let tsAgent = try await vm.dialAgent()
+                    await ts.start(context: tsAgent, interval: interval)
+                    timeSyncer = ts
+                }
+
+                state.phase = .created(.init(vm: vm, relayManager: relayManager, timeSyncer: timeSyncer))
             } catch {
                 try? await relayManager.stopAll()
                 try? await vm.stop()
@@ -688,6 +700,7 @@ extension LinuxPod {
             let createdState = try state.phase.createdState("stop")
 
             do {
+                try? await createdState.timeSyncer?.close()
                 try await createdState.relayManager.stopAll()
 
                 // Stop all containers

--- a/Sources/Containerization/TimeSyncer.swift
+++ b/Sources/Containerization/TimeSyncer.swift
@@ -19,7 +19,7 @@ import Logging
 
 actor TimeSyncer {
     private var task: Task<Void, Never>?
-    private var context: Vminitd?
+    private var context: (any VirtualMachineAgent)?
     private var paused: Bool
     private let logger: Logger?
 
@@ -28,7 +28,7 @@ actor TimeSyncer {
         self.logger = logger
     }
 
-    func start(context: Vminitd, interval: Duration = .seconds(30)) {
+    func start(context: some VirtualMachineAgent, interval: Duration = .seconds(20)) {
         guard self.task == nil else {
             return
         }

--- a/Sources/Containerization/VZVirtualMachineInstance.swift
+++ b/Sources/Containerization/VZVirtualMachineInstance.swift
@@ -74,7 +74,6 @@ struct VZVirtualMachineInstance: Sendable {
     private let lock: AsyncLock
     private let group: EventLoopGroup
     private let ownsGroup: Bool
-    private let timeSyncer: TimeSyncer
     private let logger: Logger?
 
     public init(
@@ -101,7 +100,6 @@ struct VZVirtualMachineInstance: Sendable {
         self.queue = DispatchQueue(label: "com.apple.containerization.vzvm.\(UUID().uuidString)")
         self.mounts = try config.mountAttachments()
         self.logger = logger
-        self.timeSyncer = .init(logger: logger)
 
         self.vm = VZVirtualMachine(
             configuration: try config.toVZ(),
@@ -125,23 +123,19 @@ extension VZVirtualMachineInstance: VirtualMachineInstance {
 
             try await self.vm.start(queue: self.queue)
 
-            let agent = try Vminitd(
-                connection: try await self.vm.waitForAgent(queue: self.queue),
-                group: self.group
-            )
+            try await self.vm.waitForAgent(queue: self.queue).close()
 
-            do {
-                if self.config.rosetta {
+            if self.config.rosetta {
+                try await self.withAgent { agent in
+                    guard let agent = agent as? Vminitd else {
+                        throw ContainerizationError(
+                            .internalError,
+                            message: "expected Vminitd agent for rosetta setup"
+                        )
+                    }
                     try await agent.enableRosetta()
                 }
-            } catch {
-                try await agent.close()
-                throw error
             }
-
-            // Don't close our remote context as we are providing
-            // it to our time sync routine.
-            await self.timeSyncer.start(context: agent)
         }
     }
 
@@ -154,8 +148,6 @@ extension VZVirtualMachineInstance: VirtualMachineInstance {
             guard self.state == .running else {
                 throw ContainerizationError(.invalidState, message: "vm is not running")
             }
-
-            try await self.timeSyncer.close()
 
             if self.ownsGroup {
                 try await self.group.shutdownGracefully()
@@ -170,7 +162,6 @@ extension VZVirtualMachineInstance: VirtualMachineInstance {
 
     func pause() async throws {
         try await lock.withLock { _ in
-            await self.timeSyncer.pause()
             try await self.vm.pause(queue: self.queue)
         }
     }
@@ -178,7 +169,6 @@ extension VZVirtualMachineInstance: VirtualMachineInstance {
     func resume() async throws {
         try await lock.withLock { _ in
             try await self.vm.resume(queue: self.queue)
-            await self.timeSyncer.resume()
         }
     }
 

--- a/Sources/Containerization/VirtualMachineAgent.swift
+++ b/Sources/Containerization/VirtualMachineAgent.swift
@@ -73,6 +73,9 @@ public protocol VirtualMachineAgent: Sendable {
     func configureDNS(config: DNS, location: String) async throws
     func configureHosts(config: Hosts, location: String) async throws
 
+    // Time
+    func setTime(sec: Int64, usec: Int32) async throws
+
     // Container statistics
     func containerStatistics(containerIDs: [String], categories: StatCategory) async throws -> [ContainerStatistics]
 }
@@ -96,5 +99,9 @@ extension VirtualMachineAgent {
 
     public func sync() async throws {
         throw ContainerizationError(.unsupported, message: "sync")
+    }
+
+    public func setTime(sec: Int64, usec: Int32) async throws {
+        throw ContainerizationError(.unsupported, message: "setTime")
     }
 }


### PR DESCRIPTION
Today our time syncing with the host lives in VZVirtualMachineInstance, which means if a user made their own vmm type they would have to roll their own time syncing. It likely makes more sense to hoist this up to LinuxContainer/LinuxPod so if they want it they can use it, and if they have their own synchronization they can just disable it and use whatever they want. This also lowers the default sync period to 20 seconds.