### PR TITLE
[os]: add FilePathOps utility type + initial absolute path function

### DIFF
--- a/Sources/ContainerizationOS/FileDescriptorOps.swift
+++ b/Sources/ContainerizationOS/FileDescriptorOps.swift
@@ -46,8 +46,7 @@ private let os_S_IFLNK = mode_t(Glibc.S_IFLNK)
 /// All operations use `openat`/`mkdirat`/`unlinkat` anchored to the supplied
 /// file descriptor, preventing path traversal and TOCTOU races. The type is
 /// never instantiated; it exists solely as a namespace.
-public struct FileDescriptorOps {
-    private init() {}
+public enum FileDescriptorOps {
 
     // MARK: - Nested types
 

--- a/Sources/ContainerizationOS/FilePathOps.swift
+++ b/Sources/ContainerizationOS/FilePathOps.swift
@@ -20,14 +20,12 @@ import SystemPackage
 /// Static utility functions for path operations.
 ///
 /// The type is never instantiated; it exists solely as a namespace.
-public struct FilePathOps {
-    private init() {}
-
+public enum FilePathOps {
     /// Returns an absolute version of `path`.
     ///
-    /// This is a purely lexical operation: it does not resolve symlinks
-    /// and does not access the file system. If `path` is already absolute,
-    /// this returns `path` unchanged.
+    /// This is a purely lexical operation: it does not resolve symlinks,
+    /// perform tilde expansion, and does not access the file system. If `path`
+    /// is already absolute, this returns `path` unchanged.
     public static func absolutePath(_ path: FilePath) -> FilePath {
         guard !path.isAbsolute else {
             return path

--- a/Sources/ContainerizationOS/FilePathOps.swift
+++ b/Sources/ContainerizationOS/FilePathOps.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SystemPackage
+
+/// Static utility functions for path operations.
+///
+/// The type is never instantiated; it exists solely as a namespace.
+public struct FilePathOps {
+    private init() {}
+
+    /// Returns an absolute version of `path`.
+    ///
+    /// This is a purely lexical operation: it does not resolve symlinks
+    /// and does not access the file system. If `path` is already absolute,
+    /// this returns `path` unchanged.
+    public static func absolutePath(_ path: FilePath) -> FilePath {
+        guard !path.isAbsolute else {
+            return path
+        }
+
+        return FilePath(FileManager.default.currentDirectoryPath)
+            .appending(path.components)
+            .lexicallyNormalized()
+    }
+}

--- a/Tests/ContainerizationOSTests/FilePathOpsTests.swift
+++ b/Tests/ContainerizationOSTests/FilePathOpsTests.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SystemPackage
+import Testing
+
+@testable import ContainerizationOS
+
+struct FilePathOpsTests {
+    @Test("absolutePath returns absolute inputs unchanged")
+    func absolutePathPreservesAbsolutePath() {
+        let absolute = FilePath("/tmp/containerization/file.tar")
+        let resolved = FilePathOps.absolutePath(absolute)
+
+        #expect(resolved == absolute)
+    }
+
+    @Test("absolutePath resolves relative paths against cwd and normalizes lexically")
+    func absolutePathResolvesRelativePath() {
+        let relative = FilePath("./images/../image.tar")
+        let expected = FilePath(FileManager.default.currentDirectoryPath)
+            .appending(relative.components)
+            .lexicallyNormalized()
+        let resolved = FilePathOps.absolutePath(relative)
+
+        #expect(resolved == expected)
+        #expect(resolved.isAbsolute)
+    }
+}


### PR DESCRIPTION
Relates to #744

- Adds the initial `FilePathOps` utility type
- Adds the `absolutePath` implementation
- Adds the `FilePathOpsTests` file and initial test cases