### PR TITLE
Pin macOS CI builds to Swift 6.3 for now.

### DIFF
--- a/.github/workflows/containerization-build-template.yml
+++ b/.github/workflows/containerization-build-template.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
       packages: write
     env:
-      DEVELOPER_DIR: "/Applications/Xcode-latest.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode_swift_6.3.app/Contents/Developer"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
- CI runners moved to the Xcode developer beta as the default, but macOS builds are failing with a conflicting options error for `-warnings-as-errors` and `-suppress-warnings`.