### PR TITLE
Validate symlink targets in archiveReader and mask high mode bits

### DIFF
--- a/Sources/ContainerizationArchive/ArchiveReader.swift
+++ b/Sources/ContainerizationArchive/ArchiveReader.swift
@@ -369,8 +369,17 @@ extension ArchiveReader {
                 guard let targetPath = (entry.symlinkTarget.map { FilePath($0) }) else {
                     return false
                 }
+                guard !targetPath.isAbsolute else {
+                    return false
+                }
                 var symlinkCreated = false
                 try FileDescriptorOps.mkdir(rootFileDescriptor, relativePath, makeIntermediates: true) { fd in
+                    // Validate the targetPath does not escape the root extraction path
+                    let resolvedTarget = relativePath.appending(targetPath.components).lexicallyNormalized()
+                    guard resolvedTarget.components.first != FilePath.Component("..") else {
+                        return
+                    }
+
                     // Remove existing entry if present (mimics containerd's "last entry wins" behavior)
                     try? FileDescriptorOps.unlinkRecursive(fd, filename: lastComponent)
 
@@ -398,7 +407,7 @@ extension ArchiveReader {
     }
 
     private func setFileAttributes(fd: Int32, entry: WriteEntry) {
-        fchmod(fd, entry.permissions)
+        fchmod(fd, entry.permissions & 0o777)
         if let owner = entry.owner, let group = entry.group {
             fchown(fd, owner, group)
         }

--- a/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
+++ b/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
@@ -253,8 +253,8 @@ struct ArchiveReaderTests {
                 ("dir/target.txt", .regular("target content"), nil),
                 ("dir/link", .symlink, "target.txt"),
                 ("link2", .symlink, "dir/target.txt"),
-                ("dir/passwd", .symlink, "/etc/passwd"),
-                ("dir2/passwd", .symlink, "../../../../etc/passwd"),
+                ("dir/passwd", .symlink, "/etc/passwd"),  // absolute path, should be rejected
+                ("dir2/passwd", .symlink, "../../../../etc/passwd"),  // escapes extraction root, should be rejected
             ])
 
         defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
@@ -265,9 +265,11 @@ struct ArchiveReaderTests {
         let reader = try ArchiveReader(format: .paxRestricted, filter: .none, file: archiveURL)
         let rejectedPaths = try reader.extractContents(to: extractDir)
 
-        #expect(rejectedPaths.isEmpty, "Valid symlinks should be allowed")
+        #expect(
+            Set(rejectedPaths) == Set(["dir/passwd", "dir2/passwd"]),
+            "Symlinks with absolute or escaping targets should be rejected")
 
-        // Verify symlinks were created
+        // Verify valid symlinks were created
         let linkPath = extractDir.appendingPathComponent("dir/link").path
         #expect(FileManager.default.fileExists(atPath: linkPath))
 
@@ -280,6 +282,10 @@ struct ArchiveReaderTests {
 
         let link2Target = try FileManager.default.destinationOfSymbolicLink(atPath: link2Path)
         #expect(link2Target == "dir/target.txt")
+
+        // Verify the rejected symlinks were not created
+        #expect(!FileManager.default.fileExists(atPath: extractDir.appendingPathComponent("dir/passwd").path))
+        #expect(!FileManager.default.fileExists(atPath: extractDir.appendingPathComponent("dir2/passwd").path))
     }
 
     @Test func allowSymlinkWithDotDot() throws {

--- a/Tests/ContainerizationArchiveTests/ArchiveTests.swift
+++ b/Tests/ContainerizationArchiveTests/ArchiveTests.swift
@@ -773,7 +773,9 @@ struct ArchiveTests {
         let reader = try ArchiveReader(file: archiveURL)
         let rejected = try reader.extractContents(to: extractDir)
 
-        #expect(rejected.isEmpty)
+        // The writer stores the symlink's absolute target verbatim but the reader unconditionally
+        // rejects absolute symlink targets.
+        #expect(rejected == ["source/absolute"])
 
         let extractedSource = extractDir.appendingPathComponent("source")
         #expect(
@@ -787,11 +789,7 @@ struct ArchiveTests {
             try String(contentsOf: extractedSource.appendingPathComponent("relative"), encoding: .utf8)
                 == "symlink content")
 
-        let absTarget = try FileManager.default.destinationOfSymbolicLink(
-            atPath: extractedSource.appendingPathComponent("absolute").path)
-
-        print("absTarget: \(absTarget), fileURL: \(fileURL.path)")
-        #expect(absTarget == fileURL.path)
+        #expect(!FileManager.default.fileExists(atPath: extractedSource.appendingPathComponent("absolute").path))
     }
 
     @Test func archiveDirectorySymlinkRelativeSubdir() throws {


### PR DESCRIPTION
This PR does two things: 
- Prevents target paths for symlinks from linking outside of the extraction root of the archive. Tar entries that attempt to link outside of the extraction root are added to the list of rejected paths returned from extractContents.
- Masks the high mode bits when setting file attributes for consistency with mode at file creation 