### PR TITLE
Add file handle attachment support

### DIFF
--- a/Sources/Containerization/BridgedNetworkInterface.swift
+++ b/Sources/Containerization/BridgedNetworkInterface.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+#if os(macOS)
+
+import ContainerizationError
+import ContainerizationExtras
+import Virtualization
+
+/// A network interface that bridges the container onto a host physical interface.
+/// The IP address is assigned by the upstream DHCP server; `ipv4Address` is always nil.
+@available(macOS 26, *)
+public final class BridgedNetworkInterface: Interface, Sendable {
+    public let hostInterfaceName: String
+    public let macAddress: MACAddress?
+    public let ipv4Address: CIDRv4? = nil
+    public let ipv4Gateway: IPv4Address? = nil
+    public let mtu: UInt32 = 1500
+
+    public init(hostInterfaceName: String, macAddress: MACAddress? = nil) {
+        self.hostInterfaceName = hostInterfaceName
+        self.macAddress = macAddress
+    }
+}
+
+@available(macOS 26, *)
+extension BridgedNetworkInterface: VZInterface {
+    public func device() throws -> VZVirtioNetworkDeviceConfiguration {
+        guard
+            let vzIface = VZBridgedNetworkInterface.networkInterfaces
+                .first(where: { $0.identifier == hostInterfaceName })
+        else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "no bridged interface named \(hostInterfaceName)")
+        }
+        let config = VZVirtioNetworkDeviceConfiguration()
+        config.attachment = VZBridgedNetworkDeviceAttachment(interface: vzIface)
+        if let mac = macAddress, let vzMac = VZMACAddress(string: mac.description) {
+            config.macAddress = vzMac
+        }
+        return config
+    }
+}
+
+#endif

--- a/Sources/Containerization/CHInterface.swift
+++ b/Sources/Containerization/CHInterface.swift
@@ -33,7 +33,7 @@ public protocol CHInterface {
 /// responsibility.
 public struct TAPInterface: CHInterface, Interface, Sendable {
     public let tapName: String
-    public let ipv4Address: CIDRv4
+    public let ipv4Address: CIDRv4?
     public let ipv4Gateway: IPv4Address?
     public let macAddress: MACAddress?
     public let mtu: UInt32

--- a/Sources/Containerization/FileHandleNetworkInterface.swift
+++ b/Sources/Containerization/FileHandleNetworkInterface.swift
@@ -20,34 +20,27 @@ import ContainerizationError
 import ContainerizationExtras
 import Virtualization
 
-/// A network interface that bridges the container onto a host physical interface.
-/// The IP address is assigned by the upstream DHCP server; `ipv4Address` is always nil.
+/// A network interface that connects the container to an arbitrary FileHandle-backed
+/// network service. The IP address might be assigned by the upstream DHCP server or
+/// configured inside the container; `ipv4Address` is always nil.
 @available(macOS 26, *)
-public final class BridgedNetworkInterface: Interface, Sendable {
-    public let hostInterfaceName: String
+public final class FileHandleNetworkInterface: Interface, Sendable {
     public let macAddress: MACAddress?
     public let ipv4Address: CIDRv4? = nil
     public let ipv4Gateway: IPv4Address? = nil
+    public let fileHandle: FileHandle
 
-    public init(hostInterfaceName: String, macAddress: MACAddress? = nil) {
-        self.hostInterfaceName = hostInterfaceName
+    public init(fileHandle: FileHandle, macAddress: MACAddress? = nil) {
         self.macAddress = macAddress
+        self.fileHandle = fileHandle
     }
 }
 
 @available(macOS 26, *)
-extension BridgedNetworkInterface: VZInterface {
+extension FileHandleNetworkInterface: VZInterface {
     public func device() throws -> VZVirtioNetworkDeviceConfiguration {
-        guard
-            let vzIface = VZBridgedNetworkInterface.networkInterfaces
-                .first(where: { $0.identifier == hostInterfaceName })
-        else {
-            throw ContainerizationError(
-                .invalidArgument,
-                message: "no bridged interface named \(hostInterfaceName)")
-        }
         let config = VZVirtioNetworkDeviceConfiguration()
-        config.attachment = VZBridgedNetworkDeviceAttachment(interface: vzIface)
+        config.attachment = VZFileHandleNetworkDeviceAttachment(fileHandle: fileHandle)
         if let mac = macAddress, let vzMac = VZMACAddress(string: mac.description) {
             config.macAddress = vzMac
         }

--- a/Sources/Containerization/Interface.swift
+++ b/Sources/Containerization/Interface.swift
@@ -20,7 +20,7 @@ import ContainerizationExtras
 public protocol Interface: Sendable {
     /// The interface IPv4 address and subnet prefix length, as a CIDR address.
     /// Example: `192.168.64.3/24`
-    var ipv4Address: CIDRv4 { get }
+    var ipv4Address: CIDRv4? { get }
 
     /// The IPv4 gateway address for the default route, or nil for no IPv4 default route.
     var ipv4Gateway: IPv4Address? { get }

--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -724,7 +724,7 @@ extension LinuxContainer {
                     // For every interface asked for:
                     // 1. Add the address requested
                     // 2. Online the adapter
-                    // 3. For the first interface, add the default route
+                    // 3. For the first interface with a static address, add the default route
                     var defaultRouteSet = false
                     for (index, i) in self.interfaces.enumerated() {
                         let name = "eth\(index)"

--- a/Sources/Containerization/LinuxPod.swift
+++ b/Sources/Containerization/LinuxPod.swift
@@ -784,7 +784,7 @@ extension LinuxPod {
                     // For every interface asked for:
                     // 1. Add the address requested
                     // 2. Online the adapter
-                    // 3. For the first interface, add the default route
+                    // 3. For the first interface with a static address, add the default route
                     var defaultRouteSet = false
                     for (index, i) in self.interfaces.enumerated() {
                         let name = "eth\(index)"

--- a/Sources/Containerization/NATInterface.swift
+++ b/Sources/Containerization/NATInterface.swift
@@ -17,7 +17,7 @@
 import ContainerizationExtras
 
 public struct NATInterface: Interface {
-    public var ipv4Address: CIDRv4
+    public var ipv4Address: CIDRv4?
     public var ipv4Gateway: IPv4Address?
     public var ipv6Address: CIDRv6?
     public var ipv6Gateway: IPv6Address?

--- a/Sources/Containerization/NATNetworkInterface.swift
+++ b/Sources/Containerization/NATNetworkInterface.swift
@@ -26,7 +26,7 @@ import Synchronization
 /// container/virtual machine.
 @available(macOS 26, *)
 public final class NATNetworkInterface: Interface, Sendable {
-    public let ipv4Address: CIDRv4
+    public let ipv4Address: CIDRv4?
     public let ipv4Gateway: IPv4Address?
     public let macAddress: MACAddress?
     public let mtu: UInt32

--- a/Sources/Containerization/VirtualMachineAgent+Interface.swift
+++ b/Sources/Containerization/VirtualMachineAgent+Interface.swift
@@ -26,19 +26,22 @@ extension VirtualMachineAgent {
         setDefaultRoute: Bool,
         logger: Logger?
     ) async throws {
-        logger?.debug("setting up interface \(name) with v4 \(interface.ipv4Address) v6 \(interface.ipv6Address?.description ?? "<none>")")
-        try await addressAdd(
-            name: name,
-            address: .init(ipv4Address: interface.ipv4Address, ipv6Address: interface.ipv6Address)
-        )
-        try await up(name: name, mtu: interface.mtu)
-
-        guard setDefaultRoute else { return }
-
         let ipv4Address = interface.ipv4Address
         let ipv4Gateway = interface.ipv4Gateway
         let ipv6Gateway = interface.ipv6Gateway
         let ipv6Address = interface.ipv6Address
+
+        if let ipv4Address {
+            logger?.debug("setting up interface \(name) with v4 \(ipv4Address) v6 \(interface.ipv6Address?.description ?? "<none>")")
+            try await addressAdd(
+                name: name,
+                address: .init(ipv4Address: ipv4Address, ipv6Address: interface.ipv6Address)
+            )
+        }
+        try await up(name: name, mtu: interface.mtu)
+
+        guard setDefaultRoute else { return }
+        guard let ipv4Address else { return }
 
         let needsIPv4LinkRoute: Bool
         if let ipv4Gateway {

--- a/Sources/Containerization/VmnetNetwork.swift
+++ b/Sources/Containerization/VmnetNetwork.swift
@@ -114,7 +114,7 @@ public struct VmnetNetwork: Network {
 
     /// A network interface supporting the vmnet_network_ref.
     public struct Interface: Containerization.Interface, VZInterface, Sendable {
-        public let ipv4Address: CIDRv4
+        public let ipv4Address: CIDRv4?
         public let ipv4Gateway: IPv4Address?
         public let ipv6Address: CIDRv6?
         public let ipv6Gateway: IPv6Address?

--- a/Sources/Integration/ContainerTests.swift
+++ b/Sources/Integration/ContainerTests.swift
@@ -5215,7 +5215,9 @@ extension IntegrationSuite {
         }
 
         // Capture the v4 address vmnet allocated so we can assert it ends up on eth0.
-        let expectedV4 = interface.ipv4Address.address.description
+        guard let expectedV4 = interface.ipv4Address?.address.description else {
+            throw IntegrationError.assert(msg: "network interface needs IPv4 address")
+        }
 
         let addrBuffer = BufferWriter()
         let routeBuffer = BufferWriter()

--- a/Sources/cctl/RunCommand.swift
+++ b/Sources/cctl/RunCommand.swift
@@ -142,11 +142,10 @@ extension Application {
                 }
 
                 // Add host entry for the container using just the IP (not CIDR)
-                if #available(macOS 26, *), !config.interfaces.isEmpty {
-                    let interface = config.interfaces[0]
+                if #available(macOS 26, *), let addr = config.interfaces.first?.ipv4Address {
                     hosts.entries.append(
                         Hosts.Entry(
-                            ipAddress: interface.ipv4Address.address.description,
+                            ipAddress: addr.address.description,
                             hostnames: [id]
                         ))
                 }

--- a/Tests/ContainerizationTests/ContainerManagerTests.swift
+++ b/Tests/ContainerizationTests/ContainerManagerTests.swift
@@ -26,7 +26,7 @@ import Testing
 @testable import Containerization
 
 private struct NilGatewayInterface: Interface {
-    let ipv4Address: CIDRv4
+    let ipv4Address: CIDRv4?
     let ipv4Gateway: IPv4Address? = nil
     let macAddress: MACAddress? = nil
 

--- a/Tests/ContainerizationTests/InterfaceTests.swift
+++ b/Tests/ContainerizationTests/InterfaceTests.swift
@@ -24,7 +24,7 @@ struct InterfaceTests {
     /// A minimal `Interface` conformer that only sets the IPv4 surface, relying on the
     /// protocol's default extensions to fill in `ipv6Address`, `ipv6Gateway`, and `mtu`.
     private struct V4OnlyInterface: Interface {
-        let ipv4Address: CIDRv4
+        let ipv4Address: CIDRv4?
         let ipv4Gateway: IPv4Address?
         let macAddress: MACAddress?
     }

--- a/vminitd/Sources/VminitdCore/Server+GRPC.swift
+++ b/vminitd/Sources/VminitdCore/Server+GRPC.swift
@@ -1467,13 +1467,12 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
         request: Com_Apple_Containerization_Sandbox_V3_ConfigureDnsRequest,
         context: GRPCCore.ServerContext
     ) async throws -> Com_Apple_Containerization_Sandbox_V3_ConfigureDnsResponse {
-        let domain = request.hasDomain ? request.domain : nil
         log.debug(
             "configureDns",
             metadata: [
                 "location": "\(request.location)",
                 "nameservers": "\(request.nameservers)",
-                "domain": "\(domain ?? "")",
+                "domain": "\(request.hasDomain ? request.domain : "")",
                 "searchDomains": "\(request.searchDomains)",
                 "options": "\(request.options)",
             ])
@@ -1482,8 +1481,27 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
             let etc = URL(fileURLWithPath: request.location).appendingPathComponent("etc")
             try FileManager.default.createDirectory(atPath: etc.path, withIntermediateDirectories: true)
             let resolvConf = etc.appendingPathComponent("resolv.conf")
+            var nameservers = request.nameservers
+            var domain = request.hasDomain ? request.domain : nil
+            if nameservers.isEmpty || domain == nil,
+                let pnp = try? String(contentsOfFile: "/proc/net/pnp", encoding: .utf8)
+            {
+                let lines = pnp.split(separator: "\n")
+                if nameservers.isEmpty {
+                    nameservers =
+                        lines
+                        .filter { $0.hasPrefix("nameserver") }
+                        .compactMap { $0.split(separator: " ").dropFirst().first.map(String.init) }
+                }
+                if domain == nil {
+                    domain =
+                        lines
+                        .first { $0.hasPrefix("domain") }
+                        .flatMap { $0.split(separator: " ").dropFirst().first.map(String.init) }
+                }
+            }
             let config = DNS(
-                nameservers: request.nameservers,
+                nameservers: nameservers,
                 domain: domain,
                 searchDomains: request.searchDomains,
                 options: request.options


### PR DESCRIPTION
Based on [@torarnv's existing PR](https://github.com/apple/containerization/pull/709) this PR adds also exposes a `VZFileHandleNetworkDeviceAttachment` via a`FileHandleNetworkInterface` to allow connection a container to an arbitrary file handle provided by another service.

This attachment is used by tools like [nirs/vmnet-helper](https://github.com/nirs/vmnet-helper) to bridge the container to an existing host interface. It opens also up the possibility to add a similar service directly into container to circumvent the need for without having the binary signed with the `com.apple.vm.networking` entitlement, e.g. during container development.