### PR TITLE
fix(archive): restore permissions after ownership

### DIFF
--- a/Sources/ContainerizationArchive/ArchiveReader.swift
+++ b/Sources/ContainerizationArchive/ArchiveReader.swift
@@ -398,7 +398,7 @@ extension ArchiveReader {
     }
 
     private func setFileAttributes(fd: Int32, entry: WriteEntry) {
-        fchmod(fd, entry.permissions & 0o777)
+        fchmod(fd, entry.permissions & 0o7777)
         if let owner = entry.owner, let group = entry.group {
             fchown(fd, owner, group)
         }

--- a/Sources/ContainerizationArchive/ArchiveReader.swift
+++ b/Sources/ContainerizationArchive/ArchiveReader.swift
@@ -398,10 +398,10 @@ extension ArchiveReader {
     }
 
     private func setFileAttributes(fd: Int32, entry: WriteEntry) {
-        fchmod(fd, entry.permissions & 0o7777)
         if let owner = entry.owner, let group = entry.group {
             fchown(fd, owner, group)
         }
+        fchmod(fd, entry.permissions & 0o7777)
     }
 
     private static func copyDataReaderToFd(dataReader: ArchiveEntryReader, fileFd: Int32, memberPath: FilePath) throws {

--- a/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
+++ b/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
@@ -438,6 +438,36 @@ struct ArchiveReaderTests {
         #expect((perms & permMask) == 0o755, "Permissions should be preserved")
     }
 
+    @Test func preserveSpecialPermissionBits() throws {
+        let testDirectory = createTemporaryDirectory(baseName: "ArchiveReaderTests")!
+        let archiveURL = testDirectory.appendingPathComponent("special-permissions.tar")
+        let archiver = try ArchiveWriter(format: .paxRestricted, filter: .none, file: archiveURL)
+
+        let writeEntry = WriteEntry()
+        writeEntry.path = "sticky"
+        writeEntry.fileType = .directory
+        writeEntry.permissions = 0o1777
+        writeEntry.size = 0
+        try archiver.writeEntry(entry: writeEntry, data: nil)
+        try archiver.finishEncoding()
+
+        defer { try? FileManager.default.removeItem(at: testDirectory) }
+
+        let extractDir = try createExtractionDirectory(name: "special-permissions")
+        defer { try? FileManager.default.removeItem(at: extractDir.deletingLastPathComponent()) }
+
+        let reader = try ArchiveReader(format: .paxRestricted, filter: .none, file: archiveURL)
+        let rejectedPaths = try reader.extractContents(to: extractDir)
+
+        #expect(rejectedPaths.isEmpty)
+
+        let directoryPath = extractDir.appendingPathComponent("sticky").path
+        let attrs = try FileManager.default.attributesOfItem(atPath: directoryPath)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+        let permMask: UInt16 = 0o7777
+        #expect((perms & permMask) == 0o1777, "Special permission bits should be preserved")
+    }
+
     // MARK: - Duplicate Entry Tests
 
     @Test func duplicateRegularFiles() throws {

--- a/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
+++ b/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
@@ -449,6 +449,17 @@ struct ArchiveReaderTests {
         writeEntry.permissions = 0o1777
         writeEntry.size = 0
         try archiver.writeEntry(entry: writeEntry, data: nil)
+
+        let setIDEntry = WriteEntry()
+        setIDEntry.path = "set-id"
+        setIDEntry.fileType = .regular
+        setIDEntry.permissions = 0o6755
+        setIDEntry.owner = getuid()
+        setIDEntry.group = getgid()
+        let setIDData = Data("set-id".utf8)
+        setIDEntry.size = numericCast(setIDData.count)
+        try archiver.writeEntry(entry: setIDEntry, data: setIDData)
+
         try archiver.finishEncoding()
 
         defer { try? FileManager.default.removeItem(at: testDirectory) }
@@ -466,6 +477,11 @@ struct ArchiveReaderTests {
         let perms = (attrs[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
         let permMask: UInt16 = 0o7777
         #expect((perms & permMask) == 0o1777, "Special permission bits should be preserved")
+
+        let setIDPath = extractDir.appendingPathComponent("set-id").path
+        let setIDAttrs = try FileManager.default.attributesOfItem(atPath: setIDPath)
+        let setIDPerms = (setIDAttrs[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+        #expect((setIDPerms & permMask) == 0o6755, "Set-ID permission bits should be preserved after ownership")
     }
 
     // MARK: - Duplicate Entry Tests


### PR DESCRIPTION
## Summary

Apply archived permissions after ownership so Darwin does not clear set-user-ID and set-group-ID bits during extraction.

## Motivation and Context

During testing of my `container-compose` plugin, I found and fixed the following issue: `ArchiveReader.setFileAttributes` called `fchmod` before `fchown`. On Darwin, changing ownership clears set-user-ID and set-group-ID bits, so the final extracted mode does not match the archive entry.

Fixes #819.

## Dependency and Merge Order

This PR targets the stock `apple/containerization:main` branch and depends on #820, which fixes #818. Please merge #820 first.

The head currently contains the signed #818 fix as its first prerequisite commit because both PRs target stock Apple `main`. After the prerequisite merges, the branch can merge current Apple `main` so this PR's remaining diff is only the ownership/permission ordering change and set-ID regression.

## Reproduction

The syscall behaviour is directly reproducible:

1. Create and open a regular file.
2. Call `fchmod(fd, 0o6755)`.
3. Call `fchown(fd, getuid(), getgid())`.
4. Inspect `fstat(fd).st_mode & 0o7777`.

Darwin reports `0755`.

With the #818 mask fix present, the archive regression writes a regular entry with mode `06755`, extracts it, and runs:

```sh
swift test --disable-automatic-resolution -Xswiftc -warnings-as-errors --filter preserveSpecialPermissionBits
```

Before reordering the calls, it failed with:

```text
Expectation failed: ((setIDPerms & permMask) -> 493) == (0o6755 -> 3565)
Set-ID permission bits should be preserved after ownership
```

## Changes

- Call `fchown` before the final `fchmod`.
- Extend the archive regression with a regular `06755` entry whose owner and group are explicitly restored.

## Validation

Validated on macOS 26.5.1 (25F80), Xcode 26.6 (17F113), and Swift 6.3.3.

- Regression before fix: failed with `0755` instead of `06755`
- Regression after fix: passed
- `make fmt`: passed
- `make check`: passed
- `swift test --enable-code-coverage --disable-automatic-resolution -Xswiftc -warnings-as-errors`: 574 tests in 80 suites passed
- `git diff --check`: passed
- Commits `6e32963617b3ed8f4b63432dbcf834f94807342b` and `726e1ffdceada5cc62d32c8fc939aef30220e6ff` are cryptographically signed and verified

## Compatibility and Risk

The change only alters the order of two existing file-descriptor operations. Ownership is still applied when both owner and group are present, and the archived mode becomes the final mode. There are no archive-format or public-API changes.

## Related

- #820 is the required permission-mask PR for #818.
- #816 introduced the mask that currently hides this independent ordering defect.

## Release Note Highlight

Archive extraction now preserves set-user-ID and set-group-ID bits when restoring file ownership.
