### PR TITLE
Send User-Agent header on registry requests

### DIFF
--- a/Sources/ContainerizationOCI/Client/RegistryClient.swift
+++ b/Sources/ContainerizationOCI/Client/RegistryClient.swift
@@ -167,8 +167,8 @@ public final class RegistryClient: ContentClient {
             request.headers.add(name: "Authorization", value: "\(token)")
         }
 
-        // Add any arbitrary headers
-        headers?.forEach { (k, v) in request.headers.add(name: k, value: v) }
+        // Add any arbitrary headers.
+        requestHeaders(merging: headers).forEach { (k, v) in request.headers.add(name: k, value: v) }
         var retryCount = 0
         var response: HTTPClientResponse?
         while true {
@@ -256,6 +256,17 @@ public final class RegistryClient: ContentClient {
             throw ContainerizationError(.internalError, message: "invalid response")
         }
         return try await closure(response)
+    }
+
+    internal func requestHeaders(merging headers: [(String, String)]?) -> [(String, String)] {
+        var merged: [(String, String)] = []
+        if headers?.contains(where: { $0.0.caseInsensitiveCompare("User-Agent") == .orderedSame }) != true {
+            merged.append(("User-Agent", clientID))
+        }
+        if let headers {
+            merged.append(contentsOf: headers)
+        }
+        return merged
     }
 
     internal func requestData(

--- a/Tests/ContainerizationOCITests/RegistryClientTests.swift
+++ b/Tests/ContainerizationOCITests/RegistryClientTests.swift
@@ -100,6 +100,25 @@ struct OCIClientTests: ~Copyable {
         try await client.ping()
     }
 
+    @Test func requestHeadersAddDefaultUserAgent() async throws {
+        let client = RegistryClient(host: "ghcr.io", clientID: "containerization-tests")
+        let headers = client.requestHeaders(merging: [("Accept", "*/*")])
+
+        #expect(headers.contains { $0.0 == "User-Agent" && $0.1 == "containerization-tests" })
+        #expect(headers.contains { $0.0 == "Accept" && $0.1 == "*/*" })
+    }
+
+    @Test func requestHeadersKeepExplicitUserAgent() async throws {
+        let client = RegistryClient(host: "ghcr.io", clientID: "containerization-tests")
+        let headers = client.requestHeaders(merging: [
+            ("Accept", "*/*"),
+            ("user-agent", "custom-client"),
+        ])
+
+        #expect(!headers.contains { $0.0 == "User-Agent" && $0.1 == "containerization-tests" })
+        #expect(headers.contains { $0.0 == "user-agent" && $0.1 == "custom-client" })
+    }
+
     @Test func resolve() async throws {
         let client = RegistryClient(host: "ghcr.io")
         let descriptor = try await client.resolve(name: "apple/containerization/dockermanifestimage", tag: "0.0.2")


### PR DESCRIPTION
## Summary
- add a default User-Agent header to RegistryClient requests using the existing clientID value
- keep an explicitly supplied User-Agent header when callers provide one
- cover default and explicit User-Agent header behavior in registry client tests

Fixes apple/container#1583.

## Testing
- git diff --check
- swift test --filter requestHeaders (blocked locally: package requires Swift tools 6.2.0, installed Swift is 6.0.3)