### PR TITLE
Fix a compilation warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -273,7 +273,8 @@ let package = Package(
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
-            ]
+            ],
+            exclude: ["README.md"]
         ),
         .testTarget(
             name: "CloudHypervisorTests",


### PR DESCRIPTION
Fixes a compilation warning:

```
warning: 'containerization': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
  .../containerization/Sources/CloudHypervisor/README.md
```