### PR TITLE
Fix bug when comparing the Platform struct

### DIFF
--- a/Sources/ContainerizationOCI/Platform.swift
+++ b/Sources/ContainerizationOCI/Platform.swift
@@ -250,25 +250,22 @@ extension Platform: Hashable {
 
     /// `==` compares if **lhs** and **rhs** are the exact same platforms.
     public static func == (lhs: Platform, rhs: Platform) -> Bool {
+        guard lhs.os == rhs.os else {
+            return false
+        }
+        guard lhs.architecture == rhs.architecture else {
+            return false
+        }
+
         //  NOTE:
         //  If the platform struct was created by setting the fields directly and not using (from: String)
         //  then, there is a possibility that for arm64 architecture, the variant may be set to nil
         //  In that case, the variant should be assumed to v8
-        if lhs.architecture == "arm64" && rhs.architecture == "arm64" {
-            // The following checks effectively verify
-            // that one operand has nil value and other has "v8"
-            if lhs.variant == nil || rhs.variant == nil {
-                if lhs.variant == "v8" || rhs.variant == "v8" {
-                    return true
-                }
-            }
+        if lhs.architecture == "arm64" {
+            return (lhs.variant ?? "v8") == (rhs.variant ?? "v8")
         }
 
-        let osEqual = lhs.os == rhs.os
-        let archEqual = lhs.architecture == rhs.architecture
-        let variantEqual = lhs.variant == rhs.variant
-
-        return osEqual && archEqual && variantEqual
+        return lhs.variant == rhs.variant
     }
 
     public func hash(into hasher: inout Swift.Hasher) {

--- a/Tests/ContainerizationOCITests/OCIPlatformTests.swift
+++ b/Tests/ContainerizationOCITests/OCIPlatformTests.swift
@@ -33,7 +33,7 @@ struct OCIPlatformTests {
 
     @Test func differentOS() {
         let lhs = Platform(arch: "arm64", os: "linux")
-        let rhs = Platform(arch: "arm64", os: "darwin")
+        let rhs = Platform(arch: "arm64", os: "windows")
         #expect(lhs != rhs, "Different OS should not be equal")
     }
 
@@ -80,5 +80,39 @@ struct OCIPlatformTests {
         var set = Set<Platform>()
         set.insert(withoutVariant)
         #expect(set.contains(withV8), "arm64/v8 must be found in a Set that contains arm64 with nil variant")
+    }
+
+    @Test func arm64_differentOS_nilAndV8() {
+        let linux = Platform(arch: "arm64", os: "linux", variant: nil)
+        let windows = Platform(arch: "arm64", os: "windows", variant: "v8")
+        #expect(linux != windows, "The arm64 nil/v8 variant rule must not ignore a differing OS")
+        #expect(windows != linux, "The arm64 nil/v8 variant rule must not ignore a differing OS")
+    }
+
+    @Test func arm64_differentOS_bothV8() {
+        let linux = Platform(arch: "arm64", os: "linux", variant: "v8")
+        let windows = Platform(arch: "arm64", os: "windows", variant: "v8")
+        #expect(linux != windows, "Same arch and variant but different OS => not equal")
+    }
+
+    @Test func arm64_normalizedArchDifferentOS() {
+        // aarch64 normalizes to arm64, so both sides hit the arm64 variant rule.
+        let linux = Platform(arch: "aarch64", os: "linux", variant: nil)
+        let windows = Platform(arch: "arm64", os: "windows", variant: "v8")
+        #expect(linux != windows, "Normalized arm64 platforms with a differing OS => not equal")
+    }
+
+    @Test func arm64_differentOS_setLookup() {
+        let linux = Platform(arch: "arm64", os: "linux", variant: nil)
+        let windows = Platform(arch: "arm64", os: "windows", variant: "v8")
+        var set = Set<Platform>()
+        set.insert(linux)
+        #expect(!set.contains(windows), "windows/arm64/v8 must not be found in a Set holding linux/arm64")
+    }
+
+    @Test func arm64_platformMatcherDifferentOS() {
+        let matcher = createPlatformMatcher(for: Platform(arch: "arm64", os: "linux", variant: nil))
+        #expect(!matcher(Platform(arch: "arm64", os: "windows", variant: "v8")), "matcher must reject a differing OS")
+        #expect(matcher(Platform(arch: "arm64", os: "linux", variant: "v8")), "matcher must accept the same OS with an implied v8 variant")
     }
 }


### PR DESCRIPTION
This fixes a latent bug in the `Platform` types equality operator where two platforms with differing OS's would be treated as the same if they both had variant set to 'v8' or nil