### PR TITLE
Add filesystem notification (fsnotify) support

### DIFF
--- a/Sources/Containerization/SandboxContext/SandboxContext.grpc.swift
+++ b/Sources/Containerization/SandboxContext/SandboxContext.grpc.swift
@@ -413,6 +413,19 @@ public enum Com_Apple_Containerization_Sandbox_V3_SandboxContext: Sendable {
                 type: .unary
             )
         }
+        /// Namespace for "NotifyFileSystemEvent" metadata.
+        public enum NotifyFileSystemEvent: Sendable {
+            /// Request type for "NotifyFileSystemEvent".
+            public typealias Input = Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest
+            /// Response type for "NotifyFileSystemEvent".
+            public typealias Output = Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse
+            /// Descriptor for "NotifyFileSystemEvent".
+            public static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "com.apple.containerization.sandbox.v3.SandboxContext"),
+                method: "NotifyFileSystemEvent",
+                type: .bidirectionalStreaming
+            )
+        }
         /// Descriptors for all methods in the "com.apple.containerization.sandbox.v3.SandboxContext" service.
         public static let descriptors: [GRPCCore.MethodDescriptor] = [
             Mount.descriptor,
@@ -443,7 +456,8 @@ public enum Com_Apple_Containerization_Sandbox_V3_SandboxContext: Sendable {
             ConfigureDns.descriptor,
             ConfigureHosts.descriptor,
             Sync.descriptor,
-            Kill.descriptor
+            Kill.descriptor,
+            NotifyFileSystemEvent.descriptor
         ]
     }
 }
@@ -997,6 +1011,25 @@ extension Com_Apple_Containerization_Sandbox_V3_SandboxContext {
             request: GRPCCore.StreamingServerRequest<Com_Apple_Containerization_Sandbox_V3_KillRequest>,
             context: GRPCCore.ServerContext
         ) async throws -> GRPCCore.StreamingServerResponse<Com_Apple_Containerization_Sandbox_V3_KillResponse>
+
+        /// Handle the "NotifyFileSystemEvent" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Notify the guest of filesystem events on mounted volumes.
+        /// > Used to trigger synthetic inotify events for virtio-fs mounts.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse` messages.
+        func notifyFileSystemEvent(
+            request: GRPCCore.StreamingServerRequest<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>
     }
 
     /// Service protocol for the "com.apple.containerization.sandbox.v3.SandboxContext" service.
@@ -1535,6 +1568,25 @@ extension Com_Apple_Containerization_Sandbox_V3_SandboxContext {
             request: GRPCCore.ServerRequest<Com_Apple_Containerization_Sandbox_V3_KillRequest>,
             context: GRPCCore.ServerContext
         ) async throws -> GRPCCore.ServerResponse<Com_Apple_Containerization_Sandbox_V3_KillResponse>
+
+        /// Handle the "NotifyFileSystemEvent" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Notify the guest of filesystem events on mounted volumes.
+        /// > Used to trigger synthetic inotify events for virtio-fs mounts.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request of `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        /// - Returns: A streaming response of `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse` messages.
+        func notifyFileSystemEvent(
+            request: GRPCCore.StreamingServerRequest<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest>,
+            context: GRPCCore.ServerContext
+        ) async throws -> GRPCCore.StreamingServerResponse<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>
     }
 
     /// Simple service protocol for the "com.apple.containerization.sandbox.v3.SandboxContext" service.
@@ -2072,6 +2124,26 @@ extension Com_Apple_Containerization_Sandbox_V3_SandboxContext {
             request: Com_Apple_Containerization_Sandbox_V3_KillRequest,
             context: GRPCCore.ServerContext
         ) async throws -> Com_Apple_Containerization_Sandbox_V3_KillResponse
+
+        /// Handle the "NotifyFileSystemEvent" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Notify the guest of filesystem events on mounted volumes.
+        /// > Used to trigger synthetic inotify events for virtio-fs mounts.
+        ///
+        /// - Parameters:
+        ///   - request: A stream of `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest` messages.
+        ///   - response: A response stream of `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse` messages.
+        ///   - context: Context providing information about the RPC.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
+        func notifyFileSystemEvent(
+            request: GRPCCore.RPCAsyncSequence<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest, any Swift.Error>,
+            response: GRPCCore.RPCWriter<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>,
+            context: GRPCCore.ServerContext
+        ) async throws
     }
 }
 
@@ -2393,6 +2465,17 @@ extension Com_Apple_Containerization_Sandbox_V3_SandboxContext.StreamingServiceP
             serializer: GRPCProtobuf.ProtobufSerializer<Com_Apple_Containerization_Sandbox_V3_KillResponse>(),
             handler: { request, context in
                 try await self.kill(
+                    request: request,
+                    context: context
+                )
+            }
+        )
+        router.registerHandler(
+            forMethod: Com_Apple_Containerization_Sandbox_V3_SandboxContext.Method.NotifyFileSystemEvent.descriptor,
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>(),
+            handler: { request, context in
+                try await self.notifyFileSystemEvent(
                     request: request,
                     context: context
                 )
@@ -3107,6 +3190,23 @@ extension Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServiceProt
             metadata: [:]
         )
     }
+
+    public func notifyFileSystemEvent(
+        request: GRPCCore.StreamingServerRequest<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest>,
+        context: GRPCCore.ServerContext
+    ) async throws -> GRPCCore.StreamingServerResponse<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse> {
+        return GRPCCore.StreamingServerResponse<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>(
+            metadata: [:],
+            producer: { writer in
+                try await self.notifyFileSystemEvent(
+                    request: request.messages,
+                    response: writer,
+                    context: context
+                )
+                return [:]
+            }
+        )
+    }
 }
 
 // MARK: com.apple.containerization.sandbox.v3.SandboxContext (client)
@@ -3790,6 +3890,30 @@ extension Com_Apple_Containerization_Sandbox_V3_SandboxContext {
             deserializer: some GRPCCore.MessageDeserializer<Com_Apple_Containerization_Sandbox_V3_KillResponse>,
             options: GRPCCore.CallOptions,
             onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Com_Apple_Containerization_Sandbox_V3_KillResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "NotifyFileSystemEvent" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Notify the guest of filesystem events on mounted volumes.
+        /// > Used to trigger synthetic inotify events for virtio-fs mounts.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request producing `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest` messages.
+        ///   - serializer: A serializer for `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest` messages.
+        ///   - deserializer: A deserializer for `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func notifyFileSystemEvent<Result>(
+            request: GRPCCore.StreamingClientRequest<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest>,
+            serializer: some GRPCCore.MessageSerializer<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
     }
 
@@ -4799,6 +4923,39 @@ extension Com_Apple_Containerization_Sandbox_V3_SandboxContext {
                 onResponse: handleResponse
             )
         }
+
+        /// Call the "NotifyFileSystemEvent" method.
+        ///
+        /// > Source IDL Documentation:
+        /// >
+        /// > Notify the guest of filesystem events on mounted volumes.
+        /// > Used to trigger synthetic inotify events for virtio-fs mounts.
+        ///
+        /// - Parameters:
+        ///   - request: A streaming request producing `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest` messages.
+        ///   - serializer: A serializer for `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest` messages.
+        ///   - deserializer: A deserializer for `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        public func notifyFileSystemEvent<Result>(
+            request: GRPCCore.StreamingClientRequest<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest>,
+            serializer: some GRPCCore.MessageSerializer<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.bidirectionalStreaming(
+                request: request,
+                descriptor: Com_Apple_Containerization_Sandbox_V3_SandboxContext.Method.NotifyFileSystemEvent.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
     }
 }
 
@@ -5642,6 +5799,34 @@ extension Com_Apple_Containerization_Sandbox_V3_SandboxContext.ClientProtocol {
             request: request,
             serializer: GRPCProtobuf.ProtobufSerializer<Com_Apple_Containerization_Sandbox_V3_KillRequest>(),
             deserializer: GRPCProtobuf.ProtobufDeserializer<Com_Apple_Containerization_Sandbox_V3_KillResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "NotifyFileSystemEvent" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > Notify the guest of filesystem events on mounted volumes.
+    /// > Used to trigger synthetic inotify events for virtio-fs mounts.
+    ///
+    /// - Parameters:
+    ///   - request: A streaming request producing `Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest` messages.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func notifyFileSystemEvent<Result>(
+        request: GRPCCore.StreamingClientRequest<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>) async throws -> Result
+    ) async throws -> Result where Result: Sendable {
+        try await self.notifyFileSystemEvent(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>(),
             options: options,
             onResponse: handleResponse
         )
@@ -6603,6 +6788,39 @@ extension Com_Apple_Containerization_Sandbox_V3_SandboxContext.ClientProtocol {
             metadata: metadata
         )
         return try await self.kill(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "NotifyFileSystemEvent" method.
+    ///
+    /// > Source IDL Documentation:
+    /// >
+    /// > Notify the guest of filesystem events on mounted volumes.
+    /// > Used to trigger synthetic inotify events for virtio-fs mounts.
+    ///
+    /// - Parameters:
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - producer: A closure producing request messages to send to the server. The request
+    ///       stream is closed when the closure returns.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    public func notifyFileSystemEvent<Result>(
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        requestProducer producer: @Sendable @escaping (GRPCCore.RPCWriter<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest>) async throws -> Void,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>) async throws -> Result
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.StreamingClientRequest<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest>(
+            metadata: metadata,
+            producer: producer
+        )
+        return try await self.notifyFileSystemEvent(
             request: request,
             options: options,
             onResponse: handleResponse

--- a/Sources/Containerization/SandboxContext/SandboxContext.pb.swift
+++ b/Sources/Containerization/SandboxContext/SandboxContext.pb.swift
@@ -96,6 +96,53 @@ public enum Com_Apple_Containerization_Sandbox_V3_StatCategory: SwiftProtobuf.En
 
 }
 
+/// Types of filesystem events that can be notified.
+public enum Com_Apple_Containerization_Sandbox_V3_FileSystemEventType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  public typealias RawValue = Int
+  case create // = 0
+  case delete // = 1
+  case link // = 2
+  case unlink // = 3
+  case modify // = 4
+  case UNRECOGNIZED(Int)
+
+  public init() {
+    self = .create
+  }
+
+  public init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .create
+    case 1: self = .delete
+    case 2: self = .link
+    case 3: self = .unlink
+    case 4: self = .modify
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .create: return 0
+    case .delete: return 1
+    case .link: return 2
+    case .unlink: return 3
+    case .modify: return 4
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  public static let allCases: [Com_Apple_Containerization_Sandbox_V3_FileSystemEventType] = [
+    .create,
+    .delete,
+    .link,
+    .unlink,
+    .modify,
+  ]
+
+}
+
 public struct Com_Apple_Containerization_Sandbox_V3_Stdio: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -1559,12 +1606,55 @@ public struct Com_Apple_Containerization_Sandbox_V3_MemoryEventStats: Sendable {
   public init() {}
 }
 
+public struct Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var path: String = String()
+
+  public var eventType: Com_Apple_Containerization_Sandbox_V3_FileSystemEventType = .create
+
+  public var containerID: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var success: Bool = false
+
+  public var error: String {
+    get {_error ?? String()}
+    set {_error = newValue}
+  }
+  /// Returns true if `error` has been explicitly set.
+  public var hasError: Bool {self._error != nil}
+  /// Clears the value of `error`. Subsequent reads from it will return its default value.
+  public mutating func clearError() {self._error = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _error: String? = nil
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "com.apple.containerization.sandbox.v3"
 
 extension Com_Apple_Containerization_Sandbox_V3_StatCategory: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0STAT_CATEGORY_UNSPECIFIED\0\u{1}STAT_CATEGORY_PROCESS\0\u{1}STAT_CATEGORY_MEMORY\0\u{1}STAT_CATEGORY_CPU\0\u{1}STAT_CATEGORY_BLOCK_IO\0\u{1}STAT_CATEGORY_NETWORK\0\u{1}STAT_CATEGORY_MEMORY_EVENTS\0")
+}
+
+extension Com_Apple_Containerization_Sandbox_V3_FileSystemEventType: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0CREATE\0\u{1}DELETE\0\u{1}LINK\0\u{1}UNLINK\0\u{1}MODIFY\0")
 }
 
 extension Com_Apple_Containerization_Sandbox_V3_Stdio: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -4183,6 +4273,85 @@ extension Com_Apple_Containerization_Sandbox_V3_MemoryEventStats: SwiftProtobuf.
     if lhs.oom != rhs.oom {return false}
     if lhs.oomKill != rhs.oomKill {return false}
     if lhs.oomGroupKill != rhs.oomGroupKill {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".NotifyFileSystemEventRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{3}event_type\0\u{3}container_id\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.path) }()
+      case 2: try { try decoder.decodeSingularEnumField(value: &self.eventType) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.containerID) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.path.isEmpty {
+      try visitor.visitSingularStringField(value: self.path, fieldNumber: 1)
+    }
+    if self.eventType != .create {
+      try visitor.visitSingularEnumField(value: self.eventType, fieldNumber: 2)
+    }
+    if !self.containerID.isEmpty {
+      try visitor.visitSingularStringField(value: self.containerID, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest, rhs: Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest) -> Bool {
+    if lhs.path != rhs.path {return false}
+    if lhs.eventType != rhs.eventType {return false}
+    if lhs.containerID != rhs.containerID {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".NotifyFileSystemEventResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.success) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self._error) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if self.success != false {
+      try visitor.visitSingularBoolField(value: self.success, fieldNumber: 1)
+    }
+    try { if let v = self._error {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse, rhs: Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse) -> Bool {
+    if lhs.success != rhs.success {return false}
+    if lhs._error != rhs._error {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Containerization/SandboxContext/SandboxContext.proto
+++ b/Sources/Containerization/SandboxContext/SandboxContext.proto
@@ -72,6 +72,9 @@ service SandboxContext {
   rpc Sync(SyncRequest) returns (SyncResponse);
   // Send a signal to a process via the PID.
   rpc Kill(KillRequest) returns (KillResponse);
+  // Notify the guest of filesystem events on mounted volumes.
+  // Used to trigger synthetic inotify events for virtio-fs mounts.
+  rpc NotifyFileSystemEvent(stream NotifyFileSystemEventRequest) returns (stream NotifyFileSystemEventResponse);
 }
 
 message Stdio {
@@ -450,4 +453,24 @@ message MemoryEventStats {
   uint64 oom_kill = 5;
   // Number of times charge for memory failed because of limit.
   uint64 oom_group_kill = 6;
+}
+
+// Types of filesystem events that can be notified.
+enum FileSystemEventType {
+  CREATE = 0;
+  DELETE = 1;
+  LINK = 2;
+  UNLINK = 3;
+  MODIFY = 4;
+}
+
+message NotifyFileSystemEventRequest {
+  string path = 1;
+  FileSystemEventType event_type = 2;
+  string container_id = 3;
+}
+
+message NotifyFileSystemEventResponse {
+  bool success = 1;
+  optional string error = 2;
 }

--- a/Sources/Containerization/Vminitd.swift
+++ b/Sources/Containerization/Vminitd.swift
@@ -360,6 +360,10 @@ extension Vminitd: VirtualMachineAgent {
 
 /// Vminitd specific rpcs.
 extension Vminitd {
+    public typealias FileSystemEventRequest = Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest
+    public typealias FileSystemEventResponse = Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse
+    public typealias FileSystemEventType = Com_Apple_Containerization_Sandbox_V3_FileSystemEventType
+
     /// Sets up an emulator in the guest.
     public func setupEmulator(binaryPath: String, configuration: Binfmt.Entry) async throws {
         let request = Com_Apple_Containerization_Sandbox_V3_SetupEmulatorRequest.with {
@@ -537,6 +541,54 @@ extension Vminitd {
                     }
                 }
             })
+    }
+
+    /// Send filesystem event notifications to the guest.
+    public func notifyFileSystemEvents(
+        _ events: [FileSystemEventRequest]
+    ) async throws -> [FileSystemEventResponse] {
+        try await client.notifyFileSystemEvent(
+            requestProducer: { writer in
+                for event in events {
+                    try await writer.write(event)
+                }
+            },
+            onResponse: { response in
+                var results: [FileSystemEventResponse] = []
+                for try await msg in response.messages {
+                    results.append(msg)
+                }
+
+                guard results.count == events.count else {
+                    throw ContainerizationError(
+                        .internalError,
+                        message: "fsnotify: expected \(events.count) responses, got \(results.count)"
+                    )
+                }
+                return results
+            }
+        )
+    }
+
+    /// Send a single filesystem event notification to the guest.
+    public func notifyFileSystemEvent(
+        path: String,
+        eventType: FileSystemEventType,
+        containerID: String
+    ) async throws {
+        let request = FileSystemEventRequest.with {
+            $0.path = path
+            $0.eventType = eventType
+            $0.containerID = containerID
+        }
+
+        let responses = try await notifyFileSystemEvents([request])
+        if let resp = responses.first, !resp.success {
+            throw ContainerizationError(
+                .internalError,
+                message: "fsnotify event failed: \(resp.error)"
+            )
+        }
     }
 }
 

--- a/Sources/Integration/ContainerTests.swift
+++ b/Sources/Integration/ContainerTests.swift
@@ -4724,4 +4724,78 @@ extension IntegrationSuite {
                 msg: "expected 'deep-content' but got '\(value ?? "<nil>")'")
         }
     }
+
+    func testFSNotifyEvents() async throws {
+        let id = "test-fsnotify-events"
+
+        let bs = try await bootstrap(id, reference: "docker.io/library/node:18-alpine")
+        let buffer = BufferWriter()
+        let mountDir = try createMountDirectory()
+        let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
+            config.process.arguments = [
+                "node", "-e",
+                "fs=require('fs');fs.watch(process.argv[1],(t,f)=>console.log(t,f))",
+                "/mnt",
+            ]
+            config.mounts.append(.share(source: mountDir.path, destination: "/mnt"))
+            config.process.stdout = buffer
+            config.bootLog = bs.bootLog
+        }
+
+        try await container.create()
+        try await container.start()
+        defer { Task { try? await container.stop() } }
+
+        // Give fs.watch time to initialize
+        try await Task.sleep(for: .seconds(2))
+
+        // Dial the guest agent directly via vsock
+        let conn = try await container.dialVsock(port: Vminitd.port)
+        let agent = try Vminitd(connection: conn, group: IntegrationSuite.eventLoop)
+        defer { Task { try? await agent.close() } }
+
+        // Test CREATE event
+        try await agent.notifyFileSystemEvent(
+            path: "/mnt/hi.txt",
+            eventType: .create,
+            containerID: id
+        )
+        try await Task.sleep(for: .seconds(1))
+
+        var output = String(data: buffer.data, encoding: .utf8) ?? ""
+        var lines = output.split(separator: "\n").map(String.init)
+        guard lines == ["change hi.txt"] else {
+            throw IntegrationError.assert(
+                msg: "expected ['change hi.txt'] after CREATE, got \(lines)"
+            )
+        }
+
+        // Test MODIFY event
+        try await agent.notifyFileSystemEvent(
+            path: "/mnt/hi.txt",
+            eventType: .modify,
+            containerID: id
+        )
+        try await Task.sleep(for: .seconds(1))
+
+        output = String(data: buffer.data, encoding: .utf8) ?? ""
+        lines = output.split(separator: "\n").map(String.init)
+        guard lines == ["change hi.txt", "change hi.txt"] else {
+            throw IntegrationError.assert(
+                msg: "expected two 'change hi.txt' lines after MODIFY, got \(lines)"
+            )
+        }
+
+        // Test DELETE on non-existent file — should not crash
+        try await agent.notifyFileSystemEvent(
+            path: "/mnt/nonexistent.txt",
+            eventType: .delete,
+            containerID: id
+        )
+        try await Task.sleep(for: .milliseconds(500))
+
+        // Clean shutdown
+        try await agent.close()
+        try await container.stop()
+    }
 }

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -165,8 +165,9 @@ struct IntegrationSuite: AsyncParsableCommand {
 
     static let eventLoop = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
-    func bootstrap(_ testID: String) async throws -> (rootfs: Containerization.Mount, vmm: VirtualMachineManager, image: Containerization.Image, bootLog: BootLog) {
-        let reference = "ghcr.io/linuxcontainers/alpine:3.20"
+    func bootstrap(_ testID: String, reference: String = "ghcr.io/linuxcontainers/alpine:3.20") async throws -> (
+        rootfs: Containerization.Mount, vmm: VirtualMachineManager, image: Containerization.Image, bootLog: BootLog
+    ) {
         let store = Self.imageStore
 
         let initImage = try await store.getInitImage(reference: Self.initImage)
@@ -385,6 +386,7 @@ struct IntegrationSuite: AsyncParsableCommand {
                 Test("container NBD read-only", testContainerNBDReadOnly),
                 Test("container NBD raw block", testContainerNBDRawBlock),
                 Test("container NBD volume identity", testContainerNBDVolumeIdentity),
+                Test("container fsnotify events", testFSNotifyEvents),
 
                 // Pods
                 Test("pod single container", testPodSingleContainer),

--- a/Sources/cctl/FSNotifyCommand.swift
+++ b/Sources/cctl/FSNotifyCommand.swift
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025-2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Containerization
+import ContainerizationError
+import ContainerizationOS
+import Foundation
+import NIOPosix
+
+#if os(macOS)
+extension Application {
+    struct FSNotify: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "fsnotify",
+            abstract: "Send a filesystem event notification to the guest"
+        )
+
+        @Option(help: "Container ID")
+        var container: String
+
+        @Option(help: "File path for the event")
+        var path: String
+
+        @Option(help: "Event type: create, modify, delete, link, unlink")
+        var event: String = "create"
+
+        @Option(name: .customLong("vsock-socket"), help: "Path to vsock socket")
+        var vsockSocket: String?
+
+        func run() async throws {
+            let eventType: Vminitd.FileSystemEventType
+            switch event.lowercased() {
+            case "create":
+                eventType = .create
+            case "modify":
+                eventType = .modify
+            case "delete":
+                eventType = .delete
+            case "link":
+                eventType = .link
+            case "unlink":
+                eventType = .unlink
+            default:
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "unknown event type '\(event)', expected one of: create, modify, delete, link, unlink"
+                )
+            }
+
+            guard let socketPath = vsockSocket else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "--vsock-socket is required"
+                )
+            }
+
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+            let socket = try Socket(type: UnixType(path: socketPath))
+            try socket.connect()
+            defer { try? socket.close() }
+            let handle = FileHandle(fileDescriptor: socket.fileDescriptor, closeOnDealloc: false)
+
+            let vminitd = try Vminitd(connection: handle, group: group)
+
+            do {
+                try await vminitd.notifyFileSystemEvent(
+                    path: path,
+                    eventType: eventType,
+                    containerID: container
+                )
+                print("fsnotify: sent \(event) event for '\(path)' to container '\(container)'")
+            } catch {
+                print("fsnotify: failed to send event: \(error)")
+                throw error
+            }
+
+            try? await vminitd.close()
+            try? await group.shutdownGracefully()
+        }
+    }
+}
+#endif

--- a/Sources/cctl/cctl.swift
+++ b/Sources/cctl/cctl.swift
@@ -67,6 +67,7 @@ struct Application: AsyncParsableCommand {
             ]
             #if os(macOS)
             commands += [
+                FSNotify.self,
                 Images.self,
                 Login.self,
                 Run.self,

--- a/vminitd/Sources/VminitdCore/FilesystemEventWorker.swift
+++ b/vminitd/Sources/VminitdCore/FilesystemEventWorker.swift
@@ -1,0 +1,301 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+#if os(Linux)
+
+import Containerization
+import ContainerizationError
+import Foundation
+import Logging
+import Synchronization
+
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+// MARK: - FilesystemEventWorker
+
+/// Triggers synthetic inotify events inside a container's mount namespace.
+///
+/// Architecture: a dedicated thread enters the container's mount namespace via setns(),
+/// then blocks on a signal pipe. The parent enqueues events into a Mutex-protected queue
+/// and writes a wake byte. The worker drains the queue and "pokes" each file via no-op
+/// chmod to trigger inotify.
+final class FilesystemEventWorker: Sendable {
+
+    // MARK: - Types
+
+    struct FSEvent: Sendable {
+        let path: String
+        let eventType: Com_Apple_Containerization_Sandbox_V3_FileSystemEventType
+    }
+
+    enum Phase: Sendable {
+        case created, starting, running, stopping, stopped
+    }
+
+    struct State: Sendable {
+        var phase: Phase = .created
+        var queue: [FSEvent] = []
+        var signalPipeRead: CInt = -1
+        var signalPipeWrite: CInt = -1
+        var statusPipeRead: CInt = -1
+        var statusPipeWrite: CInt = -1
+        var startError: (any Error)?
+    }
+
+    // MARK: Properties
+
+    let containerID: String
+    private let log: Logger
+    private let state: Mutex<State>
+
+    private static let handshakeReady: UInt8 = 0xAA
+    private static let handshakeFailure: UInt8 = 0xFF
+    private static let doneByte: UInt8 = 0xFE
+
+    // MARK: Init
+
+    init(containerID: String, log: Logger) {
+        self.containerID = containerID
+        self.log = log
+        self.state = Mutex(State())
+    }
+
+    // MARK: - Lifecycle
+
+    /// Start the worker thread. Blocks briefly for the namespace-entry handshake.
+    func start(containerPID: Int32) throws {
+        try state.withLock { s in
+            guard s.phase == .created else {
+                throw ContainerizationError(.internalError, message: "fsnotify: worker already started")
+            }
+        }
+
+        let signalPipe = try makePipe(nonblockWrite: true)
+        let statusPipe: (read: CInt, write: CInt)
+        do {
+            statusPipe = try makePipe()
+        } catch {
+            close(signalPipe.read)
+            close(signalPipe.write)
+            throw error
+        }
+
+        state.withLock { s in
+            s.signalPipeRead = signalPipe.read
+            s.signalPipeWrite = signalPipe.write
+            s.statusPipeRead = statusPipe.read
+            s.statusPipeWrite = statusPipe.write
+            s.phase = .starting
+        }
+
+        let thread = Thread { [weak self] in
+            self?.workerMain(
+                signalPipeRead: signalPipe.read,
+                statusPipeWrite: statusPipe.write,
+                containerPID: containerPID
+            )
+        }
+        thread.name = "fsnotify-\(containerID)"
+        thread.start()
+
+        // Block for handshake — completes in microseconds (just setns + write)
+        var handshake: UInt8 = 0
+        let n = read(statusPipe.read, &handshake, 1)
+
+        if n <= 0 || handshake == Self.handshakeFailure {
+            let error = state.withLock { $0.startError }
+            // statusPipeWrite already closed by worker on failure
+            close(signalPipe.read)
+            close(signalPipe.write)
+            close(statusPipe.read)
+            state.withLock { s in
+                s.signalPipeRead = -1
+                s.signalPipeWrite = -1
+                s.statusPipeRead = -1
+                s.statusPipeWrite = -1
+                s.phase = .stopped
+            }
+            throw error
+                ?? ContainerizationError(
+                    .internalError, message: "fsnotify: worker failed to start")
+        }
+
+        state.withLock { $0.phase = .running }
+        log.info("fsnotify worker started", metadata: ["containerID": "\(containerID)"])
+    }
+
+    /// Enqueue a filesystem event for the worker to process.
+    func enqueueEvent(path: String, eventType: Com_Apple_Containerization_Sandbox_V3_FileSystemEventType) throws {
+        // The pipe write is inside the lock to prevent stop() from closing the FD
+        // between the phase check and the write. O_NONBLOCK ensures this never blocks.
+        try state.withLock { s in
+            guard s.phase == .running else {
+                throw ContainerizationError(.internalError, message: "fsnotify worker not running")
+            }
+            s.queue.append(FSEvent(path: path, eventType: eventType))
+            var byte: UInt8 = 0x01
+            if write(s.signalPipeWrite, &byte, 1) < 0 && errno != EAGAIN {
+                log.warning("fsnotify: failed to write wake byte", metadata: ["errno": "\(errno)"])
+            }
+        }
+    }
+
+    /// Stop the worker and wait for it to exit. Async to avoid blocking the cooperative thread pool.
+    func stop() async {
+        let (writeEnd, readEnd) = state.withLock { s -> (CInt, CInt) in
+            guard s.phase == .running else { return (-1, -1) }
+            s.phase = .stopping
+            return (s.signalPipeWrite, s.statusPipeRead)
+        }
+        guard writeEnd != -1 else { return }
+
+        var byte: UInt8 = 0x01
+        _ = write(writeEnd, &byte, 1)
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            Thread.detachNewThread {
+                var doneByte: UInt8 = 0
+                _ = read(readEnd, &doneByte, 1)
+                continuation.resume()
+            }
+        }
+
+        state.withLock { s in
+            close(s.signalPipeRead)
+            close(s.signalPipeWrite)
+            close(s.statusPipeRead)
+            s.signalPipeRead = -1
+            s.signalPipeWrite = -1
+            s.statusPipeRead = -1
+            s.statusPipeWrite = -1
+            s.phase = .stopped
+        }
+        log.info("fsnotify worker stopped", metadata: ["containerID": "\(containerID)"])
+    }
+
+    // MARK: - Worker Thread
+
+    private func workerMain(signalPipeRead: CInt, statusPipeWrite: CInt, containerPID: Int32) {
+        do {
+            try enterContainerNamespace(pid: containerPID)
+        } catch {
+            state.withLock { $0.startError = error }
+            var byte = Self.handshakeFailure
+            _ = write(statusPipeWrite, &byte, 1)
+            close(statusPipeWrite)
+            return
+        }
+
+        var readyByte = Self.handshakeReady
+        _ = write(statusPipeWrite, &readyByte, 1)
+
+        var buf = [UInt8](repeating: 0, count: 256)
+        while true {
+            let n = buf.withUnsafeMutableBytes { ptr in
+                read(signalPipeRead, ptr.baseAddress!, ptr.count)
+            }
+            if n < 0 && errno == EINTR { continue }
+            if n <= 0 { break }
+
+            let (events, shouldStop) = state.withLock { s -> ([FSEvent], Bool) in
+                let events = s.queue
+                s.queue.removeAll(keepingCapacity: true)
+                return (events, s.phase == .stopping)
+            }
+
+            for event in events {
+                pokeFile(event.path)
+            }
+
+            if shouldStop { break }
+        }
+
+        var done = Self.doneByte
+        _ = write(statusPipeWrite, &done, 1)
+        close(statusPipeWrite)
+    }
+
+    // MARK: - File Poking
+
+    /// Trigger a synthetic inotify event via no-op chmod (same permissions) which triggers IN_ATTRIB.
+    private func pokeFile(_ path: String) {
+        var st = stat()
+        guard stat(path, &st) == 0 else {
+            log.debug("fsnotify: stat failed, skipping", metadata: ["path": "\(path)", "errno": "\(errno)"])
+            return
+        }
+
+        guard chmod(path, st.st_mode & 0o7777) == 0 else {
+            log.warning("fsnotify: chmod failed", metadata: ["path": "\(path)", "errno": "\(errno)"])
+            return
+        }
+    }
+
+    // MARK: - Namespace Entry
+
+    private func enterContainerNamespace(pid: Int32) throws {
+        let nsPath = "/proc/\(pid)/ns/mnt"
+        let selfNsPath = "/proc/self/ns/mnt"
+
+        var nsStat = stat()
+        var selfStat = stat()
+
+        guard stat(nsPath, &nsStat) == 0 else {
+            throw ContainerizationError(.internalError, message: "fsnotify: failed to stat \(nsPath): errno \(errno)")
+        }
+        guard stat(selfNsPath, &selfStat) == 0 else {
+            throw ContainerizationError(.internalError, message: "fsnotify: failed to stat \(selfNsPath): errno \(errno)")
+        }
+
+        if nsStat.st_ino == selfStat.st_ino { return }
+
+        let fd = open(nsPath, O_RDONLY | O_CLOEXEC)
+        guard fd >= 0 else {
+            throw ContainerizationError(.internalError, message: "fsnotify: failed to open \(nsPath): errno \(errno)")
+        }
+        defer { close(fd) }
+
+        guard unshare(CInt(CLONE_FS)) == 0 else {
+            throw ContainerizationError(.internalError, message: "fsnotify: unshare(CLONE_FS) failed: errno \(errno)")
+        }
+        guard setns(fd, CInt(CLONE_NEWNS)) == 0 else {
+            throw ContainerizationError(.internalError, message: "fsnotify: setns failed: errno \(errno)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Create a pipe with O_CLOEXEC on both ends. Optionally set O_NONBLOCK on the write end.
+    private func makePipe(nonblockWrite: Bool = false) throws -> (read: CInt, write: CInt) {
+        var fds: [CInt] = [0, 0]
+        guard pipe(&fds) == 0 else {
+            throw ContainerizationError(.internalError, message: "fsnotify: pipe failed: errno \(errno)")
+        }
+        _ = fcntl(fds[0], F_SETFD, FD_CLOEXEC)
+        _ = fcntl(fds[1], F_SETFD, FD_CLOEXEC)
+        if nonblockWrite {
+            let flags = fcntl(fds[1], F_GETFL)
+            _ = fcntl(fds[1], F_SETFL, flags | O_NONBLOCK)
+        }
+        return (read: fds[0], write: fds[1])
+    }
+}
+
+#endif

--- a/vminitd/Sources/VminitdCore/ManagedContainer.swift
+++ b/vminitd/Sources/VminitdCore/ManagedContainer.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import Cgroup
+import Containerization
 import ContainerizationError
 import ContainerizationOCI
 import ContainerizationOS
@@ -30,6 +31,7 @@ public actor ManagedContainer {
     private let bundle: ContainerizationOCI.Bundle
     private let needsCgroupCleanup: Bool
     private var execs: [String: any ContainerProcess] = [:]
+    private var filesystemEventWorker: FilesystemEventWorker?
 
     public var pid: Int32? {
         self.initProcess.pid
@@ -182,7 +184,20 @@ extension ManagedContainer {
 
     func start(execID: String) async throws -> Int32 {
         let proc = try self.getExecOrInit(execID: execID)
-        return try await ProcessSupervisor.default.start(process: proc)
+        let pid = try await ProcessSupervisor.default.start(process: proc)
+
+        // Start fsnotify worker when the init process starts
+        if execID == self.id {
+            let worker = FilesystemEventWorker(containerID: id, log: log)
+            do {
+                try worker.start(containerPID: pid)
+                self.filesystemEventWorker = worker
+            } catch {
+                log.warning("fsnotify: failed to start worker", metadata: ["containerID": "\(id)", "error": "\(error)"])
+            }
+        }
+
+        return pid
     }
 
     func wait(execID: String) async throws -> ContainerExitStatus {
@@ -216,6 +231,10 @@ extension ManagedContainer {
     }
 
     func delete() async throws {
+        // Stop fsnotify worker before other cleanup
+        await filesystemEventWorker?.stop()
+        filesystemEventWorker = nil
+
         // Delete the init process if it's a RuncProcess
         try await self.initProcess.delete()
 
@@ -232,6 +251,18 @@ extension ManagedContainer {
 
     func getMemoryEvents() throws -> MemoryEvents {
         try self.cgroupManager.getMemoryEvents()
+    }
+
+    func executeFileSystemEvent(
+        path: String,
+        eventType: Com_Apple_Containerization_Sandbox_V3_FileSystemEventType
+    ) throws {
+        guard let worker = filesystemEventWorker else {
+            throw ContainerizationError(
+                .invalidState, message: "fsnotify worker not available for container \(self.id)"
+            )
+        }
+        try worker.enqueueEvent(path: path, eventType: eventType)
     }
 
     func getExecOrInit(execID: String) throws -> any ContainerProcess {

--- a/vminitd/Sources/VminitdCore/Server+GRPC.swift
+++ b/vminitd/Sources/VminitdCore/Server+GRPC.swift
@@ -1572,6 +1572,37 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
             $0.result = r
         }
     }
+
+    public func notifyFileSystemEvent(
+        request: GRPCCore.RPCAsyncSequence<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventRequest, any Swift.Error>,
+        response: GRPCCore.RPCWriter<Com_Apple_Containerization_Sandbox_V3_NotifyFileSystemEventResponse>,
+        context: GRPCCore.ServerContext
+    ) async throws {
+        for try await req in request {
+            do {
+                let container = try await self.state.get(container: req.containerID)
+                try await container.executeFileSystemEvent(
+                    path: req.path,
+                    eventType: req.eventType
+                )
+                try await response.write(.with { $0.success = true })
+            } catch {
+                log.error(
+                    "notifyFileSystemEvent",
+                    metadata: [
+                        "containerID": "\(req.containerID)",
+                        "path": "\(req.path)",
+                        "eventType": "\(req.eventType)",
+                        "error": "\(error)",
+                    ])
+                try await response.write(
+                    .with {
+                        $0.success = false
+                        $0.error = "\(error)"
+                    })
+            }
+        }
+    }
 }
 
 extension Com_Apple_Containerization_Sandbox_V3_ConfigureHostsRequest {


### PR DESCRIPTION
This PR adds support for guest-side filesystem notifications for https://github.com/apple/container/issues/141. It adds a `NotifyFileSystemEvent` gRPC RPC so the host can send filesystem events to the guest. A dedicated worker thread enters the container's mount namespace with `setns()` and triggers synthetic inotify events using no-op chmod, which produces `IN_ATTRIB`. The worker uses a Mutex protected queue with pipe-based IPC. I'll add the host-side file watching to `container` later.