### PR TITLE
Align CIDR containment and bounds with CIDRv4 and CIDRv6

### DIFF
--- a/Sources/Containerization/VmnetNetwork.swift
+++ b/Sources/Containerization/VmnetNetwork.swift
@@ -291,7 +291,10 @@ public struct VmnetNetwork: Network {
 
     private static func configurePrefixV6(_ config: vmnet_network_configuration_ref, prefixV6: CIDRv6) throws {
         var p = in6_addr()
-        inet_pton(AF_INET6, prefixV6.lower.description, &p)
+        // `inet_pton` rejects a zone suffix, so render the network address on
+        // its own. A vmnet prefix is never link-scoped, so dropping the zone
+        // here loses nothing.
+        inet_pton(AF_INET6, IPv6Address(prefixV6.lower.value).description, &p)
 
         guard vmnet_network_configuration_set_ipv6_prefix(config, &p, prefixV6.prefix.length) == .VMNET_SUCCESS else {
             throw ContainerizationError(.internalError, message: "failed to set IPv6 prefix \(prefixV6) for network")

--- a/Sources/Containerization/VmnetNetwork.swift
+++ b/Sources/Containerization/VmnetNetwork.swift
@@ -291,10 +291,13 @@ public struct VmnetNetwork: Network {
 
     private static func configurePrefixV6(_ config: vmnet_network_configuration_ref, prefixV6: CIDRv6) throws {
         var p = in6_addr()
-        // `inet_pton` rejects a zone suffix, so render the network address on
-        // its own. A vmnet prefix is never link-scoped, so dropping the zone
-        // here loses nothing.
-        inet_pton(AF_INET6, IPv6Address(prefixV6.lower.value).description, &p)
+        // `inet_pton` rejects a zone suffix, and a vmnet prefix is never
+        // link-scoped, so the caller is responsible for supplying a zoneless
+        // prefix. Check the result: ignoring it leaves `p` zeroed and
+        // configures `::` on anything that fails to parse.
+        guard inet_pton(AF_INET6, prefixV6.lower.description, &p) == 1 else {
+            throw ContainerizationError(.invalidArgument, message: "invalid IPv6 prefix \(prefixV6) for network")
+        }
 
         guard vmnet_network_configuration_set_ipv6_prefix(config, &p, prefixV6.prefix.length) == .VMNET_SUCCESS else {
             throw ContainerizationError(.internalError, message: "failed to set IPv6 prefix \(prefixV6) for network")

--- a/Sources/ContainerizationExtras/CIDR.swift
+++ b/Sources/ContainerizationExtras/CIDR.swift
@@ -91,7 +91,7 @@ public enum CIDR: CustomStringConvertible, Equatable, Sendable, Hashable {
         case (.v4(let addr, let prefix)):
             return .v4(IPv4Address(addr.value & prefix.prefixMask32))
         case (.v6(let addr, let prefix)):
-            return .v6(IPv6Address(addr.value & prefix.prefixMask128))
+            return .v6(IPv6Address(addr.value & prefix.prefixMask128, zone: addr.zone))
         }
     }
 
@@ -113,9 +113,9 @@ public enum CIDR: CustomStringConvertible, Equatable, Sendable, Hashable {
     public func contains(_ ip: IPAddress) -> Bool {
         switch (self, ip) {
         case (.v4(let network, let prefix), .v4(let ip)):
-            return network.value == (ip.value & prefix.prefixMask32)
+            return (network.value & prefix.prefixMask32) == (ip.value & prefix.prefixMask32)
         case (.v6(let network, let prefix), .v6(let ip)):
-            return (network.zone == ip.zone) && (network.value == (ip.value & prefix.prefixMask128))
+            return (network.zone == ip.zone) && ((network.value & prefix.prefixMask128) == (ip.value & prefix.prefixMask128))
         default:
             return false
         }

--- a/Sources/ContainerizationExtras/CIDRv6.swift
+++ b/Sources/ContainerizationExtras/CIDRv6.swift
@@ -78,7 +78,7 @@ public struct CIDRv6: CustomStringConvertible, Equatable, Sendable, Hashable {
     /// The lowest address in this CIDR block
     @inlinable
     public var lower: IPv6Address {
-        IPv6Address(address.value & prefix.prefixMask128)
+        IPv6Address(address.value & prefix.prefixMask128, zone: address.zone)
     }
 
     /// The highest address in this CIDR block (broadcast address).

--- a/Tests/ContainerizationExtrasTests/TestCIDR.swift
+++ b/Tests/ContainerizationExtrasTests/TestCIDR.swift
@@ -146,6 +146,102 @@ struct TestCIDR {
         #expect(!cidr.contains(.v6(ip)))
     }
 
+    // MARK: - Wrapper Agrees With The Concrete Types
+
+    // `CIDR` keeps the address exactly as parsed, so a block written from a
+    // host address ("192.168.1.100/24") stores a value with host bits set.
+    // Containment has to mask both sides, the way `CIDRv4`/`CIDRv6` do, or the
+    // block reports that it excludes its own members.
+    @Test(arguments: [
+        ("192.168.1.100/24", "192.168.1.100"),
+        ("192.168.1.100/24", "192.168.1.0"),
+        ("192.168.1.100/24", "192.168.1.255"),
+        ("10.1.2.3/16", "10.1.99.99"),
+        ("2001:db8::1234/64", "2001:db8::1"),
+        ("2001:db8::1234/64", "2001:db8::1234"),
+    ])
+    func testWrapperContainsMembersOfAHostAddressBlock(cidr: String, ip: String) throws {
+        let block = try CIDR(cidr)
+        #expect(block.contains(try IPAddress(ip)))
+    }
+
+    @Test(arguments: [
+        ("192.168.1.100/24", "192.168.2.1"),
+        ("10.1.2.3/16", "10.2.0.1"),
+        ("2001:db8::1234/64", "2001:db9::1"),
+    ])
+    func testWrapperStillExcludesNonMembers(cidr: String, ip: String) throws {
+        let block = try CIDR(cidr)
+        #expect(!block.contains(try IPAddress(ip)))
+    }
+
+    // The wrapper must never disagree with the type it wraps.
+    @Test(arguments: ["192.168.1.100/24", "10.1.2.3/16", "192.168.1.0/24", "1.2.3.4/32"])
+    func testWrapperMatchesCIDRv4(cidr: String) throws {
+        let wrapper = try CIDR(cidr)
+        let concrete = try CIDRv4(cidr)
+        for probe in ["192.168.1.100", "192.168.1.0", "10.1.99.99", "1.2.3.4", "8.8.8.8"] {
+            let ip = try IPv4Address(probe)
+            #expect(wrapper.contains(.v4(ip)) == concrete.contains(ip), "disagreed on \(probe) for \(cidr)")
+        }
+        #expect(wrapper.lower.description == concrete.lower.description)
+        #expect(wrapper.upper.description == concrete.upper.description)
+    }
+
+    @Test(arguments: ["2001:db8::1234/64", "fe80::1%eth0/64", "2001:db8::/32"])
+    func testWrapperMatchesCIDRv6(cidr: String) throws {
+        let wrapper = try CIDR(cidr)
+        let concrete = try CIDRv6(cidr)
+        for probe in ["2001:db8::1", "2001:db8::1234", "fe80::1%eth0", "fe80::1", "2001:db9::1"] {
+            let ip = try IPv6Address(probe)
+            #expect(wrapper.contains(.v6(ip)) == concrete.contains(ip), "disagreed on \(probe) for \(cidr)")
+        }
+        #expect(wrapper.lower.description == concrete.lower.description)
+        #expect(wrapper.upper.description == concrete.upper.description)
+    }
+
+    // MARK: - Zone Preservation in Bounds
+
+    // `contains` compares zones, so a bound that drops the zone is reported as
+    // outside its own block. Both bounds have to carry the address's zone for
+    // the block to contain them.
+    @Test(arguments: ["fe80::1%eth0/64", "fe80::1%eth0/128", "2001:db8::5%lo0/126"])
+    func testZonedBlockContainsItsOwnBounds(cidr: String) throws {
+        let block = try CIDRv6(cidr)
+        #expect(block.contains(block.lower))
+        #expect(block.contains(block.upper))
+    }
+
+    @Test(arguments: ["fe80::1%eth0/64", "2001:db8::5%lo0/126"])
+    func testBoundsAgreeOnZone(cidr: String) throws {
+        let block = try CIDRv6(cidr)
+        #expect(block.lower.zone == block.address.zone)
+        #expect(block.upper.zone == block.address.zone)
+    }
+
+    @Test func testZonedLowerRendersItsZone() throws {
+        let block = try CIDRv6("2001:db8::5%lo0/126")
+        #expect(block.lower.description == "2001:db8::4%lo0")
+        #expect(block.upper.description == "2001:db8::7%lo0")
+    }
+
+    // The same bounds live on the `CIDR` wrapper, which carries its own copy.
+    @Test func testZonedWrapperContainsItsOwnBounds() throws {
+        let block = try CIDR("fe80::1%eth0/64")
+        #expect(block.contains(block.lower))
+        #expect(block.contains(block.upper))
+        #expect(block.lower.description == "fe80::%eth0")
+    }
+
+    // An unzoned block must keep rendering without a zone suffix.
+    @Test func testUnzonedBoundsCarryNoZone() throws {
+        let block = try CIDRv6("2001:db8::5/126")
+        #expect(block.lower.zone == nil)
+        #expect(block.upper.zone == nil)
+        #expect(block.lower.description == "2001:db8::4")
+        #expect(try CIDR("2001:db8::5/126").lower.description == "2001:db8::4")
+    }
+
     // MARK: - Range Constructor
 
     @Test func testRangeConstructorFindsSmallestBlock() throws {


### PR DESCRIPTION
Fixes #826.

## What

`CIDR` keeps the address exactly as parsed, so a block written from a host address keeps its host bits set. `contains` compared that unmasked stored value against the masked probe, so the wrapper reported that a block excluded its own members while the types it wraps answered the same query correctly.

| expression | before | `CIDRv4` / `CIDRv6` |
|---|---|---|
| `192.168.1.100/24` contains `192.168.1.100` | `false` | `true` |
| `192.168.1.100/24` contains `192.168.1.0` | `false` | `true` |
| `10.1.2.3/16` contains `10.1.99.99` | `false` | `true` |
| `2001:db8::1234/64` contains `2001:db8::1` | `false` | `true` |

Masking both sides matches what `CIDRv4.contains` and `CIDRv6.contains` already do. A block written in network form was unaffected, which is why this went unnoticed: every containment case in `TestCIDR.swift` used a network address.

The same accessors carried a second defect. `lower` dropped the IPv6 zone while `upper` kept it, and because `contains` compares zones, a zoned block excluded its own lower bound:

```
2001:db8::5%lo0/126  ->  lower = 2001:db8::4       (zone lost)
                         upper = 2001:db8::7%lo0
```

`lower` now carries the address's zone the way `upper` already did, in both copies of the logic: the `CIDR` wrapper and `CIDRv6`.

One caller needed a matching change. `VmnetNetwork.configurePrefixV6` renders `lower` into `inet_pton`, which rejects a zone suffix, so it was relying on `lower` stripping it. Per review, the vmnet API now leaves that to the caller: the helper renders `lower` as-is and checks the `inet_pton` result, rejecting a prefix it cannot parse rather than quietly accepting a zoned one. That check also closes a hole older than this PR — the result was discarded, so any address `inet_pton` refused left the buffer zeroed and configured `::`. Every in-repo caller already passes a zoneless prefix, so no call site changes.

## Verification

- 9 new tests in `TestCIDR.swift`: containment across v4 and v6 host-address blocks, non-members still excluded, the wrapper agreeing with `CIDRv4`/`CIDRv6` over a probe set, zoned bounds contained in their own block, zone rendering, and unzoned bounds still carrying no zone.
- Negative control: reverting only `CIDR.swift` and `CIDRv6.swift` while keeping the tests fails **7 of the 9**, with the wrong values visible in the output, for example `(block → 2001:db8::5%lo0/126).contains(block.lower → 2001:db8::4)` and `(wrapper.contains(.v4(ip)) → false) == (concrete.contains(ip) → true)`. The 2 that still pass are the controls written to pass either way: non-members stay excluded, and unzoned bounds are untouched.
- Full suite passes: 591 tests in 81 suites.
- `make containerization` builds clean with the default `WARNINGS_AS_ERRORS=true`.
- `swift format lint --strict --recursive --configuration .swift-format-nolint Sources Tests` exits 0, `swift format` leaves all four files unchanged, and `make check-licenses` reports no missing headers.
- The vmnet helper itself has no unit coverage: it is `#if os(macOS)`, private, and reachable only through `VmnetNetwork.init`, which creates a real vmnet network. It is exercised by the integration suite, which needs the vmnet entitlement.

The public shape of `CIDR`, `CIDRv4` and `CIDRv6` is untouched; only the values these accessors compute change.
