### PR TITLE
Fix missing apostrophes in Image scope-walk comment

### DIFF
--- a/Sources/Containerization/Image/Image.swift
+++ b/Sources/Containerization/Image/Image.swift
@@ -108,7 +108,7 @@ public struct Image: Sendable {
             referenced.append(manifest.digest.trimmingDigestPrefix)
             guard let m: Manifest = try? await contentStore.get(digest: manifest.digest) else {
                 // If the requested digest does not exist or is not a manifest. Skip.
-                // Its safe to skip processing this digest as it wont have any child layers.
+                // It's safe to skip processing this digest as it won't have any child layers.
                 continue
             }
             let descs = m.layers + [m.config]


### PR DESCRIPTION
## Summary

Two contractions in [`Sources/Containerization/Image/Image.swift:111`](https://github.com/apple/containerization/blob/main/Sources/Containerization/Image/Image.swift#L111) (the skip branch of the manifest scope walk):

- `Its safe` → `It's safe`
- `it wont have` → `it won't have`

## Test plan

- [x] `swiftc -parse Sources/Containerization/Image/Image.swift` — exit 0.

## Scope

Comment text only. No code, behavior, or API changes.