### PR TITLE
Keep `CVersion` in the `vminitd` package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,6 @@ import CompilerPluginSupport
 import Foundation
 import PackageDescription
 
-let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
-let gitTag = ProcessInfo.processInfo.environment["GIT_TAG"] ?? ""
-let buildTime = ProcessInfo.processInfo.environment["BUILD_TIME"] ?? "unspecified"
-
 let package = Package(
     name: "containerization",
     platforms: [.macOS("15.0")],
@@ -265,15 +261,6 @@ let package = Package(
             name: "CShim"
         ),
         .target(
-            name: "CVersion",
-            path: "vminitd/Sources/CVersion",
-            cSettings: [
-                .define("GIT_COMMIT", to: "\"\(gitCommit)\""),
-                .define("GIT_TAG", to: "\"\(gitTag)\""),
-                .define("BUILD_TIME", to: "\"\(buildTime)\""),
-            ]
-        ),
-        .target(
             name: "LCShim",
             path: "vminitd/Sources/LCShim"
         ),
@@ -303,7 +290,6 @@ let package = Package(
                 .product(name: "GRPCNIOTransportHTTP2", package: "grpc-swift-nio-transport"),
                 .product(name: "GRPCProtobuf", package: "grpc-swift-protobuf"),
                 "LCShim",
-                "CVersion",
                 "Cgroup",
             ],
             path: "vminitd/Sources/VminitdCore"

--- a/vminitd/Package.swift
+++ b/vminitd/Package.swift
@@ -17,7 +17,12 @@
 
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
+import Foundation
 import PackageDescription
+
+let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
+let gitTag = ProcessInfo.processInfo.environment["GIT_TAG"] ?? ""
+let buildTime = ProcessInfo.processInfo.environment["BUILD_TIME"] ?? "unspecified"
 
 let package = Package(
     name: "swift-vminitd",
@@ -33,6 +38,14 @@ let package = Package(
         .package(name: "containerization", path: "../"),
     ],
     targets: [
+        .target(
+            name: "CVersion",
+            cSettings: [
+                .define("GIT_COMMIT", to: "\"\(gitCommit)\""),
+                .define("GIT_TAG", to: "\"\(gitTag)\""),
+                .define("BUILD_TIME", to: "\"\(buildTime)\""),
+            ]
+        ),
         .executableTarget(
             name: "vminitd",
             dependencies: [
@@ -40,6 +53,7 @@ let package = Package(
                 .product(name: "ContainerizationOS", package: "containerization"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "VminitdCore", package: "containerization"),
+                "CVersion",
             ]
         ),
         .executableTarget(

--- a/vminitd/Sources/VminitdCore/AgentCommand.swift
+++ b/vminitd/Sources/VminitdCore/AgentCommand.swift
@@ -26,7 +26,6 @@ import GRPCCore
 import Logging
 import NIOCore
 import NIOPosix
-import Synchronization
 
 #if os(Linux)
 #if canImport(Musl)
@@ -45,8 +44,6 @@ public struct AgentCommand: AsyncParsableCommand {
 
     private static let foregroundEnvVar = "FOREGROUND"
     public static let vsockPort = 1024
-
-    public static let versionMetadata = Mutex<Logger.Metadata>([:])
 
     @OptionGroup var options: LogLevelOption
 
@@ -81,7 +78,7 @@ public struct AgentCommand: AsyncParsableCommand {
 
         signal(SIGPIPE, SIG_IGN)
 
-        log.info("vminitd booting", metadata: Self.versionMetadata.withLock { $0 })
+        log.info("vminitd booting", metadata: versionMetadata())
 
         // Set of mounts necessary to be mounted prior to taking any RPCs.
         // 1. /proc as the sysctl rpc wouldn't make sense if it wasn't there (NOTE: This is done before this method

--- a/vminitd/Sources/VminitdCore/AgentCommand.swift
+++ b/vminitd/Sources/VminitdCore/AgentCommand.swift
@@ -17,7 +17,6 @@
 #if os(Linux)
 
 import ArgumentParser
-import CVersion
 import Cgroup
 import Containerization
 import ContainerizationError
@@ -27,6 +26,7 @@ import GRPCCore
 import Logging
 import NIOCore
 import NIOPosix
+import Synchronization
 
 #if os(Linux)
 #if canImport(Musl)
@@ -45,6 +45,8 @@ public struct AgentCommand: AsyncParsableCommand {
 
     private static let foregroundEnvVar = "FOREGROUND"
     public static let vsockPort = 1024
+
+    public static let versionMetadata = Mutex<Logger.Metadata>([:])
 
     @OptionGroup var options: LogLevelOption
 
@@ -79,14 +81,7 @@ public struct AgentCommand: AsyncParsableCommand {
 
         signal(SIGPIPE, SIG_IGN)
 
-        let gitCommit = String(cString: CZ_get_git_commit())
-        let gitTag = String(cString: CZ_get_git_tag())
-        let buildTime = String(cString: CZ_get_build_time())
-        var metadata: Logger.Metadata = ["commit": "\(gitCommit)", "built": "\(buildTime)"]
-        if !gitTag.isEmpty {
-            metadata["tag"] = "\(gitTag)"
-        }
-        log.info("vminitd booting", metadata: metadata)
+        log.info("vminitd booting", metadata: Self.versionMetadata.withLock { $0 })
 
         // Set of mounts necessary to be mounted prior to taking any RPCs.
         // 1. /proc as the sysctl rpc wouldn't make sense if it wasn't there (NOTE: This is done before this method

--- a/vminitd/Sources/VminitdCore/Logging.swift
+++ b/vminitd/Sources/VminitdCore/Logging.swift
@@ -50,6 +50,16 @@ public struct LogLevelOption: ParsableArguments {
 }
 
 private let _loggingBootstrapped = Mutex(false)
+private let _versionMetadata = Mutex<Logger.Metadata>([:])
+
+/// Set the version metadata logged on boot.
+public func setVersionMetadata(_ metadata: Logger.Metadata) {
+    _versionMetadata.withLock { $0 = metadata }
+}
+
+func versionMetadata() -> Logger.Metadata {
+    _versionMetadata.withLock { $0 }
+}
 
 func makeLogger(label: String, level: Logger.Level) -> Logger {
     _loggingBootstrapped.withLock { bootstrapped in

--- a/vminitd/Sources/vminitd/Application.swift
+++ b/vminitd/Sources/vminitd/Application.swift
@@ -36,7 +36,7 @@ struct Application: AsyncParsableCommand {
     )
 
     static func main() async throws {
-        AgentCommand.versionMetadata.withLock { $0 = Self.versionMetadata() }
+        setVersionMetadata(Self.versionMetadata())
 
         // Busybox-style: if invoked as .cz-init, run init mode directly.
         let invoked = CommandLine.arguments.first?.split(separator: "/").last.map(String.init) ?? ""

--- a/vminitd/Sources/vminitd/Application.swift
+++ b/vminitd/Sources/vminitd/Application.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
+import CVersion
 import ContainerizationOS
 import Foundation
 import Logging
@@ -35,6 +36,8 @@ struct Application: AsyncParsableCommand {
     )
 
     static func main() async throws {
+        AgentCommand.versionMetadata.withLock { $0 = Self.versionMetadata() }
+
         // Busybox-style: if invoked as .cz-init, run init mode directly.
         let invoked = CommandLine.arguments.first?.split(separator: "/").last.map(String.init) ?? ""
         if invoked == ".cz-init" {
@@ -55,6 +58,17 @@ struct Application: AsyncParsableCommand {
         } else {
             try command.run()
         }
+    }
+
+    private static func versionMetadata() -> Logger.Metadata {
+        let gitCommit = String(cString: CZ_get_git_commit())
+        let gitTag = String(cString: CZ_get_git_tag())
+        let buildTime = String(cString: CZ_get_build_time())
+        var metadata: Logger.Metadata = ["commit": "\(gitCommit)", "built": "\(buildTime)"]
+        if !gitTag.isEmpty {
+            metadata["tag"] = "\(gitTag)"
+        }
+        return metadata
     }
 
     private static func mountProc() throws {


### PR DESCRIPTION
Moves `CVersion` back to the `vminitd` package. This is a follow-up for https://github.com/apple/containerization/pull/742.