### PR TITLE
Add totalAllocatedSize to ContentStore

### DIFF
--- a/Sources/ContainerizationOCI/Content/ContentStoreProtocol.swift
+++ b/Sources/ContainerizationOCI/Content/ContentStoreProtocol.swift
@@ -60,4 +60,8 @@ public protocol ContentStore: Sendable {
     /// Cancels a previously started ingest session corresponding to `id`.
     /// The contents from the ingest directory corresponding to the session are removed.
     func cancelIngestSession(_ id: String) async throws
+
+    /// Total bytes allocated on disk for the content store, covering
+    /// committed blobs and any active ingest sessions.
+    func totalAllocatedSize() async throws -> UInt64
 }

--- a/Sources/ContainerizationOCI/Content/LocalContentStore.swift
+++ b/Sources/ContainerizationOCI/Content/LocalContentStore.swift
@@ -198,4 +198,29 @@ public actor LocalContentStore: ContentStore {
         let fileManager = FileManager.default
         try? fileManager.removeItem(at: temporaryPath)
     }
+
+    /// Total bytes allocated on disk for the content store, covering
+    /// committed blobs and any active ingest sessions.
+    public func totalAllocatedSize() throws -> UInt64 {
+        let fileManager = FileManager.default
+        guard
+            let enumerator = fileManager.enumerator(
+                at: self._basePath,
+                includingPropertiesForKeys: [.totalFileAllocatedSizeKey],
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            throw ContainerizationError(.internalError, message: "failed to enumerate content store at \(self._basePath.path)")
+        }
+        var size: UInt64 = 0
+        for case let fileURL as URL in enumerator {
+            guard let values = try? fileURL.resourceValues(forKeys: [.totalFileAllocatedSizeKey]),
+                let fileSize = values.totalFileAllocatedSize
+            else {
+                continue
+            }
+            size += UInt64(fileSize)
+        }
+        return size
+    }
 }

--- a/Tests/ContainerizationOCITests/LocalContentStoreTests.swift
+++ b/Tests/ContainerizationOCITests/LocalContentStoreTests.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerizationOCI
+
+@Suite
+struct LocalContentStoreTests {
+    private static let digestA = String(repeating: "a", count: 64)
+    private static let digestB = String(repeating: "b", count: 64)
+
+    @Test func totalAllocatedSizeReportsZeroForEmptyStore() async throws {
+        let dir = FileManager.default.uniqueTemporaryDirectory(create: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = try LocalContentStore(path: dir)
+        let size = try await store.totalAllocatedSize()
+        #expect(size == 0)
+    }
+
+    @Test func totalAllocatedSizeReflectsCommittedBlobs() async throws {
+        let dir = FileManager.default.uniqueTemporaryDirectory(create: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = try LocalContentStore(path: dir)
+        let payload = Data(repeating: 0xAB, count: 64 * 1024)
+
+        try await store.ingest { tempDir in
+            try payload.write(to: tempDir.appendingPathComponent(Self.digestA))
+        }
+
+        let size = try await store.totalAllocatedSize()
+        #expect(size >= UInt64(payload.count))
+    }
+
+    @Test func totalAllocatedSizeIncludesInFlightIngest() async throws {
+        let dir = FileManager.default.uniqueTemporaryDirectory(create: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = try LocalContentStore(path: dir)
+        let payload = Data(repeating: 0xCD, count: 32 * 1024)
+
+        let session = try await store.newIngestSession()
+        try payload.write(to: session.ingestDir.appendingPathComponent(Self.digestB))
+
+        let size = try await store.totalAllocatedSize()
+        #expect(size >= UInt64(payload.count))
+
+        try await store.cancelIngestSession(session.id)
+    }
+}


### PR DESCRIPTION
This PR adds `totalAllocatedSize()` to the `ContentStore` protocol so it can be used to get the on-disk footprint without reaching past the abstraction. `LocalContentStore` implements it by walking its base path, covering both committed blobs and active ingest sessions.