### PR TITLE
fix(Platform): make arm64 nil-variant and v8 hash identically

### DIFF
--- a/Sources/ContainerizationOCI/Platform.swift
+++ b/Sources/ContainerizationOCI/Platform.swift
@@ -277,7 +277,14 @@ extension Platform: Hashable {
     }
 
     public func hash(into hasher: inout Swift.Hasher) {
-        hasher.combine(description)
+        hasher.combine(os)
+        hasher.combine(architecture)
+        // arm64 with no variant is equivalent to arm64/v8 per the == implementation
+        if architecture == "arm64" {
+            hasher.combine(variant ?? "v8")
+        } else {
+            hasher.combine(variant)
+        }
     }
 }
 

--- a/Tests/ContainerizationOCITests/OCIPlatformTests.swift
+++ b/Tests/ContainerizationOCITests/OCIPlatformTests.swift
@@ -66,4 +66,19 @@ struct OCIPlatformTests {
         let rhs = Platform(arch: "arm64", os: "linux", variant: nil)
         #expect(lhs == rhs, "Both nil variants => variantEqual is true => overall equal")
     }
+
+    @Test func arm64_nilAndV8_sameHashValue() {
+        let withoutVariant = Platform(arch: "arm64", os: "linux", variant: nil)
+        let withV8 = Platform(arch: "arm64", os: "linux", variant: "v8")
+        // Equal platforms must produce the same hash — violating this breaks Set/Dictionary lookups
+        #expect(withoutVariant.hashValue == withV8.hashValue, "arm64 nil variant and v8 must hash identically")
+    }
+
+    @Test func arm64_nilAndV8_setLookup() {
+        let withoutVariant = Platform(arch: "arm64", os: "linux", variant: nil)
+        let withV8 = Platform(arch: "arm64", os: "linux", variant: "v8")
+        var set = Set<Platform>()
+        set.insert(withoutVariant)
+        #expect(set.contains(withV8), "arm64/v8 must be found in a Set that contains arm64 with nil variant")
+    }
 }


### PR DESCRIPTION
## Summary

`Platform.==` treats `arm64` with `nil` variant as equal to `arm64/v8`, but `hash(into:)` used `description` which serializes them differently (`linux/arm64` vs `linux/arm64/v8`). This violates the `Hashable` contract — equal values must produce the same hash.

### Root cause

```swift
// == returns true for these two
let a = Platform(arch: "arm64", os: "linux", variant: nil)
let b = Platform(arch: "arm64", os: "linux", variant: "v8")
a == b // true ✓

// but hash was different — broken
a.hashValue == b.hashValue // false ✗ (before this fix)
```

This mismatch caused `Set<Platform>` and `Dictionary<Platform, ...>` lookups to silently miss entries when one platform was decoded from JSON (no `variant` field in the manifest) and another was created via `Platform(from:)` or `Platform.current` (which both set `variant = "v8"`).

### Practical consequence

In `apple/container`, this manifests as inconsistent platform-string normalization across stages of a single `container build` — some stages log `linux/arm64`, others `linux/arm64/v8` — which can cause `COPY --from=<stage>` to fail to resolve the source stage under concurrent builds. See apple/container#1542.

### Fix

`hash(into:)` now normalizes `arm64` with `nil` variant to `"v8"` before hashing, matching the existing `==` behavior.