### PR TITLE
ImageStore: write state.json atomically

### DIFF
--- a/Sources/Containerization/Image/ImageStore/ImageStore+ReferenceManager.swift
+++ b/Sources/Containerization/Image/ImageStore/ImageStore+ReferenceManager.swift
@@ -49,7 +49,7 @@ extension ImageStore {
 
         private func save(_ state: State) throws {
             let statePath = self.path.appendingPathComponent("state.json")
-            try JSONEncoder().encode(state).write(to: statePath)
+            try JSONEncoder().encode(state).write(to: statePath, options: .atomic)
         }
 
         public func delete(reference: String) throws {


### PR DESCRIPTION
save() encodes into state.json in place, so a concurrent reader can observe a truncated or garbled file.