### PR TITLE
Let a filesystem operation name a container, and report the bytes a trim discarded

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -966,6 +966,19 @@ extension LinuxContainer {
         }
     }
 
+    /// Discard the free blocks of the container's root filesystem, so a sparse
+    /// file backing it can give them back to the host. Returns the number of
+    /// bytes the filesystem reported trimmed.
+    @discardableResult
+    public func trimRootfs() async throws -> UInt64 {
+        try await self.state.withLock {
+            let state = try $0.startedState("trim")
+            return try await state.vm.withAgent { agent in
+                try await agent.trimContainerRootfs(containerID: self.id)
+            }
+        }
+    }
+
     /// Wait for the container to exit. Returns the exit code.
     @discardableResult
     public func wait(timeoutInSeconds: Int64? = nil) async throws -> ExitStatus {

--- a/Sources/Containerization/LinuxPod.swift
+++ b/Sources/Containerization/LinuxPod.swift
@@ -1134,6 +1134,25 @@ extension LinuxPod {
         }
     }
 
+    /// Discard the free blocks of a container's root filesystem, so a sparse
+    /// file backing it can give them back to the host. Returns the number of
+    /// bytes the filesystem reported trimmed.
+    @discardableResult
+    public func trimContainer(_ containerID: String) async throws -> UInt64 {
+        try await self.state.withLock { state in
+            let createdState = try state.phase.createdState("trimContainer")
+            guard let container = state.containers[containerID], container.state == .started else {
+                throw ContainerizationError(
+                    .notFound,
+                    message: "container \(containerID) not found or not started"
+                )
+            }
+            return try await createdState.vm.withAgent { agent in
+                try await agent.trimContainerRootfs(containerID: containerID)
+            }
+        }
+    }
+
     /// Wait for a container to exit. Returns the exit code.
     @discardableResult
     public func waitContainer(_ containerID: String, timeoutInSeconds: Int64? = nil) async throws -> ExitStatus {

--- a/Sources/Containerization/SandboxContext/SandboxContext.pb.swift
+++ b/Sources/Containerization/SandboxContext/SandboxContext.pb.swift
@@ -1126,7 +1126,13 @@ public nonisolated struct Com_Apple_Containerization_Sandbox_V3_FilesystemOperat
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  /// The filesystem to operate on: a path in the init namespace, or a
+  /// container whose root filesystem is the target. A container's rootfs
+  /// is mounted in its own namespace, so naming the container is how a
+  /// caller reaches it after the container has pivoted.
   public var path: String = String()
+
+  public var containerID: String = String()
 
   public var operation: Com_Apple_Containerization_Sandbox_V3_FilesystemOperationRequest.OneOf_Operation? = nil
 
@@ -3453,7 +3459,7 @@ nonisolated extension Com_Apple_Containerization_Sandbox_V3_FiTrimResult: SwiftP
 
 nonisolated extension Com_Apple_Containerization_Sandbox_V3_FilesystemOperationRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FilesystemOperationRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}trim\0\u{1}freeze\0\u{1}thaw\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}trim\0\u{1}freeze\0\u{1}thaw\0\u{3}container_id\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3501,6 +3507,7 @@ nonisolated extension Com_Apple_Containerization_Sandbox_V3_FilesystemOperationR
           self.operation = .thaw(v)
         }
       }()
+      case 5: try { try decoder.decodeSingularStringField(value: &self.containerID) }()
       default: break
       }
     }
@@ -3529,11 +3536,15 @@ nonisolated extension Com_Apple_Containerization_Sandbox_V3_FilesystemOperationR
     }()
     case nil: break
     }
+    if !self.containerID.isEmpty {
+      try visitor.visitSingularStringField(value: self.containerID, fieldNumber: 5)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Com_Apple_Containerization_Sandbox_V3_FilesystemOperationRequest, rhs: Com_Apple_Containerization_Sandbox_V3_FilesystemOperationRequest) -> Bool {
     if lhs.path != rhs.path {return false}
+    if lhs.containerID != rhs.containerID {return false}
     if lhs.operation != rhs.operation {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/Sources/Containerization/SandboxContext/SandboxContext.proto
+++ b/Sources/Containerization/SandboxContext/SandboxContext.proto
@@ -309,7 +309,12 @@ message FiTrimResult {
 }
 
 message FilesystemOperationRequest {
+  // The filesystem to operate on: a path in the init namespace, or a
+  // container whose root filesystem is the target. A container's rootfs
+  // is mounted in its own namespace, so naming the container is how a
+  // caller reaches it after the container has pivoted.
   string path = 1;
+  string container_id = 5;
   oneof operation {
     FiTrimParams trim = 2;
     FiFreezeParams freeze = 3;

--- a/Sources/Containerization/VirtualMachineAgent.swift
+++ b/Sources/Containerization/VirtualMachineAgent.swift
@@ -42,6 +42,10 @@ public protocol VirtualMachineAgent: Sendable {
     func close() async throws
     // Perform a filesystem operation on the given path.
     func filesystemOperation(operation: FilesystemOperation, path: String) async throws
+    /// Discard the free blocks of a container's root filesystem, which is
+    /// mounted in the container's own namespace where a path cannot name it.
+    /// Returns the number of bytes the filesystem reported trimmed.
+    func trimContainerRootfs(containerID: String) async throws -> UInt64
 
     // POSIX-y
     func getenv(key: String) async throws -> String
@@ -89,6 +93,10 @@ public protocol VirtualMachineAgent: Sendable {
 extension VirtualMachineAgent {
     public func closeProcessStdin(id: String, containerID: String?) async throws {
         throw ContainerizationError(.unsupported, message: "closeProcessStdin")
+    }
+
+    public func trimContainerRootfs(containerID: String) async throws -> UInt64 {
+        throw ContainerizationError(.unsupported, message: "trimContainerRootfs")
     }
 
     public func configureHosts(config: Hosts, location: String) async throws {

--- a/Sources/Containerization/Vminitd.swift
+++ b/Sources/Containerization/Vminitd.swift
@@ -221,6 +221,19 @@ extension Vminitd: VirtualMachineAgent {
             })
     }
 
+    /// Discard the free blocks of a container's root filesystem. The rootfs is
+    /// mounted in the container's own namespace, so the request names the
+    /// container and the guest reaches its view of the filesystem itself.
+    /// Returns the number of bytes the filesystem reported trimmed.
+    public func trimContainerRootfs(containerID: String) async throws -> UInt64 {
+        let response = try await client.filesystemOperation(
+            .with {
+                $0.operation = FilesystemOperation.trim.toProtoOperation()
+                $0.containerID = containerID
+            })
+        return response.trim.trimmedBytes
+    }
+
     public func createProcess(
         id: String,
         containerID: String?,

--- a/Sources/Integration/ContainerTests.swift
+++ b/Sources/Integration/ContainerTests.swift
@@ -137,6 +137,41 @@ extension IntegrationSuite {
         }
     }
 
+    /// A trim answers with the bytes the filesystem discarded, which is the
+    /// whole of what a caller reclaiming space has to go on: the operation
+    /// itself succeeds either way, so a count that never leaves the guest
+    /// reads exactly like a filesystem with nothing to give back.
+    func testContainerTrimReportsBytes() async throws {
+        let id = "test-container-trim-reports-bytes"
+        let bs = try await bootstrap(id)
+
+        let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
+            config.process.arguments = ["/bin/sh", "-c", "sleep 30"]
+            config.bootLog = bs.bootLog
+        }
+
+        do {
+            try await container.create()
+            try await container.start()
+
+            // A filesystem carries free space from the moment it is made, and
+            // the first discard covers all of it, so a container that reached
+            // this point has blocks to report whatever it has written.
+            let trimmed = try await container.trimRootfs()
+
+            try await container.kill(.kill)
+            _ = try await container.wait()
+            try await container.stop()
+
+            guard trimmed > 0 else {
+                throw IntegrationError.assert(msg: "trim reported \(trimmed) bytes")
+            }
+        } catch {
+            try? await container.stop()
+            throw error
+        }
+    }
+
     func testProcessEchoHi() async throws {
         let id = "test-process-echo-hi"
         let bs = try await bootstrap(id)

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -422,6 +422,7 @@ struct IntegrationSuite: AsyncParsableCommand {
             // Process basics
             Test("process true", testProcessTrue),
             Test("process false", testProcessFalse),
+            Test("container trim reports bytes", testContainerTrimReportsBytes),
             Test("process echo hi", testProcessEchoHi),
             Test("process no executable", testProcessNoExecutable),
             Test("process user", testProcessUser),

--- a/vminitd/Sources/VminitdCore/Server+GRPC.swift
+++ b/vminitd/Sources/VminitdCore/Server+GRPC.swift
@@ -721,7 +721,26 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
     public func filesystemOperation(request: Com_Apple_Containerization_Sandbox_V3_FilesystemOperationRequest, context: GRPCCore.ServerContext)
         async throws -> Com_Apple_Containerization_Sandbox_V3_FilesystemOperationResponse
     {
-        let path = FilePath(request.path)
+        // A request that names a container targets that container's root
+        // filesystem. The rootfs is mounted in the container's own namespace,
+        // where this process holds no path to it, so the container's view is
+        // reached through the init process's proc entry: the kernel resolves
+        // /proc/<pid>/root through the pid's namespace, and the trailing dot
+        // makes the magic link a traversed component rather than the opened
+        // one, which the O_NOFOLLOW below would refuse.
+        // https://man7.org/linux/man-pages/man5/proc_pid_root.5.html
+        let path: FilePath
+        if !request.containerID.isEmpty {
+            guard let container = await self.state.containers[request.containerID] else {
+                throw RPCError(code: .notFound, message: "container \(request.containerID) not found")
+            }
+            guard let pid = await container.pid else {
+                throw RPCError(code: .failedPrecondition, message: "container \(request.containerID) has no running init process")
+            }
+            path = FilePath("/proc/\(pid)/root/.")
+        } else {
+            path = FilePath(request.path)
+        }
 
         log.debug(
             "filesystemOperation",
@@ -761,7 +780,8 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
             case .trim(let params):
                 switch params.schedule {
                 case .oneShot:
-                    try trimFilesystem(fd: fd)
+                    let trimmed = try trimFilesystem(fd: fd)
+                    return .with { $0.trim = .with { $0.trimmedBytes = trimmed } }
                 case .none:
                     throw RPCError(code: .invalidArgument, message: "trim schedule must be specified")
                 }
@@ -804,7 +824,14 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
         var min_len: UInt64
     }
 
-    private func trimFilesystem(fd: Int32) throws {
+    /// Discard the filesystem's free blocks, answering with the bytes it
+    /// reported discarding.
+    ///
+    /// The ioctl writes the count back into the range it was given, which is
+    /// the filesystem's own account of what the trim returned and the only
+    /// one there is.
+    /// https://man7.org/linux/man-pages/man2/ioctl_fitrim.2.html
+    private func trimFilesystem(fd: Int32) throws -> UInt64 {
         let FITRIM: UInt = 0xC018_5879
         var trange = fitrim_range(start: 0, len: UInt64.max, min_len: 0)
         let rc: CInt = ioctl(fd, FITRIM, &trange)
@@ -812,6 +839,7 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
             let error = swiftErrno("ioctl(FITRIM)")
             throw RPCError(code: .internalError, message: "trim failed", cause: error)
         }
+        return trange.len
     }
 
     public func umount(request: Com_Apple_Containerization_Sandbox_V3_UmountRequest, context: GRPCCore.ServerContext)


### PR DESCRIPTION
## Summary

A filesystem operation takes a path in the init namespace, and a container's root filesystem is not there: the container mounts it in a namespace of its own, and after the pivot nothing in the init namespace names it. The operations that matter for a root filesystem, trim above all, were out of reach for exactly the filesystems that grow.

A request that names a container reaches its root filesystem through the init process's proc entry: the kernel resolves `/proc/<pid>/root` through that process's namespace, and the trailing dot component keeps the opened target a directory rather than the magic link itself, which the handler's `O_NOFOLLOW` refuses. The agent surface takes the container id and answers with the bytes the filesystem reported trimmed, for a single container and for a pod's members alike.

Closes #858. Addresses the requirement described in apple/container#2105.

## Relationship to #838

This supersedes #838, which asks for the same thing from issue apple/container#2105. Both add `containerID` to `FilesystemOperationRequest` so the operation runs against the intended container. The differences:

* **`FiTrimResult.trimmed_bytes` is populated here.** The field arrived with the trim operation in #700 and has never been set: `trimFilesystem(fd:)` throws away the count that `FITRIM` writes back into the range, and `filesystemOperation` returns a bare `.init()`, so the oneof is never set and callers decode the default. #838 keeps `return .init()`, so the field stays dead after it. Reporting is the whole reason the field exists, and a caller that loops until a trim returns nothing cannot work without it.
* **`containerID` stays optional.** #838 rejects a request that does not carry one, which breaks the existing path-addressed callers. Here a request names either a path or a container, so existing callers keep working.
* **The host side gains the operation it needs.** `LinuxContainer.trimRootfs()` and `LinuxPod.trimContainer(_:)` return the bytes discarded, rather than leaving each caller to assemble the request.
* **There is a test for the count.** `testContainerTrimReportsBytes` boots a container, trims, and asserts the answer is not zero, which is what fails today.

One thing #838 does that this does not: it enters the container's mount namespace with `setns(CLONE_NEWNS)` on a dedicated thread after `unshare(CLONE_FS)`. That is a correct way to do it, and it generalises to any path inside the container. Resolving through `/proc/<pid>/root` reaches the same filesystem through the same namespace without moving a thread between namespaces. If maintainers prefer the `setns` approach, the reporting fix and the host-side API here apply on top of it unchanged.

## Testing

- `swift build` and `make check` clean.
- `swift test`: 603 tests in 83 suites passed.
- `make vminitd` builds the guest with the change.
- Integration: `./bin/containerization-integration --filter trim` runs `container trim reports bytes` and the existing `container trim ext4 clone`, both passing. The new test fails before the reporting fix with `trim reported 0 bytes`.
