### PR TITLE
LinuxContainer: stop the VM when setup fails after start

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -641,8 +641,8 @@ extension LinuxContainer {
             let vm = try await self.vmm.create(config: creationConfig)
             let relayManager = UnixSocketRelayManager(vm: vm, log: self.logger)
 
-            try await vm.start()
             do {
+                try await vm.start()
                 let mountsForAgent = containerMounts
                 try await vm.withAgent { agent in
                     try await agent.standardSetup()


### PR DESCRIPTION
vm.start() sits outside the do block that owns teardown. This change prevents a failure in the agent setup from orphaning a VM.