### PR TITLE
Defer directory attributes without following symlinks

### DIFF
--- a/Sources/ContainerizationArchive/ArchiveReader.swift
+++ b/Sources/ContainerizationArchive/ArchiveReader.swift
@@ -284,6 +284,7 @@ extension ArchiveReader {
         // Iterate and extract archive entries, collecting rejected paths.
         var foundEntry = false
         var rejectedPaths = [String]()
+        var deferredDirAttrs: [(path: FilePath, entry: WriteEntry)] = []
         for (entry, dataReader) in self.makeStreamingIterator() {
             guard let memberPath = (entry.path.map { FilePath($0) }) else {
                 continue
@@ -298,12 +299,34 @@ extension ArchiveReader {
                 rootFileDescriptor: rootFileDescriptor
             )
 
+            if extracted, entry.fileType == .directory {
+                deferredDirAttrs.append((memberPath, entry))
+            }
+
             if !extracted {
                 rejectedPaths.append(memberPath.string)
             }
         }
         guard foundEntry else {
             throw ArchiveError.failedToExtractArchive("no entries found in archive")
+        }
+
+        // Apply directory permissions after all children are extracted, deepest first,
+        // so a restrictive parent cannot block access to its children.
+        for deferred in deferredDirAttrs.sorted(by: { $0.path.components.count > $1.path.components.count }) {
+            do {
+                try FileDescriptorOps.withOpenDirectory(rootFileDescriptor, deferred.path) { fd in
+                    setFileAttributes(fd: fd.rawValue, entry: deferred.entry)
+                }
+            } catch let error as FileDescriptorOps.Error {
+                switch error {
+                case .invalidPathComponent, .cannotFollowSymlink:
+                    // A later archive entry replaced this directory. Last entry wins.
+                    continue
+                case .invalidRelativePath, .systemError:
+                    throw error
+                }
+            }
         }
 
         return rejectedPaths
@@ -362,9 +385,7 @@ extension ArchiveReader {
                     setFileAttributes(fd: fileFd, entry: entry)
                 }
             case .directory:
-                try FileDescriptorOps.mkdir(rootFileDescriptor, memberPath, makeIntermediates: true) { fd in
-                    setFileAttributes(fd: fd.rawValue, entry: entry)
-                }
+                try FileDescriptorOps.mkdir(rootFileDescriptor, memberPath, makeIntermediates: true) { _ in }
             case .symbolicLink:
                 guard let targetPath = (entry.symlinkTarget.map { FilePath($0) }) else {
                     return false

--- a/Sources/ContainerizationArchive/ArchiveReader.swift
+++ b/Sources/ContainerizationArchive/ArchiveReader.swift
@@ -284,7 +284,7 @@ extension ArchiveReader {
         // Iterate and extract archive entries, collecting rejected paths.
         var foundEntry = false
         var rejectedPaths = [String]()
-        var deferredDirAttrs: [(path: FilePath, entry: WriteEntry)] = []
+        var deferredDirAttrs: [FilePath: WriteEntry] = [:]
         for (entry, dataReader) in self.makeStreamingIterator() {
             guard let memberPath = (entry.path.map { FilePath($0) }) else {
                 continue
@@ -300,7 +300,8 @@ extension ArchiveReader {
             )
 
             if extracted, entry.fileType == .directory {
-                deferredDirAttrs.append((memberPath, entry))
+                let deferredPath = FilePath().appending(memberPath.components).lexicallyNormalized()
+                deferredDirAttrs[deferredPath] = entry
             }
 
             if !extracted {
@@ -313,10 +314,10 @@ extension ArchiveReader {
 
         // Apply directory permissions after all children are extracted, deepest first,
         // so a restrictive parent cannot block access to its children.
-        for deferred in deferredDirAttrs.sorted(by: { $0.path.components.count > $1.path.components.count }) {
+        for deferred in deferredDirAttrs.sorted(by: { $0.key.components.count > $1.key.components.count }) {
             do {
-                try FileDescriptorOps.withOpenDirectory(rootFileDescriptor, deferred.path) { fd in
-                    setFileAttributes(fd: fd.rawValue, entry: deferred.entry)
+                try FileDescriptorOps.withOpenDirectory(rootFileDescriptor, deferred.key) { fd in
+                    setFileAttributes(fd: fd.rawValue, entry: deferred.value)
                 }
             } catch let error as FileDescriptorOps.Error {
                 switch error {

--- a/Sources/ContainerizationArchive/ArchiveReader.swift
+++ b/Sources/ContainerizationArchive/ArchiveReader.swift
@@ -249,6 +249,29 @@ extension ArchiveReader: Sequence {
 }
 
 extension ArchiveReader {
+    private struct DirectoryIdentity: Equatable {
+        let device: UInt64
+        let inode: UInt64
+    }
+
+    private struct DeferredDirectoryAttributes {
+        let entry: WriteEntry
+        let identity: DirectoryIdentity
+    }
+
+    private struct ExtractionResult {
+        let extracted: Bool
+        let deferredDirectoryAttributes: DeferredDirectoryAttributes?
+
+        static var rejected: ExtractionResult {
+            ExtractionResult(extracted: false, deferredDirectoryAttributes: nil)
+        }
+
+        static var extracted: ExtractionResult {
+            ExtractionResult(extracted: true, deferredDirectoryAttributes: nil)
+        }
+    }
+
     public convenience init(name: String, bundle: Data, tempDirectoryBaseName: String? = nil) throws {
         let baseName = tempDirectoryBaseName ?? "Unarchiver"
         guard let tempDir = createTemporaryDirectory(baseName: baseName) else {
@@ -284,7 +307,7 @@ extension ArchiveReader {
         // Iterate and extract archive entries, collecting rejected paths.
         var foundEntry = false
         var rejectedPaths = [String]()
-        var deferredDirAttrs: [FilePath: WriteEntry] = [:]
+        var deferredDirAttrs: [FilePath: DeferredDirectoryAttributes] = [:]
         for (entry, dataReader) in self.makeStreamingIterator() {
             guard let memberPath = (entry.path.map { FilePath($0) }) else {
                 continue
@@ -292,19 +315,19 @@ extension ArchiveReader {
             foundEntry = true
 
             // Try to extract the entry, catching path validation errors
-            let extracted = try extractEntry(
+            let result = try extractEntry(
                 entry: entry,
                 dataReader: dataReader,
                 memberPath: memberPath,
                 rootFileDescriptor: rootFileDescriptor
             )
 
-            if extracted, entry.fileType == .directory {
+            if let deferredDirectoryAttributes = result.deferredDirectoryAttributes {
                 let deferredPath = FilePath().appending(memberPath.components).lexicallyNormalized()
-                deferredDirAttrs[deferredPath] = entry
+                deferredDirAttrs[deferredPath] = deferredDirectoryAttributes
             }
 
-            if !extracted {
+            if !result.extracted {
                 rejectedPaths.append(memberPath.string)
             }
         }
@@ -317,7 +340,10 @@ extension ArchiveReader {
         for deferred in deferredDirAttrs.sorted(by: { $0.key.components.count > $1.key.components.count }) {
             do {
                 try FileDescriptorOps.withOpenDirectory(rootFileDescriptor, deferred.key) { fd in
-                    setFileAttributes(fd: fd.rawValue, entry: deferred.value)
+                    guard try Self.directoryIdentity(fd) == deferred.value.identity else {
+                        return
+                    }
+                    setFileAttributes(fd: fd.rawValue, entry: deferred.value.entry)
                 }
             } catch let error as FileDescriptorOps.Error {
                 switch error {
@@ -360,9 +386,9 @@ extension ArchiveReader {
         dataReader: ArchiveEntryReader,
         memberPath: FilePath,
         rootFileDescriptor: FileDescriptor
-    ) throws -> Bool {
+    ) throws -> ExtractionResult {
         guard let lastComponent = memberPath.lastComponent else {
-            return false
+            return .rejected
         }
         let relativePath = memberPath.removingLastComponent()
         let type = entry.fileType
@@ -385,11 +411,22 @@ extension ArchiveReader {
                     try Self.copyDataReaderToFd(dataReader: dataReader, fileFd: fileFd, memberPath: memberPath)
                     setFileAttributes(fd: fileFd, entry: entry)
                 }
+                return .extracted
             case .directory:
-                try FileDescriptorOps.mkdir(rootFileDescriptor, memberPath, makeIntermediates: true) { _ in }
+                var deferredDirectoryAttributes: DeferredDirectoryAttributes?
+                try FileDescriptorOps.mkdir(rootFileDescriptor, memberPath, makeIntermediates: true) { fd in
+                    deferredDirectoryAttributes = DeferredDirectoryAttributes(
+                        entry: entry,
+                        identity: try Self.directoryIdentity(fd)
+                    )
+                }
+                return ExtractionResult(
+                    extracted: true,
+                    deferredDirectoryAttributes: deferredDirectoryAttributes
+                )
             case .symbolicLink:
                 guard let targetPath = (entry.symlinkTarget.map { FilePath($0) }) else {
-                    return false
+                    return .rejected
                 }
                 var symlinkCreated = false
                 try FileDescriptorOps.mkdir(rootFileDescriptor, relativePath, makeIntermediates: true) { fd in
@@ -401,12 +438,10 @@ extension ArchiveReader {
                     }
                     symlinkCreated = true
                 }
-                return symlinkCreated
+                return symlinkCreated ? .extracted : .rejected
             default:
-                return false
+                return .rejected
             }
-
-            return true
         } catch let error as FileDescriptorOps.Error {
             // Just reject path validation errors, don't fail the extraction
             switch error {
@@ -414,9 +449,20 @@ extension ArchiveReader {
                 // Fail for system errors
                 throw error
             case .invalidRelativePath, .invalidPathComponent, .cannotFollowSymlink:
-                return false
+                return .rejected
             }
         }
+    }
+
+    private static func directoryIdentity(_ fd: FileDescriptor) throws -> DirectoryIdentity {
+        var attributes = stat()
+        guard fstat(fd.rawValue, &attributes) == 0 else {
+            throw FileDescriptorOps.Error.systemError("fstat during archive directory extraction", errno)
+        }
+        return DirectoryIdentity(
+            device: UInt64(attributes.st_dev),
+            inode: UInt64(attributes.st_ino)
+        )
     }
 
     private func setFileAttributes(fd: Int32, entry: WriteEntry) {

--- a/Sources/ContainerizationOS/FileDescriptorOps.swift
+++ b/Sources/ContainerizationOS/FileDescriptorOps.swift
@@ -111,6 +111,19 @@ public enum FileDescriptorOps {
         )
     }
 
+    /// Opens an existing directory relative to `fd` without following symbolic links.
+    ///
+    /// Each path component must already exist and be a directory. Unlike ``mkdir``,
+    /// this operation never creates or replaces filesystem entries.
+    public static func withOpenDirectory(
+        _ fd: FileDescriptor,
+        _ relativePath: FilePath,
+        completion: (FileDescriptor) throws -> Void
+    ) throws {
+        try validateRelativePath(relativePath)
+        try withOpenDirectory(fd, relativePath.components, completion: completion)
+    }
+
     /// Recursively removes a direct child of the directory at `fd`.
     ///
     /// - Parameters:
@@ -267,6 +280,37 @@ public enum FileDescriptorOps {
         try mkdir(
             componentFileDescriptor, childComponents,
             permissions: permissions, makeIntermediates: makeIntermediates, completion: completion)
+    }
+
+    private static func withOpenDirectory(
+        _ fd: FileDescriptor,
+        _ relativeComponents: FilePath.ComponentView,
+        completion: (FileDescriptor) throws -> Void
+    ) throws {
+        guard let currentComponent = relativeComponents.first else {
+            try completion(fd)
+            return
+        }
+
+        let componentFd = openat(fd.rawValue, currentComponent.string, O_NOFOLLOW | O_RDONLY | O_DIRECTORY)
+        guard componentFd >= 0 else {
+            switch errno {
+            case ELOOP:
+                throw Error.cannotFollowSymlink
+            case ENOENT, ENOTDIR:
+                throw Error.invalidPathComponent
+            default:
+                throw Error.systemError("directory open during file descriptor traversal", errno)
+            }
+        }
+
+        let componentFileDescriptor = FileDescriptor(rawValue: componentFd)
+        defer { try? componentFileDescriptor.close() }
+        try withOpenDirectory(
+            componentFileDescriptor,
+            FilePath.ComponentView(relativeComponents.dropFirst()),
+            completion: completion
+        )
     }
 
     private static func enumerateHelper(

--- a/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
+++ b/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
@@ -561,6 +561,37 @@ struct ArchiveReaderTests {
         #expect((permissions & 0o777) == 0o700, "deferred attributes escaped the extraction root")
     }
 
+    @Test func duplicateDirectoryUsesLastDeferredAttributes() throws {
+        let testDirectory = createTemporaryDirectory(baseName: "ArchiveReaderTests.duplicateDirectory")!
+        defer { try? FileManager.default.removeItem(at: testDirectory) }
+        let archiveURL = testDirectory.appendingPathComponent("duplicate-directory.tar")
+        let writer = try ArchiveWriter(format: .paxRestricted, filter: .none, file: archiveURL)
+
+        let entries: [(path: String, permissions: mode_t)] = [
+            ("directory/", 0o000),
+            ("./directory/", 0o755),
+        ]
+        for (path, permissions) in entries {
+            let entry = WriteEntry()
+            entry.path = path
+            entry.fileType = .directory
+            entry.permissions = permissions
+            entry.size = 0
+            try writer.writeEntry(entry: entry, data: nil)
+        }
+        try writer.finishEncoding()
+
+        let extractDir = testDirectory.appendingPathComponent("extract")
+        let reader = try ArchiveReader(format: .paxRestricted, filter: .none, file: archiveURL)
+        let rejectedPaths = try reader.extractContents(to: extractDir)
+
+        #expect(rejectedPaths.isEmpty)
+        let attributes = try FileManager.default.attributesOfItem(
+            atPath: extractDir.appendingPathComponent("directory").path)
+        let permissions = (attributes[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+        #expect((permissions & 0o777) == 0o755, "the last directory entry should define final permissions")
+    }
+
     @Test func regularFileToSymlink() throws {
         let archiveURL = try createTestArchive(
             name: "file-to-symlink",

--- a/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
+++ b/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
@@ -534,6 +534,33 @@ struct ArchiveReaderTests {
         #expect(content == "content", "Should have file content")
     }
 
+    @Test func deferredDirectoryAttributesDoNotFollowReplacedParentSymlink() throws {
+        let externalRoot = createTemporaryDirectory(baseName: "ArchiveReaderTests.external")!
+        defer { try? FileManager.default.removeItem(at: externalRoot) }
+        let externalChild = externalRoot.appendingPathComponent("child")
+        try FileManager.default.createDirectory(at: externalChild, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: externalChild.path)
+
+        let archiveURL = try createTestArchive(
+            name: "deferred-attrs-replaced-parent",
+            entries: [
+                ("parent/child/", .directory, nil),
+                ("parent", .symlink, externalRoot.path),
+            ])
+        defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
+
+        let extractDir = try createExtractionDirectory(name: "deferred-attrs-replaced-parent")
+        defer { try? FileManager.default.removeItem(at: extractDir.deletingLastPathComponent()) }
+
+        let reader = try ArchiveReader(format: .paxRestricted, filter: .none, file: archiveURL)
+        let rejectedPaths = try reader.extractContents(to: extractDir)
+
+        #expect(rejectedPaths.isEmpty)
+        let attributes = try FileManager.default.attributesOfItem(atPath: externalChild.path)
+        let permissions = (attributes[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+        #expect((permissions & 0o777) == 0o700, "deferred attributes escaped the extraction root")
+    }
+
     @Test func regularFileToSymlink() throws {
         let archiveURL = try createTestArchive(
             name: "file-to-symlink",

--- a/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
+++ b/Tests/ContainerizationArchiveTests/ArchiveReaderTests.swift
@@ -592,6 +592,55 @@ struct ArchiveReaderTests {
         #expect((permissions & 0o777) == 0o755, "the last directory entry should define final permissions")
     }
 
+    @Test func replacedDirectoryDoesNotReceiveStaleDeferredAttributes() throws {
+        let testDirectory = createTemporaryDirectory(baseName: "ArchiveReaderTests.replacedDirectory")!
+        defer { try? FileManager.default.removeItem(at: testDirectory) }
+        let archiveURL = testDirectory.appendingPathComponent("replaced-directory.tar")
+        let writer = try ArchiveWriter(format: .paxRestricted, filter: .none, file: archiveURL)
+
+        let directory = WriteEntry()
+        directory.path = "parent/child/"
+        directory.fileType = .directory
+        directory.permissions = 0o123
+        directory.size = 0
+        try writer.writeEntry(entry: directory, data: nil)
+
+        let symlink = WriteEntry()
+        symlink.path = "parent"
+        symlink.fileType = .symbolicLink
+        symlink.symlinkTarget = "elsewhere"
+        symlink.size = 0
+        try writer.writeEntry(entry: symlink, data: nil)
+
+        let file = WriteEntry()
+        file.path = "parent/child/file"
+        file.fileType = .regular
+        file.permissions = 0o644
+        let data = Data("content".utf8)
+        file.size = numericCast(data.count)
+        try writer.writeEntry(entry: file, data: data)
+        try writer.finishEncoding()
+
+        let extractDir = testDirectory.appendingPathComponent("extract")
+        let reader = try ArchiveReader(format: .paxRestricted, filter: .none, file: archiveURL)
+        let rejectedPaths = try reader.extractContents(to: extractDir)
+
+        let parent = extractDir.appendingPathComponent("parent")
+        let child = parent.appendingPathComponent("child")
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: child.path) }
+
+        #expect(rejectedPaths.isEmpty)
+        let parentAttributes = try FileManager.default.attributesOfItem(atPath: parent.path)
+        let childAttributes = try FileManager.default.attributesOfItem(atPath: child.path)
+        let parentPermissions = (parentAttributes[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+        let childPermissions = (childAttributes[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+        #expect(
+            (childPermissions & 0o777) == (parentPermissions & 0o777),
+            "a replacement directory received stale attributes from an unlinked inode"
+        )
+        #expect(try String(contentsOf: child.appendingPathComponent("file"), encoding: .utf8) == "content")
+    }
+
     @Test func regularFileToSymlink() throws {
         let archiveURL = try createTestArchive(
             name: "file-to-symlink",

--- a/Tests/ContainerizationArchiveTests/ArchiveTests.swift
+++ b/Tests/ContainerizationArchiveTests/ArchiveTests.swift
@@ -242,6 +242,37 @@ struct ArchiveTests {
         #expect(try String(contentsOf: extractDir.appendingPathComponent("subdir/file2.txt"), encoding: .utf8) == "world")
     }
 
+    @Test func archiveDirectoryPreservesReadonlySubdirectory() throws {
+        let testDir = createTemporaryDirectory(baseName: "ArchiveTests.archiveDirReadonlySubdir")!
+        defer { try? FileManager.default.removeItem(at: testDir) }
+
+        let sourceDir = testDir.appendingPathComponent("source")
+        let readonlyDir = sourceDir.appendingPathComponent("readonly")
+        try FileManager.default.createDirectory(at: readonlyDir, withIntermediateDirectories: true)
+        try "content".write(to: readonlyDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: readonlyDir.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: readonlyDir.path)
+        }
+
+        let archiveURL = testDir.appendingPathComponent("test.tar.gz")
+        let writer = try ArchiveWriter(format: .pax, filter: .gzip, file: archiveURL)
+        try writer.archiveDirectory(sourceDir)
+        try writer.finishEncoding()
+
+        let extractDir = testDir.appendingPathComponent("extract")
+        let reader = try ArchiveReader(file: archiveURL)
+        let rejected = try reader.extractContents(to: extractDir)
+
+        #expect(rejected.isEmpty)
+        #expect(
+            try String(contentsOf: extractDir.appendingPathComponent("readonly/file.txt"), encoding: .utf8)
+                == "content")
+        let attrs = try FileManager.default.attributesOfItem(atPath: extractDir.appendingPathComponent("readonly").path)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+        #expect((perms & 0o777) == 0o555, "Read-only directory permissions should be preserved")
+    }
+
     @Test func archiveDirectoryEmpty() throws {
         let testDir = createTemporaryDirectory(baseName: "ArchiveTests.archiveDirEmpty")!
         defer { try? FileManager.default.removeItem(at: testDir) }
@@ -722,7 +753,7 @@ struct ArchiveTests {
         let readonlyDir = sourceDir.appendingPathComponent("readonly")
         try FileManager.default.createDirectory(at: readonlyDir, withIntermediateDirectories: true)
         try "content".write(to: readonlyDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes([.posixPermissions: 0o777], ofItemAtPath: readonlyDir.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: readonlyDir.path)
         defer {
             try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: readonlyDir.path)
         }
@@ -742,7 +773,7 @@ struct ArchiveTests {
                 == "content")
         let attrs = try FileManager.default.attributesOfItem(atPath: extractDir.appendingPathComponent("readonly").path)
         let perms = (attrs[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
-        #expect((perms & 0o777) == 0o777, "Read-only directory permissions should be preserved")
+        #expect((perms & 0o777) == 0o555, "Read-only directory permissions should be preserved")
     }
 
     @Test func archiveURLsSymlinks() throws {

--- a/Tests/ContainerizationOSTests/FileDescriptorOpsTests.swift
+++ b/Tests/ContainerizationOSTests/FileDescriptorOpsTests.swift
@@ -186,6 +186,40 @@ struct FileDescriptorPathSecureTests {
         }
     }
 
+    @Test
+    func withOpenDirectoryDoesNotReplaceRegularFile() async throws {
+        let rootPath = try createTempDirectory()
+        defer { try? FileManager.default.removeItem(atPath: rootPath.string) }
+        try createEntries(rootPath: rootPath, entries: [.regular(path: "entry")], permissions: nil)
+
+        let rootFd = try FileDescriptor.open(rootPath, .readOnly, options: [.directory])
+        defer { try? rootFd.close() }
+
+        #expect(throws: FileDescriptorOps.Error.invalidPathComponent) {
+            try FileDescriptorOps.withOpenDirectory(rootFd, FilePath("entry")) { _ in }
+        }
+
+        var isDirectory: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: rootPath.appending("entry").string, isDirectory: &isDirectory))
+        #expect(!isDirectory.boolValue)
+    }
+
+    @Test
+    func withOpenDirectoryTraversesExistingDirectories() async throws {
+        let rootPath = try createTempDirectory()
+        defer { try? FileManager.default.removeItem(atPath: rootPath.string) }
+        try createEntries(rootPath: rootPath, entries: [.directory(path: "parent/child")], permissions: nil)
+
+        let rootFd = try FileDescriptor.open(rootPath, .readOnly, options: [.directory])
+        defer { try? rootFd.close() }
+
+        var opened = false
+        try FileDescriptorOps.withOpenDirectory(rootFd, FilePath("parent/child")) { _ in
+            opened = true
+        }
+        #expect(opened)
+    }
+
     @Test(
         "Test paths with .. that normalize to valid paths",
         arguments: [


### PR DESCRIPTION
During testing of my Container Compose plugin, I found that archives containing read-only directories cannot be extracted by the current `main` branch because directory attributes are applied before their children are written.

This supersedes and credits @JaewonHur's work in #716. That PR correctly defers directory attributes, but its single `openat` call passes the full relative path with `O_NOFOLLOW`. `O_NOFOLLOW` protects only the final path component, so a directory replaced by an intermediate symlink can redirect the deferred `fchown` and `fchmod` operations outside the extraction root.

## Reproduction

On stock `apple/containerization` `main` at `50f77222964ed3d01dcb53f803ea2d511656a9dc`:

1. Create an archive containing `readonly/` with mode `0555` and `readonly/file.txt`.
2. Extract it with `ArchiveReader.extractContents`.
3. Extraction fails while creating `readonly/file.txt` because the parent directory was already made read-only.

The regression test `archiveDirectoryPreservesReadonlySubdirectory` fails on stock `main` with:

```text
failed to extract archive: failed to create file: readonly/file.txt
```

On the current #716 head at `77da467c16d8e406b38f3257188a7f1fbe078368`:

1. Extract a directory entry such as `parent/child/`.
2. Later in the same archive, replace `parent` with a symlink to an external directory.
3. Allow deferred attributes to run.
4. The external `child` directory's permissions are changed, demonstrating that metadata escaped the extraction root.

The current #716 head also loses last-entry-wins semantics when the same directory is represented by aliases such as `directory/` and `./directory/`.

## Change

- Defer directory ownership and permissions until all archive entries have been extracted.
- Open each existing path component relative to the extraction-root descriptor with `O_NOFOLLOW | O_RDONLY | O_DIRECTORY`.
- Refuse symlink and non-directory traversal without replacing the existing entry.
- Canonicalise successfully extracted directory paths and retain only the final deferred attributes for each directory.
- Apply deferred attributes deepest-first so restrictive parent permissions do not block child updates.
- Bind deferred metadata to the extracted directory's device and inode identity so a removed and recreated path cannot inherit stale attributes.
- Correct the existing read-only-directory regression test, which previously used and expected mode `0777`.
- Add focused regressions for intermediate-symlink traversal, aliased duplicate directory entries, and descriptor-relative directory opening.

## Expected result

Read-only directory archives extract successfully and retain their final metadata. Deferred metadata operations remain anchored beneath the extraction root, and the last successful directory entry defines the final attributes.

## Testing

- `make fmt`
- `make check`
- `swift test --filter ArchiveReaderTests`: 26 tests passed in 43.917 seconds
- `swift test --filter FileDescriptorOpsTests`: 28 tests passed in 18.969 seconds
- `make test`: 579 tests in 80 suites passed in 45.230 seconds after build
- Post-review `make check`: passed in 3.62 seconds
- Post-review full `make test`: passed in 121.14 seconds including the coverage rebuild
- Stock `main` comparison: corrected read-only test fails as described
- Current #716 comparison: intermediate-symlink and aliased-directory regressions fail as described

All commits are signed and verified.