### PR TITLE
LinuxContainer: Allow cpu/mem overhead to be configurable

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -78,6 +78,13 @@ public final class LinuxContainer: Container, Sendable {
         /// Run the container with a minimal init process that handles signal
         /// forwarding and zombie reaping.
         public var useInit: Bool = false
+        /// Additional CPU cores to allocate for the virtual machine on top
+        /// of the container's configured `cpus` value.
+        public var cpuOverhead: Int = 1
+        /// Additional memory in bytes to allocate for the virtual machine
+        /// on top of the container's configured `memoryInBytes` value.
+        /// The total is aligned to a 1 MiB boundary.
+        public var memoryOverhead: UInt64 = 128.mib()
 
         public init() {}
 
@@ -95,7 +102,9 @@ public final class LinuxContainer: Container, Sendable {
             virtualization: Bool = false,
             bootLog: BootLog? = nil,
             ociRuntimePath: String? = nil,
-            useInit: Bool = false
+            useInit: Bool = false,
+            cpuOverhead: Int = 1,
+            memoryOverhead: UInt64 = 128.mib()
         ) {
             self.process = process
             self.cpus = cpus
@@ -111,6 +120,8 @@ public final class LinuxContainer: Container, Sendable {
             self.bootLog = bootLog
             self.ociRuntimePath = ociRuntimePath
             self.useInit = useInit
+            self.cpuOverhead = cpuOverhead
+            self.memoryOverhead = memoryOverhead
         }
     }
 
@@ -540,16 +551,10 @@ extension LinuxContainer {
             var modifiedRootfs = self.rootfs
             modifiedRootfs.options.removeAll(where: { $0 == "ro" })
 
-            // Calculate VM memory with overhead for the guest agent.
-            // The container cgroup limit stays at the requested memory, but the VM
-            // gets an additional 75MiB for the guest agent (could be higher, could
-            // be lower but this is a decent baseline for now).
-            let guestAgentOverhead: UInt64 = 75.mib()
             let mib: UInt64 = 1.mib()
-            let vmMemory = (self.memoryInBytes + guestAgentOverhead + mib - 1) & ~(mib - 1)
+            let vmMemory = (self.memoryInBytes + self.config.memoryOverhead + mib - 1) & ~(mib - 1)
 
-            // Give the guest agent a core to play with outside of the container.
-            let vmCpus = self.cpus + 1
+            let vmCpus = self.cpus + self.config.cpuOverhead
 
             // Prepare file mounts. This transforms single-file mounts into directory shares.
             let fileMountContext = try FileMountContext.prepare(mounts: self.config.mounts)

--- a/Sources/Integration/ContainerTests.swift
+++ b/Sources/Integration/ContainerTests.swift
@@ -4608,6 +4608,78 @@ extension IntegrationSuite {
         }
     }
 
+    func testVMResourceOverhead() async throws {
+        let id = "test-vm-resource-overhead"
+
+        let bs = try await bootstrap(id)
+        let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
+            config.process.arguments = ["sleep", "infinity"]
+            config.cpus = 2
+            config.memoryInBytes = 256.mib()
+            config.cpuOverhead = 2
+            config.memoryOverhead = 1024.mib()
+            config.bootLog = bs.bootLog
+        }
+
+        do {
+            try await container.create()
+            try await container.start()
+
+            let cpuBuffer = BufferWriter()
+            let cpuExec = try await container.exec("check-nproc") { config in
+                config.arguments = ["nproc"]
+                config.stdout = cpuBuffer
+            }
+            try await cpuExec.start()
+            var status = try await cpuExec.wait()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "nproc status \(status) != 0")
+            }
+            try await cpuExec.delete()
+
+            guard let cpuStr = String(data: cpuBuffer.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                let cpuCount = Int(cpuStr)
+            else {
+                throw IntegrationError.assert(msg: "failed to parse nproc output")
+            }
+            let expectedCpus = 4
+            guard cpuCount == expectedCpus else {
+                throw IntegrationError.assert(msg: "nproc \(cpuCount) != expected \(expectedCpus)")
+            }
+
+            let memBuffer = BufferWriter()
+            let memExec = try await container.exec("check-meminfo") { config in
+                config.arguments = ["sh", "-c", "grep MemTotal /proc/meminfo | awk '{print $2}'"]
+                config.stdout = memBuffer
+            }
+            try await memExec.start()
+            status = try await memExec.wait()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "meminfo status \(status) != 0")
+            }
+            try await memExec.delete()
+
+            guard let memStr = String(data: memBuffer.data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                let memTotalKiB = UInt64(memStr)
+            else {
+                throw IntegrationError.assert(msg: "failed to parse MemTotal")
+            }
+            let memTotalBytes = memTotalKiB * 1024
+            let expectedMin: UInt64 = 1024.mib()
+            guard memTotalBytes > expectedMin else {
+                throw IntegrationError.assert(
+                    msg: "MemTotal \(memTotalBytes) should exceed \(expectedMin)")
+            }
+
+            try await container.kill(.kill)
+            try await container.wait()
+            try await container.stop()
+        } catch {
+            try? await container.stop()
+            throw error
+        }
+    }
+
     // Verify that mounts are sorted by destination path depth so that a
     // higher-level mount (e.g. /mnt) doesn't shadow a deeper mount
     // (e.g. /mnt/deep/nested). Both directories are separate virtiofs

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -380,6 +380,7 @@ struct IntegrationSuite: AsyncParsableCommand {
                 Test("container workingDir created", testWorkingDirCreated),
                 Test("container workingDir exec created", testWorkingDirExecCreated),
                 Test("container mount sort by depth", testMountsSortedByDepth),
+                Test("container VM resource overhead", testVMResourceOverhead),
                 Test("container NBD mount", testContainerNBDMount),
                 Test("container NBD read-only", testContainerNBDReadOnly),
                 Test("container NBD raw block", testContainerNBDRawBlock),

--- a/vminitd/Sources/vminitd/AgentCommand.swift
+++ b/vminitd/Sources/vminitd/AgentCommand.swift
@@ -122,8 +122,8 @@ struct AgentCommand: AsyncParsableCommand {
         try cgManager.create()
         try cgManager.toggleAllAvailableControllers(enable: true)
 
-        // Set memory.high threshold to 75 MiB
-        let high: UInt64 = 75 * 1024 * 1024
+        // Set memory.high threshold to 80 MiB
+        let high: UInt64 = 80 * 1024 * 1024
         // Set memory.low to 50 MiB to avoid reclaiming vminitd's memory
         let low: UInt64 = 50 * 1024 * 1024
 


### PR DESCRIPTION
If someone wanted to use a custom guest agent/guest image in general the overhead we chose is kind of a nuisance.. This allows the values to be configurable, and raises the default to 128, and vminitds cgroup monitoring to 80.