### PR TITLE
Fix ECR BLOB_UPLOAD_INVALID by forcing new session on push retry

### DIFF
--- a/Sources/ContainerizationOCI/Client/RegistryClient+Push.swift
+++ b/Sources/ContainerizationOCI/Client/RegistryClient+Push.swift
@@ -103,39 +103,7 @@ extension RegistryClient {
             headers = [
                 ("Content-Type", mediaType)
             ]
-        } else {
-            // Start upload request for blobs.
-            components.path = "/v2/\(name)/blobs/uploads/"
-            try await request(components: components, method: .POST) { response in
-                switch response.status {
-                case .ok, .accepted, .noContent:
-                    break
-                case .created:
-                    throw ContainerizationError(.exists, message: "content already exists \(descriptor.digest)")
-                default:
-                    let url = components.url?.absoluteString ?? "unknown"
-                    let reason = await ErrorResponse.fromResponseBody(response.body)?.jsonString
-                    throw Error.invalidStatus(url: url, response.status, reason: reason)
-                }
-
-                // Get the location to upload the blob.
-                guard let location = response.headers.first(name: "Location") else {
-                    throw ContainerizationError(.invalidArgument, message: "missing required header Location")
-                }
-
-                guard let urlComponents = URLComponents(string: location) else {
-                    throw ContainerizationError(.invalidArgument, message: "invalid url \(location)")
-                }
-                var queryItems = urlComponents.queryItems ?? []
-                queryItems.append(URLQueryItem(name: "digest", value: descriptor.digest))
-                components.path = urlComponents.path
-                components.queryItems = queryItems
-                headers = [
-                    ("Content-Type", "application/octet-stream"),
-                    ("Content-Length", String(descriptor.size)),
-                ]
-            }
-        }
+        } 
 
         // We have to pass a body closure rather than a body to reset the stream when retrying.
         let bodyClosure = {
@@ -144,19 +112,89 @@ extension RegistryClient {
             return body
         }
 
-        return try await request(components: components, method: .PUT, bodyClosure: bodyClosure, headers: headers) { response in
-            switch response.status {
-            case .ok, .created, .noContent:
-                break
-            default:
-                let url = components.url?.absoluteString ?? "unknown"
-                let reason = await ErrorResponse.fromResponseBody(response.body)?.jsonString
-                throw Error.invalidStatus(url: url, response.status, reason: reason)
-            }
+        // Establish our smart retry limits
+        let maxRetries = self.retryOptions?.maxRetries ?? 3
+        let retryInterval = self.retryOptions?.retryInterval ?? 1_000_000_000
+        var retryCount = 0
 
-            guard descriptor.digest == response.headers.first(name: "Docker-Content-Digest") else {
-                let required = response.headers.first(name: "Docker-Content-Digest") ?? ""
-                throw ContainerizationError(.internalError, message: "digest mismatch \(descriptor.digest) != \(required)")
+        while true {
+            do {
+                if !isManifest {
+                    // Start upload request for blobs to get a FRESH session URL.
+                    var postComponents = base
+                    postComponents.path = "/v2/\(name)/blobs/uploads/"
+                    
+                    // Override generic retry: we do NOT want the generic client retrying this POST
+                    try await request(
+                        components: postComponents, 
+                        method: .POST,
+                        retryOptionsOverride: RetryOptions(maxRetries: 0, retryInterval: 0)
+                    ) { response in
+                        switch response.status {
+                        case .ok, .accepted, .noContent:
+                            break
+                        case .created:
+                            throw ContainerizationError(.exists, message: "content already exists \(descriptor.digest)")
+                        default:
+                            let url = postComponents.url?.absoluteString ?? "unknown"
+                            let reason = await ErrorResponse.fromResponseBody(response.body)?.jsonString
+                            throw Error.invalidStatus(url: url, response.status, reason: reason)
+                        }
+
+                        guard let location = response.headers.first(name: "Location") else {
+                            throw ContainerizationError(.invalidArgument, message: "missing required header Location")
+                        }
+
+                        guard let urlComponents = URLComponents(string: location) else {
+                            throw ContainerizationError(.invalidArgument, message: "invalid url \(location)")
+                        }
+                        
+                        var queryItems = urlComponents.queryItems ?? []
+                        queryItems.append(URLQueryItem(name: "digest", value: descriptor.digest))
+                        components.path = urlComponents.path
+                        components.queryItems = queryItems
+                        headers = [
+                            ("Content-Type", "application/octet-stream"),
+                            ("Content-Length", String(descriptor.size)),
+                        ]
+                    }
+                }
+
+                // Execute the PUT request with generic retries completely disabled
+                try await request(
+                    components: components, 
+                    method: .PUT, 
+                    bodyClosure: bodyClosure, 
+                    headers: headers,
+                    retryOptionsOverride: RetryOptions(maxRetries: 0, retryInterval: 0)
+                ) { response in
+                    switch response.status {
+                    case .ok, .created, .noContent:
+                        break
+                    default:
+                        let url = components.url?.absoluteString ?? "unknown"
+                        let reason = await ErrorResponse.fromResponseBody(response.body)?.jsonString
+                        throw Error.invalidStatus(url: url, response.status, reason: reason)
+                    }
+
+                    guard descriptor.digest == response.headers.first(name: "Docker-Content-Digest") else {
+                        let required = response.headers.first(name: "Docker-Content-Digest") ?? ""
+                        throw ContainerizationError(.internalError, message: "digest mismatch \(descriptor.digest) != \(required)")
+                    }
+                }
+                
+                // If the PUT succeeds without throwing, we break out of our smart retry loop
+                break 
+                
+            } catch {
+                // Intercept the failure. If we haven't hit our max retries, loop again to generate a new POST session.
+                if retryCount < maxRetries {
+                    retryCount += 1
+                    try await Task.sleep(nanoseconds: retryInterval)
+                    continue
+                } else {
+                    throw error
+                }
             }
         }
     }

--- a/Sources/ContainerizationOCI/Client/RegistryClient.swift
+++ b/Sources/ContainerizationOCI/Client/RegistryClient.swift
@@ -146,6 +146,7 @@ public final class RegistryClient: ContentClient {
         method: HTTPMethod = .GET,
         bodyClosure: () throws -> HTTPClientRequest.Body? = { nil },
         headers: [(String, String)]? = nil,
+        retryOptionsOverride: RetryOptions? = nil,
         closure: (HTTPClientResponse) async throws -> T
     ) async throws -> T {
         guard let path = components.url?.absoluteString else {
@@ -173,6 +174,7 @@ public final class RegistryClient: ContentClient {
         var response: HTTPClientResponse?
         while true {
             request.body = try bodyClosure()
+            let activeRetryOptions = retryOptionsOverride ?? self.retryOptions
             do {
                 let _response = try await client.execute(request, deadline: .distantFuture)
                 response = _response
@@ -217,7 +219,7 @@ public final class RegistryClient: ContentClient {
                     retryCount += 1
                     continue
                 }
-                guard let retryOptions = self.retryOptions else {
+                guard let retryOptions = activeRetryOptions else {
                     break
                 }
                 guard retryCount < retryOptions.maxRetries else {
@@ -245,7 +247,7 @@ public final class RegistryClient: ContentClient {
                     }
                 }
                 #endif
-                guard let retryOptions = self.retryOptions, retryCount < retryOptions.maxRetries else {
+                guard let retryOptions = activeRetryOptions, retryCount < retryOptions.maxRetries else {
                     throw error
                 }
                 retryCount += 1


### PR DESCRIPTION
Fixes #790 
Resolves apple/container#1895 

### Motivation
When pushing large, multi-architecture images to AWS ECR, network interruptions cause the push to fail with a `416 Range Not Satisfiable` and `BLOB_UPLOAD_INVALID` error. 

This occurs because the generic retry loop in `RegistryClient.swift` catches the failure, resets the data stream to byte 0, and blindly retries the **exact same upload session URL**. Because ECR expects the retry to resume from the last committed byte, it rejects the byte 0 payload.

### Modifications
This PR decouples blob upload retries from the generic `RegistryClient` retry loop to allow for proper session regeneration. 

1. **`RegistryClient.swift`**: Added a `retryOptionsOverride` parameter to the generic `request()` signature. This allows specific operations to opt out of the default infinite retry loop while maintaining the client's standard behavior for auth and manifests.
2. **`RegistryClient+Push.swift`**: Completely disabled the generic retry for blob `POST` and `PUT` requests by passing `RetryOptions(maxRetries: 0, retryInterval: 0)`. 
3. **`RegistryClient+Push.swift`**: Wrapped the blob upload sequence in a dedicated, smart retry loop. If a `PUT` drops mid-upload, the loop now catches the error locally, requests a fresh session UUID via a new `POST`, and starts the byte 0 upload on that clean session.

### Result
Interrupted pushes to AWS ECR now successfully recover by abandoning the stale session and initiating a fresh upload, eliminating the 416 error.