### PR TITLE
fix(oci): render arm64 platform description without redundant v8

### DIFF
--- a/Sources/ContainerizationOCI/Platform.swift
+++ b/Sources/ContainerizationOCI/Platform.swift
@@ -47,13 +47,25 @@ public struct Platform: Sendable, Equatable {
         return .init(arch: normalized.arch, os: "linux", variant: normalized.variant)
     }
 
-    /// The computed description, for example, `linux/arm64/v8`.
+    /// The computed description, for example, `linux/amd64` or `linux/arm/v7`.
+    ///
+    /// `arm64`'s only defined variant is `v8`, which `==` and `hash` already treat as
+    /// equivalent to a `nil` variant. The redundant `v8` is therefore omitted so that
+    /// two equal arm64 platforms (one with `variant == nil`, one with `"v8"`) describe
+    /// identically as `linux/arm64`, rather than drifting between `arm64` and
+    /// `arm64/v8`.
     public var description: String {
         let architecture = architecture
-        if let variant = variant {
+        if let variant, !Self.isRedundantVariant(variant, for: architecture) {
             return "\(os)/\(architecture)/\(variant)"
         }
         return "\(os)/\(architecture)"
+    }
+
+    /// Whether `variant` is the canonical default for `architecture` and can be omitted
+    /// from the rendered description without losing information.
+    private static func isRedundantVariant(_ variant: String, for architecture: String) -> Bool {
+        architecture == "arm64" && variant == "v8"
     }
 
     /// The CPU architecture, for example, `amd64` or `arm64`.

--- a/Tests/ContainerizationOCITests/OCIPlatformTests.swift
+++ b/Tests/ContainerizationOCITests/OCIPlatformTests.swift
@@ -115,4 +115,40 @@ struct OCIPlatformTests {
         #expect(!matcher(Platform(arch: "arm64", os: "windows", variant: "v8")), "matcher must reject a differing OS")
         #expect(matcher(Platform(arch: "arm64", os: "linux", variant: "v8")), "matcher must accept the same OS with an implied v8 variant")
     }
+
+    // MARK: - description consistency
+
+    @Test func arm64_nilAndV8_sameDescription() {
+        let withoutVariant = Platform(arch: "arm64", os: "linux", variant: nil)
+        let withV8 = Platform(arch: "arm64", os: "linux", variant: "v8")
+        #expect(
+            withoutVariant.description == withV8.description,
+            "equal arm64 platforms must produce the same description"
+        )
+    }
+
+    @Test func arm64_descriptionDropsRedundantV8() {
+        let withV8 = Platform(arch: "arm64", os: "linux", variant: "v8")
+        #expect(withV8.description == "linux/arm64", "arm64/v8 is canonical arm64, rendered without the redundant variant")
+    }
+
+    @Test func arm64_nilVariantDescription() {
+        let withoutVariant = Platform(arch: "arm64", os: "linux", variant: nil)
+        #expect(withoutVariant.description == "linux/arm64")
+    }
+
+    @Test func arm64_fromStringWithV8DescriptionIsCanonical() throws {
+        let parsed = try Platform(from: "linux/arm64/v8")
+        #expect(parsed.description == "linux/arm64", "parsing arm64/v8 then describing must yield the canonical short form")
+    }
+
+    @Test func arm_v7_descriptionKeepsVariant() {
+        let armv7 = Platform(arch: "arm", os: "linux", variant: "v7")
+        #expect(armv7.description == "linux/arm/v7", "non-redundant variants such as arm/v7 must be preserved")
+    }
+
+    @Test func amd64_descriptionUnaffected() {
+        let amd64 = Platform(arch: "amd64", os: "linux")
+        #expect(amd64.description == "linux/amd64")
+    }
 }


### PR DESCRIPTION
## Summary

`Platform.description` renders the same arm64 platform two different ways
depending on how the value was constructed:

```swift
Platform(arch: "arm64", os: "linux", variant: nil).description  // "linux/arm64"
Platform(arch: "arm64", os: "linux", variant: "v8").description // "linux/arm64/v8"
```

These are the **same** platform — `==`, `hash(into:)`, and `Set` membership
already treat an arm64 `nil` variant as equivalent to `"v8"` — yet they
serialize differently, so a single platform drifts between `linux/arm64` and
`linux/arm64/v8` across stages of one build (apple/container#1542).

## Relation to #764

#764 fixed the `Hashable` side of this: it stopped `hash(into:)` from using
`description` and canonicalized arm64 `nil` → `v8` in the hash. That worked
around the inconsistent `description` but did not fix it — its own summary
names `description` (`linux/arm64` vs `linux/arm64/v8`) as the root cause.
This PR fixes that remaining gap at the source.

## Change

Omit the redundant `v8` variant for arm64 when rendering `description`, so
equal arm64 platforms always describe as `linux/arm64` — matching how Docker
and containerd display the platform. Other variants (`arm/v7`) and
architectures (`amd64`) are unaffected.

Only the rendered `description` changes. The stored `variant` and the
`Codable` encoding are untouched, so OCI content digests remain stable.

## Testing

Added `OCIPlatformTests` cases for description consistency (equal arm64
platforms describe identically; `arm64/v8` renders as `linux/arm64`;
`arm/v7` and `amd64` preserved). `swift test --filter ContainerizationOCITests`
passes (55 tests); `swift format lint --strict` clean.

Closes apple/container#1542 (normalization-consistency aspect).