### PR TITLE
[gitignore]: ignore vscode workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ DerivedData/
 workdir/
 installer/
 .venv/
+.vscode/
 test_results/
 *.pid
 *.log


### PR DESCRIPTION
In case any devs are using `vscode` we should add this so autogenerated files are not accidentally committed.