### PR TITLE
Relax escaping requirement for closures in Async{Lock|Mutex}

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -922,7 +922,7 @@ extension LinuxContainer {
                 agent: agent,
                 vm: startedState.vm,
                 logger: self.logger,
-                onDelete: { [weak self = self] in
+                onDelete: { [weak self] in
                     await self?.removeProcess(id: id)
                 }
             )
@@ -959,7 +959,7 @@ extension LinuxContainer {
                 agent: agent,
                 vm: state.vm,
                 logger: self.logger,
-                onDelete: { [weak self = self] in
+                onDelete: { [weak self] in
                     await self?.removeProcess(id: id)
                 }
             )

--- a/Sources/ContainerizationExtras/AsyncLock.swift
+++ b/Sources/ContainerizationExtras/AsyncLock.swift
@@ -34,7 +34,7 @@ public actor AsyncLock {
     }
 
     /// withLock provides a scoped locking API to run a function while holding the lock.
-    public func withLock<T: Sendable>(logMetadata: Logger.Metadata? = nil, _ body: @Sendable @escaping (Context) async throws -> T) async rethrows -> T {
+    public func withLock<T: Sendable>(logMetadata: Logger.Metadata? = nil, _ body: @Sendable (Context) async throws -> T) async rethrows -> T {
         log?.debug("acquiring lock", metadata: logMetadata)
         while self.busy {
             await withCheckedContinuation { cc in

--- a/Sources/ContainerizationExtras/AsyncMutex.swift
+++ b/Sources/ContainerizationExtras/AsyncMutex.swift
@@ -36,7 +36,7 @@ public actor AsyncMutex<T: Sendable> {
 
     /// withLock provides a scoped locking API to run a function while holding the lock.
     /// The protected value is passed to the closure for safe access.
-    public func withLock<R: Sendable>(_ body: @Sendable @escaping (inout T) async throws -> R) async rethrows -> R {
+    public func withLock<R: Sendable>(_ body: @Sendable (inout T) async throws -> R) async rethrows -> R {
         while self.busy {
             await withCheckedContinuation { cc in
                 self.queue.append(cc)


### PR DESCRIPTION
I was looking into why https://github.com/apple/containerization/pull/696 was implemented, which was a fix for new warnings in the 6.4 compiler, and was confused why the diagnostic would be firing in the case it appeared to address. It turns out this was due to the `AsyncMutex.withLock` method taking an escaping closure parameter. However, the closure does not actually escape, so we can undo that prior workaround and make the API slightly more general by dropping the `@escaping` attribute. The same reasoning applies to `AsyncLock` as well, so for consistency I applied the change there too.

This does alter a public API though and I'm not sure what the source compatibility goals of this project are exactly, so let me know if you think that will be problematic.