### PR TITLE
fix(copy): keep lifecycle usable after missing source

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -26,6 +26,18 @@ import SystemPackage
 
 import struct ContainerizationOS.Terminal
 
+private final class CopyOutProducerError: Sendable {
+    private let value = Mutex<(any Error)?>(nil)
+
+    func store(_ error: any Error) {
+        value.withLock { $0 = error }
+    }
+
+    func load() -> (any Error)? {
+        value.withLock { $0 }
+    }
+}
+
 /// `LinuxContainer` is an easy to use type for launching and managing the
 /// full lifecycle of a Linux container ran inside of a virtual machine.
 public final class LinuxContainer: Container, Sendable {
@@ -1353,31 +1365,51 @@ extension LinuxContainer {
             let listener = try state.vm.listen(port)
 
             let (metadataStream, metadataCont) = AsyncStream.makeStream(of: Vminitd.CopyMetadata.self)
+            let producerError = CopyOutProducerError()
+            defer {
+                metadataCont.finish()
+                try? listener.finish()
+            }
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
-                    try await state.vm.withAgent { agent in
-                        guard let vminitd = agent as? Vminitd else {
-                            throw ContainerizationError(.unsupported, message: "copyOut requires Vminitd agent")
-                        }
-                        try await vminitd.copy(
-                            direction: .copyOut,
-                            guestPath: guestPath,
-                            vsockPort: port,
-                            onMetadata: { meta in
-                                metadataCont.yield(meta)
-                                metadataCont.finish()
+                    do {
+                        try await state.vm.withAgent { agent in
+                            guard let vminitd = agent as? Vminitd else {
+                                throw ContainerizationError(.unsupported, message: "copyOut requires Vminitd agent")
                             }
-                        )
+                            try await vminitd.copy(
+                                direction: .copyOut,
+                                guestPath: guestPath,
+                                vsockPort: port,
+                                onMetadata: { meta in
+                                    metadataCont.yield(meta)
+                                    metadataCont.finish()
+                                }
+                            )
+                        }
+                    } catch {
+                        // Guest validation can fail before either stream yields.
+                        // Finish both so the sibling task can release the state lock.
+                        producerError.store(error)
+                        metadataCont.finish()
+                        try? listener.finish()
+                        throw error
                     }
                 }
 
                 group.addTask {
                     guard let metadata = await metadataStream.first(where: { _ in true }) else {
+                        if let error = producerError.load() {
+                            throw error
+                        }
                         throw ContainerizationError(.internalError, message: "copyOut: no metadata received")
                     }
 
                     guard let conn = await listener.first(where: { _ in true }) else {
+                        if let error = producerError.load() {
+                            throw error
+                        }
                         throw ContainerizationError(.internalError, message: "copyOut: vsock connection not established")
                     }
                     try listener.finish()

--- a/Sources/Integration/ContainerTests.swift
+++ b/Sources/Integration/ContainerTests.swift
@@ -2114,6 +2114,62 @@ extension IntegrationSuite {
         }
     }
 
+    func testCopyOutMissingSourceDoesNotBlockLifecycle() async throws {
+        let id = "test-copy-out-missing-source"
+
+        let bs = try await bootstrap(id)
+        let hostDestination = FileManager.default.uniqueTemporaryDirectory(create: true)
+            .appendingPathComponent("missing-output.txt")
+
+        let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
+            config.process.arguments = ["sleep", "100"]
+            config.bootLog = bs.bootLog
+        }
+
+        do {
+            try await container.create()
+            try await container.start()
+
+            do {
+                try await Timeout.run(seconds: 5) {
+                    try await container.copyOut(
+                        from: URL(filePath: "/does-not-exist"),
+                        to: hostDestination
+                    )
+                }
+                throw IntegrationError.assert(msg: "copyOut should fail for a missing source")
+            } catch is CancellationError {
+                throw IntegrationError.assert(msg: "copyOut did not fail before the timeout")
+            } catch let error as IntegrationError {
+                throw error
+            } catch {
+                let message = String(describing: error)
+                guard !message.contains("copyOut: no metadata received"),
+                    !message.contains("copyOut: vsock connection not established")
+                else {
+                    throw IntegrationError.assert(msg: "copyOut replaced the guest error with '\(message)'")
+                }
+            }
+
+            let exec = try await container.exec("after-missing-copy") { config in
+                config.arguments = ["true"]
+            }
+            try await exec.start()
+            let status = try await exec.wait()
+            try await exec.delete()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "container lifecycle remained blocked after copyOut failure")
+            }
+
+            try await container.kill(.kill)
+            try await container.wait()
+            try await container.stop()
+        } catch {
+            try? await container.stop()
+            throw error
+        }
+    }
+
     func testCopyLargeFile() async throws {
         let id = "test-copy-large-file"
 

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -465,6 +465,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             Test("container copy in file to missing directory fails", testCopyInFileToMissingDirectoryFails),
             Test("container copy in directory over existing file fails", testCopyInDirectoryOverExistingFileFails),
             Test("container copy out", testCopyOut),
+            Test("container copy out missing source does not block lifecycle", testCopyOutMissingSourceDoesNotBlockLifecycle),
             Test("container copy large file", testCopyLargeFile),
             Test("container copy in directory", testCopyInDirectory),
             Test("container copy out directory", testCopyOutDirectory),


### PR DESCRIPTION
## Summary

Finish copy-out coordination streams when guest-side source validation fails, preserve the original guest error across the task-group race, and release the container state lock so later lifecycle operations remain usable.

## Motivation

[apple/container#1927](https://github.com/apple/container/issues/1927) reports that `container cp` hangs indefinitely when the guest source path does not exist. The same container then cannot be used by `exec`, `stop`, `delete`, or system shutdown because `LinuxContainer.copyOut` still owns its state lock.

The producer task receives the guest error before emitting metadata or establishing a vsock connection. Its sibling task waits on those asynchronous streams and does not unblock merely because the task group is cancelled. The group therefore cannot unwind. Closing both streams fixes the deadlock, while a small synchronized error state ensures the consumer cannot replace the useful guest error with an internal `no metadata` or `vsock connection not established` error.

## Changes

- Finish the metadata continuation and vsock listener on every producer failure.
- Keep outer cleanup idempotent for successful and failed transfers.
- Preserve the original guest error if either consumer guard observes stream termination first.
- Add a VM integration regression that bounds missing-source copy, rejects coordination fallback errors, and runs a successful exec against the same container afterward.

## Validation

```sh
swift build --disable-automatic-resolution \
  --product containerization-integration \
  -Xswiftc -warnings-as-errors
swift test --enable-code-coverage \
  --disable-automatic-resolution \
  -Xswiftc -warnings-as-errors
make check
./bin/containerization-integration \
  --kernel ./bin/vmlinux-arm64 \
  --max-concurrency 4 \
  --filter 'container copy out missing source does not block lifecycle'
./bin/containerization-integration \
  --kernel ./bin/vmlinux-arm64 \
  --max-concurrency 4 \
  --filter 'container copy out'
```

- All 569 Swift tests in 79 suites pass with coverage instrumentation and warnings treated as errors.
- Swift formatting and Hawkeye license checks pass.
- The exact missing-source VM regression passes three consecutive runs, returns the original `notFound` guest-path error, and completes a subsequent exec on the same container.
- All 3 matching copy-out VM integration cases pass together.
- The committed diff has no whitespace errors.

## Compatibility

There is no public API or successful-transfer behavior change. Missing guest paths now fail promptly and leave the container usable. `apple/container` can surface the lower-runtime error without adding its own lock or stream cleanup.

## Related

- Fixes [apple/container#1927](https://github.com/apple/container/issues/1927).
- Root-cause analysis: [apple/container#1927 comment](https://github.com/apple/container/issues/1927#issuecomment-4925733977).

## Release Note Highlight

- Fixes [apple/container#1927](https://github.com/apple/container/issues/1927): copying a missing container path now fails promptly without blocking later exec, stop, or delete operations.
