### PR TITLE
ContentStore: Fix totalAllocatedSize on Linux

### DIFF
--- a/Sources/ContainerizationOCI/Content/LocalContentStore.swift
+++ b/Sources/ContainerizationOCI/Content/LocalContentStore.swift
@@ -206,7 +206,7 @@ public actor LocalContentStore: ContentStore {
         guard
             let enumerator = fileManager.enumerator(
                 at: self._basePath,
-                includingPropertiesForKeys: [.totalFileAllocatedSizeKey],
+                includingPropertiesForKeys: [.totalFileAllocatedSizeKey, .isRegularFileKey],
                 options: [.skipsHiddenFiles]
             )
         else {
@@ -214,9 +214,13 @@ public actor LocalContentStore: ContentStore {
         }
         var size: UInt64 = 0
         for case let fileURL as URL in enumerator {
-            guard let values = try? fileURL.resourceValues(forKeys: [.totalFileAllocatedSizeKey]),
+            guard let values = try? fileURL.resourceValues(forKeys: [.totalFileAllocatedSizeKey, .isRegularFileKey]), values.isRegularFile == true,
                 let fileSize = values.totalFileAllocatedSize
             else {
+                // Skip directories and other non-regular entries. On Linux,
+                // `.totalFileAllocatedSizeKey` reports block allocation for
+                // directories, which would otherwise count empty-store
+                // inode overhead as content.
                 continue
             }
             size += UInt64(fileSize)


### PR DESCRIPTION
`.totalFileAllocatedSizeKey` returns nil for directories on Darwin but on Linux it returns `st_blocks * st_blksize` (4 KB each) in Foundation. The empty-store test summed three directory inodes on Linux and failed with `#expect(size == 0)`. This change adds filter on the enumerator to regular files only so the totals are content-only and will work for both Darwin and Linux.