### PR TITLE
LinuxContainer: finish the copyOut metadata stream on every path

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -1356,6 +1356,7 @@ extension LinuxContainer {
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
+                    defer { metadataCont.finish() }
                     try await state.vm.withAgent { agent in
                         guard let vminitd = agent as? Vminitd else {
                             throw ContainerizationError(.unsupported, message: "copyOut requires Vminitd agent")


### PR DESCRIPTION
metadataCont.finish() only runs inside onMetadata, which vminitd.copy never invokes when the guest path is missing.