### PR TITLE
fix(package): exclude CloudHypervisor README

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -273,6 +273,9 @@ let package = Package(
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+            ],
+            exclude: [
+                "README.md"
             ]
         ),
         .testTarget(


### PR DESCRIPTION
## Summary

Exclude `Sources/CloudHypervisor/README.md` from the `CloudHypervisor` SwiftPM target. The README remains tracked and available as source documentation, while package evaluation and builds no longer emit an unhandled-file warning.

## Motivation

[apple/containerization#782](https://github.com/apple/containerization/pull/782) added a standalone `CloudHypervisor` target with a README inside its source directory. SwiftPM requires non-source files in target directories to be declared as resources or excluded. This README is documentation rather than a runtime resource, so exclusion is the smallest accurate manifest change.

## Changes

- Add `README.md` to the `CloudHypervisor` target's `exclude` list.
- Preserve the existing README content and location.
- Leave runtime code, products, resources, and package APIs unchanged.

## Validation

```sh
swift package describe >/dev/null
swift test --disable-automatic-resolution --filter CloudHypervisorTests
make check
git diff --check upstream/main...HEAD
```

- Package evaluation completes without the `Sources/CloudHypervisor/README.md` warning.
- All 41 focused `CloudHypervisorTests` pass.
- Swift formatting and Hawkeye license checks pass.
- The committed diff has no whitespace errors.

## Compatibility And Risk

This manifest-only change does not alter compiled sources, runtime resources, public APIs, or supported platforms. The README is already non-executable documentation, so excluding it accurately records SwiftPM's intended treatment of the file.

## Related

- Follow-up to [apple/containerization#782](https://github.com/apple/containerization/pull/782).

## Release Note Highlight

- Stops SwiftPM builds from warning about the `CloudHypervisor` README added by [apple/containerization#782](https://github.com/apple/containerization/pull/782).
