### PR TITLE
Set devcontainer Swift image version to 6.3.0.

### DIFF
--- a/vminitd/.devcontainer/Dockerfile
+++ b/vminitd/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG SWIFT_VERSION=6.3
+ARG SWIFT_VERSION=6.3.0
 FROM swift:${SWIFT_VERSION}-noble
 
 RUN apt-get update \


### PR DESCRIPTION
- We were using Swift 6.3, which can pick up a newer version that is out of sync of both the `.swift-version` file for the project and the Swift SDK downloaded in the Dockerfile.