### PR TITLE
LinuxContainer/LinuxPod: Add ID length restriction

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -28,6 +28,8 @@ import struct ContainerizationOS.Terminal
 /// `LinuxContainer` is an easy to use type for launching and managing the
 /// full lifecycle of a Linux container ran inside of a virtual machine.
 public final class LinuxContainer: Container, Sendable {
+    static let maxIDLength = 64
+
     /// The identifier of the container.
     public let id: String
 
@@ -332,6 +334,12 @@ public final class LinuxContainer: Container, Sendable {
         configuration: LinuxContainer.Configuration,
         logger: Logger? = nil
     ) throws {
+        guard id.count <= Self.maxIDLength else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "container id length \(id.count) exceeds maximum of \(Self.maxIDLength) characters"
+            )
+        }
         if let writableLayer {
             guard writableLayer.isBlock else {
                 throw ContainerizationError(

--- a/Sources/Containerization/LinuxPod.swift
+++ b/Sources/Containerization/LinuxPod.swift
@@ -29,6 +29,8 @@ import struct ContainerizationOS.Terminal
 /// virtual machine. Each container has its own rootfs and process, but
 /// shares the VM's resources (CPU, memory, network).
 public final class LinuxPod: Sendable {
+    static let maxIDLength = 64
+
     /// The identifier of the pod.
     public let id: String
 
@@ -223,6 +225,12 @@ public final class LinuxPod: Sendable {
         logger: Logger? = nil,
         configuration: (inout Configuration) throws -> Void
     ) throws {
+        guard id.count <= Self.maxIDLength else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "pod id length \(id.count) exceeds maximum of \(Self.maxIDLength) characters"
+            )
+        }
         self.id = id
         self.vmm = vmm
         self.hostVsockPorts = Atomic<UInt32>(0x1000_0000)
@@ -328,6 +336,12 @@ extension LinuxPod {
         rootfs: Mount,
         configuration: @Sendable @escaping (inout ContainerConfiguration) throws -> Void
     ) async throws {
+        guard id.count <= Self.maxIDLength else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "container id length \(id.count) exceeds maximum of \(Self.maxIDLength) characters"
+            )
+        }
         try await self.state.withLock { state in
             guard case .initialized = state.phase else {
                 throw ContainerizationError(


### PR DESCRIPTION
I think realistically we should have a limit on this. Technically today the ID length restriction is whatever our grpc buffer length is..

I think 64 is long enough so that folks could use an entire hex based sha256, any uuid, and also sethostname has a length restriction of 64 anyways.