### PR TITLE
Fix ArchiveReader to support readonly directory

### DIFF
--- a/Sources/ContainerizationArchive/ArchiveReader.swift
+++ b/Sources/ContainerizationArchive/ArchiveReader.swift
@@ -284,6 +284,7 @@ extension ArchiveReader {
         // Iterate and extract archive entries, collecting rejected paths.
         var foundEntry = false
         var rejectedPaths = [String]()
+        var deferredDirAttrs: [(path: FilePath, entry: WriteEntry)] = []
         for (entry, dataReader) in self.makeStreamingIterator() {
             guard let memberPath = (entry.path.map { FilePath($0) }) else {
                 continue
@@ -298,12 +299,25 @@ extension ArchiveReader {
                 rootFileDescriptor: rootFileDescriptor
             )
 
+            if extracted, entry.fileType == .directory {
+                deferredDirAttrs.append((memberPath, entry))
+            }
+
             if !extracted {
                 rejectedPaths.append(memberPath.string)
             }
         }
         guard foundEntry else {
             throw ArchiveError.failedToExtractArchive("no entries found in archive")
+        }
+
+        // Apply directory permissions after all children are extracted, deepest first,
+        // so a read-only parent doesn't block applying permissions to its children.
+        for deferred in deferredDirAttrs.sorted(by: { $0.path.string.count > $1.path.string.count }) {
+            let fd = openat(rootFileDescriptor.rawValue, deferred.path.string, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
+            guard fd >= 0 else { continue }
+            setFileAttributes(fd: fd, entry: deferred.entry)
+            close(fd)
         }
 
         return rejectedPaths
@@ -362,9 +376,7 @@ extension ArchiveReader {
                     setFileAttributes(fd: fileFd, entry: entry)
                 }
             case .directory:
-                try rootFileDescriptor.mkdirSecure(memberPath, makeIntermediates: true) { fd in
-                    setFileAttributes(fd: fd.rawValue, entry: entry)
-                }
+                try rootFileDescriptor.mkdirSecure(memberPath, makeIntermediates: true) { _ in }
             case .symbolicLink:
                 guard let targetPath = (entry.symlinkTarget.map { FilePath($0) }) else {
                     return false

--- a/Sources/ContainerizationArchive/ArchiveReader.swift
+++ b/Sources/ContainerizationArchive/ArchiveReader.swift
@@ -284,6 +284,7 @@ extension ArchiveReader {
         // Iterate and extract archive entries, collecting rejected paths.
         var foundEntry = false
         var rejectedPaths = [String]()
+        var deferredDirAttrs: [(path: FilePath, entry: WriteEntry)] = []
         for (entry, dataReader) in self.makeStreamingIterator() {
             guard let memberPath = (entry.path.map { FilePath($0) }) else {
                 continue
@@ -298,12 +299,25 @@ extension ArchiveReader {
                 rootFileDescriptor: rootFileDescriptor
             )
 
+            if extracted, entry.fileType == .directory {
+                deferredDirAttrs.append((memberPath, entry))
+            }
+
             if !extracted {
                 rejectedPaths.append(memberPath.string)
             }
         }
         guard foundEntry else {
             throw ArchiveError.failedToExtractArchive("no entries found in archive")
+        }
+
+        // Apply directory permissions after all children are extracted, deepest first,
+        // so a read-only parent doesn't block applying permissions to its children.
+        for deferred in deferredDirAttrs.sorted(by: { $0.path.string.count > $1.path.string.count }) {
+            let fd = openat(rootFileDescriptor.rawValue, deferred.path.string, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
+            guard fd >= 0 else { continue }
+            setFileAttributes(fd: fd, entry: deferred.entry)
+            close(fd)
         }
 
         return rejectedPaths
@@ -362,9 +376,7 @@ extension ArchiveReader {
                     setFileAttributes(fd: fileFd, entry: entry)
                 }
             case .directory:
-                try FileDescriptorOps.mkdir(rootFileDescriptor, memberPath, makeIntermediates: true) { fd in
-                    setFileAttributes(fd: fd.rawValue, entry: entry)
-                }
+                try FileDescriptorOps.mkdir(rootFileDescriptor, memberPath, makeIntermediates: true) { _ in }
             case .symbolicLink:
                 guard let targetPath = (entry.symlinkTarget.map { FilePath($0) }) else {
                     return false

--- a/Tests/ContainerizationArchiveTests/ArchiveTests.swift
+++ b/Tests/ContainerizationArchiveTests/ArchiveTests.swift
@@ -242,6 +242,37 @@ struct ArchiveTests {
         #expect(try String(contentsOf: extractDir.appendingPathComponent("subdir/file2.txt"), encoding: .utf8) == "world")
     }
 
+    @Test func archiveDirectoryPreservesReadonlySubdirectory() throws {
+        let testDir = createTemporaryDirectory(baseName: "ArchiveTests.archiveDirReadonlySubdir")!
+        defer { try? FileManager.default.removeItem(at: testDir) }
+
+        let sourceDir = testDir.appendingPathComponent("source")
+        let readonlyDir = sourceDir.appendingPathComponent("readonly")
+        try FileManager.default.createDirectory(at: readonlyDir, withIntermediateDirectories: true)
+        try "content".write(to: readonlyDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: readonlyDir.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: readonlyDir.path)
+        }
+
+        let archiveURL = testDir.appendingPathComponent("test.tar.gz")
+        let writer = try ArchiveWriter(format: .pax, filter: .gzip, file: archiveURL)
+        try writer.archiveDirectory(sourceDir)
+        try writer.finishEncoding()
+
+        let extractDir = testDir.appendingPathComponent("extract")
+        let reader = try ArchiveReader(file: archiveURL)
+        let rejected = try reader.extractContents(to: extractDir)
+
+        #expect(rejected.isEmpty)
+        #expect(
+            try String(contentsOf: extractDir.appendingPathComponent("readonly/file.txt"), encoding: .utf8)
+                == "content")
+        let attrs = try FileManager.default.attributesOfItem(atPath: extractDir.appendingPathComponent("readonly").path)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+        #expect((perms & 0o777) == 0o555, "Read-only directory permissions should be preserved")
+    }
+
     @Test func archiveDirectoryEmpty() throws {
         let testDir = createTemporaryDirectory(baseName: "ArchiveTests.archiveDirEmpty")!
         defer { try? FileManager.default.removeItem(at: testDir) }
@@ -722,7 +753,7 @@ struct ArchiveTests {
         let readonlyDir = sourceDir.appendingPathComponent("readonly")
         try FileManager.default.createDirectory(at: readonlyDir, withIntermediateDirectories: true)
         try "content".write(to: readonlyDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes([.posixPermissions: 0o777], ofItemAtPath: readonlyDir.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: readonlyDir.path)
         defer {
             try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: readonlyDir.path)
         }
@@ -742,7 +773,7 @@ struct ArchiveTests {
                 == "content")
         let attrs = try FileManager.default.attributesOfItem(atPath: extractDir.appendingPathComponent("readonly").path)
         let perms = (attrs[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
-        #expect((perms & 0o777) == 0o777, "Read-only directory permissions should be preserved")
+        #expect((perms & 0o777) == 0o555, "Read-only directory permissions should be preserved")
     }
 
     @Test func archiveURLsSymlinks() throws {


### PR DESCRIPTION
Defer attribute setting of directories so that we can unarchive child entries first, then apply attributes which might be read-only.