### PR TITLE
fix(EXT4): create missing parent dirs for hardlinks during unpack

### DIFF
--- a/Sources/ContainerizationEXT4/EXT4+Formatter.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Formatter.swift
@@ -166,6 +166,8 @@ extension EXT4 {
             if self.tree.lookup(path: link) != nil {
                 try self.unlink(path: link)
             }
+            // create all predecessors recursively
+            try self.create(path: parentPath, mode: Inode.Mode(.S_IFDIR, 0o755), recursion: true)
             guard let parentTreeNodePtr = self.tree.lookup(path: parentPath) else {
                 throw Error.notFound(parentPath)
             }

--- a/Tests/ContainerizationEXT4Tests/TestEXT4Format+Link.swift
+++ b/Tests/ContainerizationEXT4Tests/TestEXT4Format+Link.swift
@@ -43,6 +43,25 @@ struct Ext4FormatLinkTests {
         #expect(try EXT4.EXT4Reader(blockDevice: afterUnlink).stat("/original").inode.linksCount == 1)
     }
 
+    @Test func hardlinkCreatesMissingParents() throws {
+        let path = FilePath(
+            FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: false))
+        defer { try? FileManager.default.removeItem(at: path.url) }
+        let fmt = try EXT4.Formatter(path, minDiskSize: 32.kib())
+        try fmt.create(path: "/original", mode: EXT4.Inode.Mode(.S_IFREG, 0o755), buf: nil)
+        // Parent dirs /a and /a/b do not exist yet; link must create them implicitly.
+        try fmt.link(link: "/a/b/hardlink", target: "/original")
+        try fmt.close()
+
+        let reader = try EXT4.EXT4Reader(blockDevice: path)
+        #expect(try reader.stat("/a").inode.mode.isDir())
+        #expect(try reader.stat("/a/b").inode.mode.isDir())
+        let target = try reader.stat("/original")
+        #expect(try reader.stat("/a/b/hardlink").inodeNumber == target.inodeNumber)
+        #expect(target.inode.linksCount == 2)
+    }
+
     @Test func unlinkFirstInodeFreesInode() throws {
         let emptyPath = FilePath(FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: false))
         defer { try? FileManager.default.removeItem(at: emptyPath.url) }

--- a/Tests/ContainerizationEXT4Tests/TestFormatterUnpack.swift
+++ b/Tests/ContainerizationEXT4Tests/TestFormatterUnpack.swift
@@ -361,6 +361,97 @@ struct UnpackProgressTest {
         let childNames = Set(children.map { $0.0 })
         #expect(childNames.contains("test"), "Directory 'test' should exist in unpacked filesystem")
     }
+
+    @Test func unpackCreatesImplicitParentsForHardlink() async throws {
+        // A hardlink whose parent dir has no explicit archive entry must unpack: the
+        // missing parents are created implicitly instead of failing with "... not found".
+        // This is the exact repro shape (e.g. Bazel rules_img runfiles trees).
+        let tempDir = FileManager.default.uniqueTemporaryDirectory()
+        let archivePath = tempDir.appendingPathComponent("hardlink.tar.gz", isDirectory: false)
+        let fsPath = FilePath(tempDir.appendingPathComponent("hardlink.ext4.img", isDirectory: false))
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let archiver = try ArchiveWriter(
+            configuration: ArchiveWriterConfiguration(format: .paxRestricted, filter: .gzip))
+        try archiver.open(file: archivePath)
+        // The hardlink target. /bin itself has no explicit dir entry either.
+        let payload = Data("hello".utf8)
+        try archiver.writeEntry(
+            entry: WriteEntry.file(path: "/bin/app", permissions: 0o755, size: Int64(payload.count)),
+            data: payload)
+        // The parent dir /bin/app.runfiles/_main/app_ has no explicit archive entry.
+        try archiver.writeEntry(
+            entry: WriteEntry.hardlink(path: "/bin/app.runfiles/_main/app_/app", target: "/bin/app"),
+            data: nil)
+        try archiver.finishEncoding()
+
+        let formatter = try EXT4.Formatter(fsPath)
+        try await formatter.unpack(source: archivePath)  // must not throw notFound
+        try formatter.close()
+
+        let reader = try EXT4.EXT4Reader(blockDevice: fsPath)
+        // Implicitly-created parent directories exist and are directories.
+        #expect(try reader.stat("/bin/app.runfiles").inode.mode.isDir())
+        #expect(try reader.stat("/bin/app.runfiles/_main").inode.mode.isDir())
+        #expect(try reader.stat("/bin/app.runfiles/_main/app_").inode.mode.isDir())
+        // Hardlink resolves to the target inode and bumps the link count to 2.
+        let target = try reader.stat("/bin/app")
+        let hardlink = try reader.stat("/bin/app.runfiles/_main/app_/app")
+        #expect(hardlink.inodeNumber == target.inodeNumber)
+        #expect(target.inode.linksCount == 2)
+    }
+
+    @Test func unpackCreatesImplicitParentsForSymlink() async throws {
+        // A symlink whose parent dir has no explicit archive entry must unpack.
+        let tempDir = FileManager.default.uniqueTemporaryDirectory()
+        let archivePath = tempDir.appendingPathComponent("symlink.tar.gz", isDirectory: false)
+        let fsPath = FilePath(tempDir.appendingPathComponent("symlink.ext4.img", isDirectory: false))
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let archiver = try ArchiveWriter(
+            configuration: ArchiveWriterConfiguration(format: .paxRestricted, filter: .gzip))
+        try archiver.open(file: archivePath)
+        // The parent dir /etc/links has no explicit archive entry.
+        try archiver.writeEntry(
+            entry: WriteEntry.link(path: "/etc/links/cur", permissions: 0o777, target: "/bin/app"),
+            data: nil)
+        try archiver.finishEncoding()
+
+        let formatter = try EXT4.Formatter(fsPath)
+        try await formatter.unpack(source: archivePath)  // must not throw notFound
+        try formatter.close()
+
+        let reader = try EXT4.EXT4Reader(blockDevice: fsPath)
+        #expect(try reader.stat("/etc/links").inode.mode.isDir())
+        #expect(try reader.stat("/etc/links/cur", followSymlinks: false).inode.mode.isLink())
+    }
+
+    @Test func unpackCreatesImplicitParentsForRegularFile() async throws {
+        // A regular file whose parent dir has no explicit archive entry must unpack.
+        let tempDir = FileManager.default.uniqueTemporaryDirectory()
+        let archivePath = tempDir.appendingPathComponent("file.tar.gz", isDirectory: false)
+        let fsPath = FilePath(tempDir.appendingPathComponent("file.ext4.img", isDirectory: false))
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let archiver = try ArchiveWriter(
+            configuration: ArchiveWriterConfiguration(format: .paxRestricted, filter: .gzip))
+        try archiver.open(file: archivePath)
+        // The parent dir /var/lib/data has no explicit archive entry.
+        let payload = Data("world".utf8)
+        try archiver.writeEntry(
+            entry: WriteEntry.file(path: "/var/lib/data/file.txt", permissions: 0o644, size: Int64(payload.count)),
+            data: payload)
+        try archiver.finishEncoding()
+
+        let formatter = try EXT4.Formatter(fsPath)
+        try await formatter.unpack(source: archivePath)  // must not throw notFound
+        try formatter.close()
+
+        let reader = try EXT4.EXT4Reader(blockDevice: fsPath)
+        #expect(try reader.stat("/var/lib/data").inode.mode.isDir())
+        #expect(try reader.stat("/var/lib/data/file.txt").inode.mode.isReg())
+        #expect(try reader.readFile(at: "/var/lib/data/file.txt") == payload)
+    }
 }
 
 extension ContainerizationArchive.WriteEntry {
@@ -389,6 +480,14 @@ extension ContainerizationArchive.WriteEntry {
         entry.path = path
         entry.fileType = .symbolicLink
         entry.symlinkTarget = target
+        return entry
+    }
+
+    static func hardlink(path: String, target: String) -> WriteEntry {
+        let entry = WriteEntry()
+        entry.path = path
+        entry.fileType = .regular
+        entry.hardlink = target
         return entry
     }
 }


### PR DESCRIPTION
When unpacking an OCI/tar layer, create() already creates missing parent directories recursively, so regular files and symlinks with absent parent entries unpack correctly. link() did not, so a hardlink whose parent directory had no explicit archive entry failed with "<path> not found" (e.g. images produced by Bazel rules_img). Mirror create()'s implicit parent creation in link() so such layers unpack, matching Docker/containerd.

Adds a direct link() unit test and an end-to-end unpack regression test covering a hardlink, regular file, and symlink with no explicit parent.

Fixes https://github.com/apple/container/issues/1797