### PR TITLE
vminitd: set oom_score_adj to -999 on boot

### DIFF
--- a/vminitd/Sources/VminitdCore/AgentCommand.swift
+++ b/vminitd/Sources/VminitdCore/AgentCommand.swift
@@ -212,5 +212,11 @@ public struct AgentCommand: AsyncParsableCommand {
         guard CZ_setrlimit(CZ_RLIMIT_NOFILE, max, max) == 0 else {
             throw POSIXError(.init(rawValue: errno)!)
         }
+
+        // Protect vminitd from the OOM killer. If PID 1 is killed the kernel
+        // panics, so we make ourselves a last-resort target. Workload processes
+        // retain the default score (0) and will be selected first.
+        log.debug("setting oom_score_adj to -999")
+        try "-999\n".write(toFile: "/proc/self/oom_score_adj", atomically: false, encoding: .utf8)
     }
 }


### PR DESCRIPTION
Under heavy memory pressure the OOM killer can select vminitd as a victim. Since vminitd is PID 1, killing it causes a kernel panic and reboots the guest rather than gracefully recovering.

Set oom_score_adj to -999 at startup so the OOM killer strongly prefers workload processes, which retain the default score of 0.