### PR TITLE
fix(archive): preserve special permission bits

### DIFF
--- a/Sources/ContainerizationArchive/ArchiveReader.swift
+++ b/Sources/ContainerizationArchive/ArchiveReader.swift
@@ -398,7 +398,7 @@ extension ArchiveReader {
     }
 
     private func setFileAttributes(fd: Int32, entry: WriteEntry) {
-        fchmod(fd, entry.permissions & 0o777)
+        fchmod(fd, entry.permissions & 0o7777)
         if let owner = entry.owner, let group = entry.group {
             fchown(fd, owner, group)
         }

--- a/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
+++ b/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
@@ -438,6 +438,36 @@ struct ArchiveReaderTests {
         #expect((perms & permMask) == 0o755, "Permissions should be preserved")
     }
 
+    @Test func preserveSpecialPermissionBits() throws {
+        let testDirectory = createTemporaryDirectory(baseName: "ArchiveReaderTests")!
+        let archiveURL = testDirectory.appendingPathComponent("special-permissions.tar")
+        let archiver = try ArchiveWriter(format: .paxRestricted, filter: .none, file: archiveURL)
+
+        let writeEntry = WriteEntry()
+        writeEntry.path = "sticky"
+        writeEntry.fileType = .directory
+        writeEntry.permissions = 0o1777
+        writeEntry.size = 0
+        try archiver.writeEntry(entry: writeEntry, data: nil)
+        try archiver.finishEncoding()
+
+        defer { try? FileManager.default.removeItem(at: testDirectory) }
+
+        let extractDir = try createExtractionDirectory(name: "special-permissions")
+        defer { try? FileManager.default.removeItem(at: extractDir.deletingLastPathComponent()) }
+
+        let reader = try ArchiveReader(format: .paxRestricted, filter: .none, file: archiveURL)
+        let rejectedPaths = try reader.extractContents(to: extractDir)
+
+        #expect(rejectedPaths.isEmpty)
+
+        let directoryPath = extractDir.appendingPathComponent("sticky").path
+        let attrs = try FileManager.default.attributesOfItem(atPath: directoryPath)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+        let permMask: UInt16 = 0o7777
+        #expect((perms & permMask) == 0o1777, "Special permission bits should be preserved")
+    }
+
     // MARK: - Duplicate Entry Tests
 
     @Test func duplicateRegularFiles() throws {


### PR DESCRIPTION
## Summary

Preserve sticky, set-user-ID, and set-group-ID permission bits when extracting archive entries.

## Motivation and Context

During testing of my `container-compose` plugin, I found and fixed the following issue: archive extraction masked entry permissions with `0o777`, which discarded all special POSIX permission bits.

This regressed in #816. A directory archived with mode `01777` was extracted as `0777`; set-user-ID and set-group-ID bits were affected by the same mask.

Fixes #818.

## Reproduction

1. Write a directory archive entry with mode `01777`.
2. Extract it with `ArchiveReader`.
3. Inspect the extracted directory's POSIX permissions.
4. Run:

   ```sh
   swift test --disable-automatic-resolution -Xswiftc -warnings-as-errors --filter preserveSpecialPermissionBits
   ```

On stock `main` at `50f77222964ed3d01dcb53f803ea2d511656a9dc`, the regression failed with:

```text
Expectation failed: ((perms & permMask) -> 511) == (0o1777 -> 1023)
Special permission bits should be preserved
```

## Changes

- Apply `entry.permissions & 0o7777` instead of `entry.permissions & 0o777`.
- Add a sticky-directory archive extraction regression.

## Validation

Validated on macOS 26.5.1 (25F80), Xcode 26.6 (17F113), and Swift 6.3.3.

- Regression before fix: failed with `0777` instead of `01777`
- Regression after fix: passed
- `make fmt`: passed
- `make check`: passed
- `swift test --enable-code-coverage --disable-automatic-resolution -Xswiftc -warnings-as-errors`: 574 tests in 80 suites passed
- `git diff --check`: passed
- Commit `6e32963617b3ed8f4b63432dbcf834f94807342b` is cryptographically signed and verified

## Compatibility and Risk

The change preserves the complete POSIX permission field while still excluding file-type bits. It does not change archive formats or public APIs. The behavioural change is limited to restoring permissions that are already present in the archive entry.

## Related

- #816 introduced the narrower mask.
- #819 and #821 track the separate `fchown` ordering issue that can clear set-ID bits after this mask is corrected.

## Release Note Highlight

Archive extraction now preserves sticky, set-user-ID, and set-group-ID permission bits.
