### PR TITLE
perf: index EXT4 FileTree children by name to avoid O(n^2) unpack

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -106,6 +106,7 @@ let package = Package(
             name: "ContainerizationEXT4",
             dependencies: [
                 "ContainerizationArchive",
+                .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "SystemPackage", package: "swift-system"),
                 "ContainerizationOS",
             ],

--- a/Sources/ContainerizationEXT4/EXT4+FileTree.swift
+++ b/Sources/ContainerizationEXT4/EXT4+FileTree.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import OrderedCollections
 import SystemPackage
 
 extension EXT4 {
@@ -22,7 +23,11 @@ extension EXT4 {
         class FileTreeNode {
             let inode: InodeNumber
             let name: String
-            var children: [Ptr<FileTreeNode>] = []
+            // Children keyed by name for O(1) lookup, preserving insertion order.
+            private(set) var childrenByName: OrderedDictionary<String, Ptr<FileTreeNode>> = [:]
+            var children: OrderedDictionary<String, Ptr<FileTreeNode>>.Values {
+                childrenByName.values
+            }
             var blocks: (start: UInt32, end: UInt32)?
             var additionalBlocks: [(start: UInt32, end: UInt32)]?
             var link: InodeNumber?
@@ -39,16 +44,17 @@ extension EXT4 {
             ) {
                 self.inode = inode
                 self.name = name
-                self.children = children
                 self.blocks = blocks
                 self.additionalBlocks = additionalBlocks
                 self.link = link
                 self.parent = parent
+                for child in children {
+                    self.addChild(child)
+                }
             }
 
             deinit {
-                self.children.removeAll()
-                self.children = []
+                self.childrenByName.removeAll()
                 self.blocks = nil
                 self.additionalBlocks = nil
                 self.link = nil
@@ -63,6 +69,14 @@ extension EXT4 {
                 }
                 let path = components.reversed().joined(separator: "/")
                 return FilePath(path).lexicallyNormalized()
+            }
+
+            func addChild(_ child: Ptr<FileTreeNode>) {
+                childrenByName[child.pointee.name] = child
+            }
+
+            func removeChild(named name: String) {
+                childrenByName.removeValue(forKey: name)
             }
         }
 
@@ -82,18 +96,10 @@ extension EXT4 {
                 return node
             }
             for component in components {
-                var found = false
-                for childPtr in node.pointee.children {
-                    let child = childPtr.pointee
-                    if child.name == component {
-                        node = childPtr
-                        found = true
-                        break
-                    }
-                }
-                guard found else {
+                guard let childPtr = node.pointee.childrenByName[component] else {
                     return nil
                 }
+                node = childPtr
             }
             return node
         }

--- a/Sources/ContainerizationEXT4/EXT4+Formatter.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Formatter.swift
@@ -186,7 +186,7 @@ extension EXT4 {
                     blocks: nil,
                     link: targetNode.inode
                 ))
-            parentTreeNode.children.append(linkTreeNodePtr)
+            parentTreeNode.addChild(linkTreeNodePtr)
             parentTreeNodePtr.pointee = parentTreeNode
         }
 
@@ -254,9 +254,7 @@ extension EXT4 {
                 }
             }
             parentInodePtr.pointee = parentInode
-            parentNode.children.removeAll { childPtr in
-                childPtr.pointee.name == pathComponent
-            }
+            parentNode.removeChild(named: pathComponent)
             parentNodePtr.pointee = parentNode
 
             if let hardlink = pathNode.link {
@@ -412,7 +410,7 @@ extension EXT4 {
                         children: [],
                         blocks: (startBlock, endBlock)
                     ))
-                parentTreeNode.children.append(childTreeNodePtr)
+                parentTreeNode.addChild(childTreeNodePtr)
                 parentTreeNodePtr.pointee = parentTreeNode
             }
             childInode.mode = mode

--- a/Sources/ContainerizationEXT4/EXT4+Reader.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Reader.swift
@@ -102,7 +102,7 @@ extension EXT4 {
                         itemTreeNode.blocks = blocks.first
                     }
                     let itemTreeNodePtr = Ptr(itemTreeNode)
-                    root.children.append(itemTreeNodePtr)
+                    root.addChild(itemTreeNodePtr)
                     itemPtr.pointee = root
                     let itemInode = try self.getInode(number: itemInodeNum)
                     if itemInode.mode.isDir() {

--- a/Sources/ContainerizationEXT4/EXT4Reader+Export.swift
+++ b/Sources/ContainerizationEXT4/EXT4Reader+Export.swift
@@ -24,7 +24,7 @@ extension EXT4.EXT4Reader {
             format: .paxRestricted, filter: .none, options: [Options.xattrformat(.schily)])
         let writer = try ArchiveWriter(configuration: config)
         try writer.open(file: archive.url)
-        var items = self.tree.root.pointee.children
+        var items = Array(self.tree.root.pointee.children)
         let hardlinkedInodes = Set(self.hardlinks.values)
         var hardlinkTargets: [EXT4.InodeNumber: FilePath] = [:]
 

--- a/Tests/ContainerizationEXT4Tests/TestEXT4Reader+IO.swift
+++ b/Tests/ContainerizationEXT4Tests/TestEXT4Reader+IO.swift
@@ -617,10 +617,10 @@ struct EXT4PathIOTests {
         let tree = EXT4.FileTree(EXT4.RootInode, "/")
 
         let dirPtr = EXT4.Ptr(EXT4.FileTree.FileTreeNode(inode: 3, name: "dir", parent: tree.root))
-        tree.root.pointee.children.append(dirPtr)
+        tree.root.pointee.addChild(dirPtr)
 
         let filePtr = EXT4.Ptr(EXT4.FileTree.FileTreeNode(inode: 4, name: "file", parent: dirPtr))
-        dirPtr.pointee.children.append(filePtr)
+        dirPtr.pointee.addChild(filePtr)
 
         #expect(dirPtr.pointee.path == FilePath("/dir"))
         #expect(filePtr.pointee.path == FilePath("/dir/file"))
@@ -631,10 +631,10 @@ struct EXT4PathIOTests {
         let tree = EXT4.FileTree(EXT4.RootInode, ".")
 
         let dirPtr = EXT4.Ptr(EXT4.FileTree.FileTreeNode(inode: 3, name: "dir", parent: tree.root))
-        tree.root.pointee.children.append(dirPtr)
+        tree.root.pointee.addChild(dirPtr)
 
         let filePtr = EXT4.Ptr(EXT4.FileTree.FileTreeNode(inode: 4, name: "file", parent: dirPtr))
-        dirPtr.pointee.children.append(filePtr)
+        dirPtr.pointee.addChild(filePtr)
 
         #expect(dirPtr.pointee.path == FilePath("dir"))
         #expect(filePtr.pointee.path == FilePath("dir/file"))
@@ -645,7 +645,7 @@ struct EXT4PathIOTests {
         let tree = EXT4.FileTree(EXT4.RootInode, "dir")
 
         let filePtr = EXT4.Ptr(EXT4.FileTree.FileTreeNode(inode: 3, name: "file", parent: tree.root))
-        tree.root.pointee.children.append(filePtr)
+        tree.root.pointee.addChild(filePtr)
 
         #expect(filePtr.pointee.path == FilePath("dir/file"))
     }


### PR DESCRIPTION
## What

`FileTree.lookup` resolved each path component by linearly scanning the node's `children` array. This changes the node's child storage to an `OrderedDictionary<String, Ptr<FileTreeNode>>` (from swift-collections, which is already a package dependency) keyed by name, so `lookup` resolves each component in O(1) while iteration keeps the existing insertion order.

## Why

`EXT4.Formatter.create` calls `lookup` for every entry (and once per ancestor directory). With a linearly-scanned array, populating a directory with K entries is O(K²), which dominates unpack time for images with large directories (`node_modules`, `/usr/lib`, apt lists, …).

## Design

`childrenByName` is the single source of truth; `children` remains available as an ordered view (`.values`), so existing iterate/map call sites are unchanged. Mutation goes through two helpers on `FileTreeNode` — `addChild(_:)` and `removeChild(named:)` — used by every mutation site: `Formatter.link`, `Formatter._unlink`, `Formatter.create`, `FileTreeNode.init`, and the reader's tree build in `EXT4+Reader`. A single keyed structure also makes duplicate-name children unrepresentable.

*(An earlier revision of this PR added a separate `childIndex` dictionary mirroring the `children` array; per review feedback it now uses a single `OrderedDictionary` instead — same lookup performance, less memory, and no two structures to keep in sync.)*

## Results

Measured on Apple Silicon unpacking `louislam/uptime-kuma:1` (40,834 files / 438 MB):

- Optimized build: **~15s → ~9s (~40% faster)**.
- The relative improvement grows with directory size; in unoptimized/debug builds the absolute difference is far larger.

A single-directory microbenchmark (30,000 `create` calls into one directory, release build) runs in ~0.33s vs ~1.9s before this change, with peak RSS slightly lower than the array+index revision.

## Testing

`swift test --filter ContainerizationEXT4Tests` — all pass (62 tests), including the whiteout, hardlink, symlink, and replace-semantics cases that exercise the mutated sites.
