### PR TITLE
Let callers choose the image platform in ContainerManager.create

### DIFF
--- a/Sources/Containerization/ContainerManager.swift
+++ b/Sources/Containerization/ContainerManager.swift
@@ -205,6 +205,7 @@ public struct ContainerManager: Sendable {
         writableLayerSizeInBytes: UInt64? = nil,
         readOnly: Bool = false,
         networking: Bool = true,
+        platform: Platform = .current,
         progress: ProgressHandler? = nil,
         configuration: (inout LinuxContainer.Configuration) throws -> Void
     ) async throws -> LinuxContainer {
@@ -216,6 +217,7 @@ public struct ContainerManager: Sendable {
             writableLayerSizeInBytes: writableLayerSizeInBytes,
             readOnly: readOnly,
             networking: networking,
+            platform: platform,
             progress: progress,
             configuration: configuration
         )
@@ -231,6 +233,11 @@ public struct ContainerManager: Sendable {
     ///   - readOnly: Whether to mount the root filesystem as read-only.
     ///   - networking: Whether to create a network interface for this container. Defaults to `true`.
     ///     When `false`, no network resources are allocated and `releaseNetwork`/`delete` remain safe to call.
+    ///   - platform: Which platform's image variant to use. Defaults to `.current`, preserving the
+    ///     previous behaviour. A caller running a FOREIGN-architecture image (e.g. an x86_64 image
+    ///     on an arm64 host under Rosetta) must pass that image's platform: resolving the config
+    ///     and unpacking the rootfs both need the variant that actually exists in the image, and
+    ///     `.current` fails before any translation layer is consulted.
     ///   - progress: Optional handler for tracking rootfs unpacking progress.
     public mutating func create(
         _ id: String,
@@ -239,6 +246,7 @@ public struct ContainerManager: Sendable {
         writableLayerSizeInBytes: UInt64? = nil,
         readOnly: Bool = false,
         networking: Bool = true,
+        platform: Platform = .current,
         progress: ProgressHandler? = nil,
         configuration: (inout LinuxContainer.Configuration) throws -> Void
     ) async throws -> LinuxContainer {
@@ -248,6 +256,7 @@ public struct ContainerManager: Sendable {
             image: image,
             destination: path.appendingPathComponent("rootfs.ext4"),
             size: rootfsSizeInBytes,
+            platform: platform,
             progress: progress
         )
         if readOnly {
@@ -269,6 +278,7 @@ public struct ContainerManager: Sendable {
             rootfs: rootfs,
             writableLayer: writableLayer,
             networking: networking,
+            platform: platform,
             configuration: configuration
         )
     }
@@ -290,9 +300,10 @@ public struct ContainerManager: Sendable {
         rootfs: Mount,
         writableLayer: Mount? = nil,
         networking: Bool = true,
+        platform: Platform = .current,
         configuration: (inout LinuxContainer.Configuration) throws -> Void
     ) async throws -> LinuxContainer {
-        let imageConfig = try await image.config(for: .current).config
+        let imageConfig = try await image.config(for: platform).config
         return try LinuxContainer(
             id,
             rootfs: rootfs,
@@ -340,10 +351,13 @@ public struct ContainerManager: Sendable {
         return path
     }
 
-    private func unpack(image: Image, destination: URL, size: UInt64, progress: ProgressHandler? = nil) async throws -> Mount {
+    private func unpack(
+        image: Image, destination: URL, size: UInt64, platform: Platform = .current,
+        progress: ProgressHandler? = nil
+    ) async throws -> Mount {
         do {
             let unpacker = EXT4Unpacker(capacityInBytes: size)
-            return try await unpacker.unpack(image, for: .current, at: destination, progress: progress)
+            return try await unpacker.unpack(image, for: platform, at: destination, progress: progress)
         } catch let err as ContainerizationError {
             if err.code == .exists {
                 return .block(


### PR DESCRIPTION
### Summary

`ContainerManager.create` resolves images against `.current`, so a container can only be created
from an image variant matching the host architecture. This adds an optional `platform` parameter
(defaulting to `.current`) so callers can select a different variant.

### The problem

Two sites on the `create` path pin the platform:

```swift
// Sources/Containerization/ContainerManager.swift
let imageConfig = try await image.config(for: .current).config           // :295
return try await unpacker.unpack(image, for: .current, at: destination)  // :346
```

Creating a container from an amd64 image on an arm64 host fails with:

```
platform linux/arm64
```

Two things make this hard to diagnose from the outside:

1. The error names the platform that was **requested**, not the one the image **has**, so it looks
   like the image is mistagged or corrupt.
2. It happens with `rosetta: true` on the `ContainerManager` as well — the failure is at *config
   resolution*, before the runtime reaches the point where translation applies. So the flag that
   exists to make this case work appears to do nothing, with no indication why.

### The change

`Image.config(for:)` and `EXT4Unpacker.unpack(_:for:at:progress:)` already accept a platform; only
`create` pins it. This threads `platform: Platform = .current` through the three `create` overloads
and the private `unpack`.

The default preserves current behaviour exactly — the change is additive, and no existing caller
needs to change.

### Why it matters in practice

We run SWE-bench's per-instance task images on Apple silicon. That corpus is mixed: of the 500
SWE-bench Verified instances, **281 publish arm64 images and 219 publish amd64 only**. A host-pinned
platform therefore makes 44% of the benchmark unrunnable — and evaluating only the arm64 remainder
would produce a score over a non-random subset (architecture correlates with repository and era),
which would not be a valid benchmark result.

### Verification

Tested on an arm64 host against both variants, running the same command shape in each:

| image | result |
| --- | --- |
| `astropy` instance (arm64) | conda env activates; `import astropy` → `5.1.dev623+gd16bfe05a7` |
| `pytest` instance (amd64, Rosetta) | `uname -m` → `x86_64`; `import _pytest` → `3.9.20` |

The second row is the case that could not be expressed before this change.
