### PR TITLE
Skip comment lines when parsing the `passwd` and `group` files

### DIFF
--- a/Sources/ContainerizationOS/User.swift
+++ b/Sources/ContainerizationOS/User.swift
@@ -115,10 +115,14 @@ extension User {
         let content = try String(contentsOf: file, encoding: .ascii)
         let lines = content.components(separatedBy: .newlines)
         for line in lines {
-            guard !line.isEmpty else {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else {
                 continue
             }
-            try handler(line.trimmingCharacters(in: .whitespaces))
+            guard !trimmed.hasPrefix("#") else {
+                continue
+            }
+            try handler(trimmed)
         }
     }
 


### PR DESCRIPTION
Skips comment lines when parsing the `passwd` and `group` files.