### PR TITLE
refactor memory alignment to VZVirtualMachineInstance

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -551,8 +551,7 @@ extension LinuxContainer {
             var modifiedRootfs = self.rootfs
             modifiedRootfs.options.removeAll(where: { $0 == "ro" })
 
-            let mib: UInt64 = 1.mib()
-            let vmMemory = (self.memoryInBytes + self.config.memoryOverhead + mib - 1) & ~(mib - 1)
+            let vmMemory = self.memoryInBytes + self.config.memoryOverhead
 
             let vmCpus = self.cpus + self.config.cpuOverhead
 

--- a/Sources/Containerization/VZVirtualMachineInstance.swift
+++ b/Sources/Containerization/VZVirtualMachineInstance.swift
@@ -315,7 +315,8 @@ extension VZVirtualMachineInstance.Configuration {
         var config = VZVirtualMachineConfiguration()
 
         config.cpuCount = self.cpus
-        config.memorySize = self.memoryInBytes
+        let mib: UInt64 = 1 << 20
+        config.memorySize = (self.memoryInBytes + mib - 1) & ~(mib - 1)
         config.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
         config.socketDevices = [VZVirtioSocketDeviceConfiguration()]
 

--- a/Sources/Integration/ContainerTests.swift
+++ b/Sources/Integration/ContainerTests.swift
@@ -33,6 +33,7 @@ extension IntegrationSuite {
         let bs = try await bootstrap(id)
         let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
             config.process.arguments = ["/bin/true"]
+            config.memoryInBytes = 250_000_000
             config.bootLog = bs.bootLog
         }
 

--- a/Sources/Integration/PodTests.swift
+++ b/Sources/Integration/PodTests.swift
@@ -495,7 +495,7 @@ extension IntegrationSuite {
         let bs = try await bootstrap(id)
         let pod = try LinuxPod(id, vmm: bs.vmm) { config in
             config.cpus = 4
-            config.memoryInBytes = 1024.mib()
+            config.memoryInBytes = 1_000_000_000
             config.bootLog = bs.bootLog
         }
 


### PR DESCRIPTION
Move the MiB rounding from LinuxContainer into `VZVirtualMachineInstance`, so all callers are covered in one place and the alignment constraint stays with the VMM layer that owns it.

This will also ensure LinuxPod can get memory alignment for free.