### PR TITLE
produce initfs.ext4 for package creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,11 @@ endif
 .PHONY: init
 init: containerization vminitd
 	@echo Creating init.ext4...
-	@rm -f bin/init.rootfs.tar.gz bin/init.block
+	@rm -f bin/init.rootfs.tar.gz bin/init.block bin/initfs.ext4
 	@./bin/cctl rootfs create \
 		--vminitd vminitd/bin/vminitd \
 		--vmexec vminitd/bin/vmexec \
+		--ext4 ./bin/initfs.ext4 \
 		--label org.opencontainers.image.source=https://github.com/apple/containerization \
 		--image vminit:latest \
 		bin/init.rootfs.tar.gz


### PR DESCRIPTION
This does not break and prevent any other asset from being produced. 