### PR TITLE
Fix: bad request will remove header and retry login

### DIFF
--- a/Sources/ContainerizationOCI/Client/RegistryClient.swift
+++ b/Sources/ContainerizationOCI/Client/RegistryClient.swift
@@ -211,6 +211,11 @@ public final class RegistryClient: ContentClient {
                     }
 
                     continue
+                } else if _response.status == .badRequest && request.headers.contains(name: "Authorization") {
+                    // Retry without basic auth
+                    request.headers.remove(name: "Authorization")
+                    retryCount += 1
+                    continue
                 }
                 guard let retryOptions = self.retryOptions else {
                     break


### PR DESCRIPTION
If you're requesting on `/v2/` with basic auth, AWS ECR will return 400 Bad Request and won't provide `www-authenticate` information.

Retry the request after removing the Authorization header.

Continue PR #429

Fixed apple/container#847