### PR TITLE
Mask high mode bits in archive reader

### DIFF
--- a/Sources/ContainerizationArchive/ArchiveReader.swift
+++ b/Sources/ContainerizationArchive/ArchiveReader.swift
@@ -398,7 +398,7 @@ extension ArchiveReader {
     }
 
     private func setFileAttributes(fd: Int32, entry: WriteEntry) {
-        fchmod(fd, entry.permissions)
+        fchmod(fd, entry.permissions & 0o777)
         if let owner = entry.owner, let group = entry.group {
             fchown(fd, owner, group)
         }


### PR DESCRIPTION
This PR masks the high mode bits when setting file attributes for consistency with mode at file creation. 