### PR TITLE
fix: run interactive pty in raw mode so stdout is not truncated

### DIFF
--- a/Sources/ContainerizationOS/Terminal.swift
+++ b/Sources/ContainerizationOS/Terminal.swift
@@ -140,9 +140,15 @@ extension Terminal {
 
 extension Terminal {
     /// Enable raw mode for the pty.
-    public func setraw() throws {
+    /// - Parameter preserveSignalGeneration: Keep `ISIG` enabled so control
+    ///   characters such as Ctrl-C still signal the foreground process.
+    /// - Throws: An error if the terminal attributes cannot be read or applied.
+    public func setraw(preserveSignalGeneration: Bool = false) throws {
         var attr = try Self.getattr(descriptor)
         cfmakeraw(&attr)
+        if preserveSignalGeneration {
+            attr.c_lflag |= tcflag_t(ISIG)
+        }
         attr.c_oflag = attr.c_oflag | tcflag_t(OPOST)
         try fromSyscall(tcsetattr(descriptor, TCSANOW, &attr))
     }

--- a/Tests/ContainerizationOSTests/TerminalRawModeTests.swift
+++ b/Tests/ContainerizationOSTests/TerminalRawModeTests.swift
@@ -35,8 +35,8 @@ struct TerminalRawModeTests {
         return attrs
     }
 
-    private func has(_ flag: tcflag_t, in attributes: termios) -> Bool {
-        attributes.c_lflag & flag != 0
+    private func has(_ flag: tcflag_t, in flags: tcflag_t) -> Bool {
+        flags & flag != 0
     }
 
     @Test("pty slave is in canonical mode before raw-mode setup")
@@ -49,7 +49,7 @@ struct TerminalRawModeTests {
 
         // A freshly allocated pty slave is canonical by default (ICANON set).
         let attrs = try termiosAttributes(of: child.handle.fileDescriptor)
-        #expect(has(tcflag_t(ICANON), in: attrs))
+        #expect(has(tcflag_t(ICANON), in: attrs.c_lflag))
     }
 
     @Test("setraw clears ICANON and preserves OPOST")
@@ -63,7 +63,7 @@ struct TerminalRawModeTests {
         try child.setraw()
 
         let attrs = try termiosAttributes(of: child.handle.fileDescriptor)
-        #expect(!has(tcflag_t(ICANON), in: attrs), "setraw must clear canonical mode")
-        #expect(attrs.c_oflag & tcflag_t(OPOST) != 0, "setraw must preserve OPOST for CRLF output translation")
+        #expect(!has(tcflag_t(ICANON), in: attrs.c_lflag), "setraw must clear canonical mode")
+        #expect(has(tcflag_t(OPOST), in: attrs.c_oflag), "setraw must preserve OPOST for CRLF output translation")
     }
 }

--- a/Tests/ContainerizationOSTests/TerminalRawModeTests.swift
+++ b/Tests/ContainerizationOSTests/TerminalRawModeTests.swift
@@ -64,6 +64,7 @@ struct TerminalRawModeTests {
 
         let attrs = try termiosAttributes(of: child.handle.fileDescriptor)
         #expect(!has(tcflag_t(ICANON), in: attrs.c_lflag), "setraw must clear canonical mode")
-        #expect(has(tcflag_t(OPOST), in: attrs.c_oflag), "setraw must preserve OPOST for CRLF output translation")
+        #expect(has(tcflag_t(OPOST), in: attrs.c_oflag), "setraw must preserve OPOST for output post-processing")
+        #expect(has(tcflag_t(ONLCR), in: attrs.c_oflag), "setraw must preserve ONLCR for CRLF output translation")
     }
 }

--- a/Tests/ContainerizationOSTests/TerminalRawModeTests.swift
+++ b/Tests/ContainerizationOSTests/TerminalRawModeTests.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerizationOS
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+@Suite("Terminal raw mode tests")
+struct TerminalRawModeTests {
+    private func termiosAttributes(of descriptor: Int32) throws -> termios {
+        var attrs = termios()
+        try #require(tcgetattr(descriptor, &attrs) == 0, "tcgetattr failed, errno: \(errno)")
+        return attrs
+    }
+
+    private func has(_ flag: tcflag_t, in attributes: termios) -> Bool {
+        attributes.c_lflag & flag != 0
+    }
+
+    @Test("pty slave is in canonical mode before raw-mode setup")
+    func ptySlaveIsCanonicalBeforeSetup() throws {
+        let (parent, child) = try Terminal.create(initialSize: Terminal.Size(width: 120, height: 40))
+        defer {
+            try? parent.close()
+            try? child.close()
+        }
+
+        // A freshly allocated pty slave is canonical by default (ICANON set).
+        let attrs = try termiosAttributes(of: child.handle.fileDescriptor)
+        #expect(has(tcflag_t(ICANON), in: attrs))
+    }
+
+    @Test("setraw clears ICANON and preserves OPOST")
+    func setrawClearsCanonicalAndPreservesOutputPostProcessing() throws {
+        let (parent, child) = try Terminal.create(initialSize: Terminal.Size(width: 120, height: 40))
+        defer {
+            try? parent.close()
+            try? child.close()
+        }
+
+        try child.setraw()
+
+        let attrs = try termiosAttributes(of: child.handle.fileDescriptor)
+        #expect(!has(tcflag_t(ICANON), in: attrs), "setraw must clear canonical mode")
+        #expect(attrs.c_oflag & tcflag_t(OPOST) != 0, "setraw must preserve OPOST for CRLF output translation")
+    }
+}

--- a/Tests/ContainerizationOSTests/TerminalRawModeTests.swift
+++ b/Tests/ContainerizationOSTests/TerminalRawModeTests.swift
@@ -67,4 +67,19 @@ struct TerminalRawModeTests {
         #expect(has(tcflag_t(OPOST), in: attrs.c_oflag), "setraw must preserve OPOST for output post-processing")
         #expect(has(tcflag_t(ONLCR), in: attrs.c_oflag), "setraw must preserve ONLCR for CRLF output translation")
     }
+
+    @Test("setraw can preserve terminal signal generation")
+    func setrawCanPreserveSignalGeneration() throws {
+        let (parent, child) = try Terminal.create(initialSize: Terminal.Size(width: 120, height: 40))
+        defer {
+            try? parent.close()
+            try? child.close()
+        }
+
+        try child.setraw(preserveSignalGeneration: true)
+
+        let attrs = try termiosAttributes(of: child.handle.fileDescriptor)
+        #expect(!has(tcflag_t(ICANON), in: attrs.c_lflag), "raw input must remain non-canonical")
+        #expect(has(tcflag_t(ISIG), in: attrs.c_lflag), "Ctrl-C must continue to generate SIGINT")
+    }
 }

--- a/Tests/ContainerizationOSTests/TerminalRawModeTests.swift
+++ b/Tests/ContainerizationOSTests/TerminalRawModeTests.swift
@@ -64,6 +64,7 @@ struct TerminalRawModeTests {
 
         let attrs = try termiosAttributes(of: child.handle.fileDescriptor)
         #expect(!has(tcflag_t(ICANON), in: attrs.c_lflag), "setraw must clear canonical mode")
+        #expect(!has(tcflag_t(ISIG), in: attrs.c_lflag), "setraw must clear ISIG by default")
         #expect(has(tcflag_t(OPOST), in: attrs.c_oflag), "setraw must preserve OPOST for output post-processing")
         #expect(has(tcflag_t(ONLCR), in: attrs.c_oflag), "setraw must preserve ONLCR for CRLF output translation")
     }

--- a/vminitd/Sources/vmexec/Console.swift
+++ b/vminitd/Sources/vmexec/Console.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerizationOS
 import FoundationEssentials
 import LCShim
 
@@ -54,6 +55,12 @@ class Console {
             throw App.Errno(stage: "open_pts")
         }
         defer { _ = _close(slaveFD) }
+
+        // Put the pty slave into raw mode so the tty line discipline does not
+        // buffer or truncate large output writes (the container's stdout goes
+        // through this slave). `Terminal.setraw()` applies cfmakeraw and keeps
+        // OPOST, so newline translation to CRLF on output is preserved.
+        try Terminal(descriptor: slaveFD, setInitState: false).setraw()
 
         for fd: Int32 in 0...2 {
             guard dup3(slaveFD, fd, 0) != -1 else {

--- a/vminitd/Sources/vmexec/Console.swift
+++ b/vminitd/Sources/vmexec/Console.swift
@@ -59,8 +59,11 @@ class Console {
         // Put the pty slave into raw mode so the tty line discipline does not
         // buffer or truncate large output writes (the container's stdout goes
         // through this slave). `Terminal.setraw()` applies cfmakeraw and keeps
-        // OPOST, so newline translation to CRLF on output is preserved.
-        try Terminal(descriptor: slaveFD, setInitState: false).setraw()
+        // OPOST, so newline translation to CRLF on output is preserved. Keep
+        // ISIG enabled because cctl forwards terminal bytes, and guest Ctrl-C
+        // therefore depends on the slave line discipline generating SIGINT.
+        try Terminal(descriptor: slaveFD, setInitState: false)
+            .setraw(preserveSignalGeneration: true)
 
         for fd: Int32 in 0...2 {
             guard dup3(slaveFD, fd, 0) != -1 else {


### PR DESCRIPTION
Interactive containers (`container run --interactive` on apple/container) truncated stdout at 1024 bytes when output went to a terminal or file: the guest pty slave was left in canonical mode, whose line discipline buffers large writes, so a process writing more than 1024 bytes and exiting lost the buffered tail.

The pty slave is now put into raw mode before it is wired onto the container's stdio, using the existing `Terminal.setraw()` recipe (cfmakeraw with OPOST/ONLCR preserved so CRLF output translation is kept). Putting the slave fully into raw mode also clears `ISIG`, and @stephenlclarke pointed out in review that this would stop Ctrl-C from generating `SIGINT` for the container's own process. `Terminal.setraw()` now takes an opt-in `preserveSignalGeneration` parameter (default `false`, so every other caller — the host-side terminals in `cctl` and the examples — keeps its current behavior); only the guest pty slave in `vmexec` enables it, so Ctrl-C still interrupts the running process.

Regression tests cover both paths: default `setraw()` clears `ICANON` and `ISIG` while preserving `OPOST`/`ONLCR`; with `preserveSignalGeneration: true`, `ICANON` still clears but `ISIG` stays set.

Related: apple/container#1148

## Unapplied review findings

- [ ] P2 (advisory) — `Sources/ContainerizationOS/Terminal.swift:150` — Restoring `ISIG` on the guest pty slave re-arms `SIGQUIT` (Ctrl-\) and `SIGTSTP` (Ctrl-Z) generation, not just `SIGINT` (Ctrl-C).
  `cfmakeraw` clears the whole `ISIG` bit, so re-setting it (rather than selectively re-enabling only the `INTR` special character) restores all three signal-generating characters at once. This matches this repo's pre-truncation-fix behavior exactly (a freshly allocated pty slave has `ISIG` on by default), so it isn't a new regression relative to `main` — but it's worth an explicit call on whether that's the intended scope (matching runc's own console contract, which does the same) or whether only `SIGINT` should be restored (via `_POSIX_VDISABLE` on `VQUIT`/`VSUSP`). No code change proposed pending that call.
