### PR TITLE
Mount at /run/virtiofs only what containers bind from there

### DIFF
--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -671,7 +671,12 @@ extension LinuxContainer {
                         // gets populated.
                         if vm.virtiofsLayout == .perTag {
                             try await agent.mkdir(path: "/run/virtiofs", all: true, perms: 0o755)
-                            let virtiofsAttachments = (vm.mounts[self.id] ?? []).filter { $0.type == "virtiofs" }
+                            // Additional mounts bind from /run/virtiofs/<tag>; the
+                            // rootfs and writable layer (the leading entries) are
+                            // mounted at the container's own paths directly, so
+                            // their tags stay out.
+                            let leadingEntries = self.writableLayer != nil ? 2 : 1
+                            let virtiofsAttachments = (vm.mounts[self.id] ?? []).dropFirst(leadingEntries).filter { $0.type == "virtiofs" }
                             let uniqueTags = Set(virtiofsAttachments.map(\.source))
                             for tag in uniqueTags {
                                 let dest = "/run/virtiofs/\(tag)"

--- a/Sources/Containerization/LinuxPod.swift
+++ b/Sources/Containerization/LinuxPod.swift
@@ -457,10 +457,15 @@ extension LinuxPod {
                             if vm.virtiofsLayout == .perTag {
                                 // Tags already mounted in the guest at boot or by a
                                 // prior hotplug (i.e. present on another container).
+                                // Only additional mounts put their tags under
+                                // /run/virtiofs; a virtiofs rootfs is mounted at the
+                                // container's own rootfs path, so its entry (the
+                                // first) says nothing about /run/virtiofs and would
+                                // wrongly satisfy a tag another container binds from.
                                 let alreadyMounted = Set(
                                     vm.mounts
                                         .filter { $0.key != id }
-                                        .values.flatMap { $0 }
+                                        .values.flatMap { $0.dropFirst() }
                                         .filter { $0.type == "virtiofs" }
                                         .map { $0.source }
                                 )
@@ -647,10 +652,14 @@ extension LinuxPod {
                             // CH backend: one virtio-fs device per source-hash
                             // tag, so mount each tag separately at
                             // /run/virtiofs/<tag>. See LinuxContainer for the
-                            // VZ vs. CH model split.
+                            // VZ vs. CH model split. /run/virtiofs carries the
+                            // tags containers bind additional mounts from; a
+                            // virtiofs rootfs (each container's first entry) is
+                            // mounted at the container's own rootfs path and
+                            // takes no bind, so its tag stays out.
                             var seenTags: Set<String> = []
                             for (_, attached) in vm.mounts {
-                                for entry in attached where entry.type == "virtiofs" {
+                                for entry in attached.dropFirst() where entry.type == "virtiofs" {
                                     guard seenTags.insert(entry.source).inserted else { continue }
                                     let dest = "/run/virtiofs/\(entry.source)"
                                     try await agent.mkdir(path: dest, all: true, perms: 0o755)


### PR DESCRIPTION
## Summary

A container's additional virtiofs mounts are bind-mounted into it from `/run/virtiofs/<tag>`, so those tags are what belongs there. A virtiofs rootfs is mounted at the container's own rootfs path and nothing binds it, but the per-tag boot walk put its tag under `/run/virtiofs` anyway, and the hotplug join counted it as satisfying `/run/virtiofs` for every other container. A container joining with a directory another container boots from was skipped as already mounted, and its bind failed with `ENOENT` at start.

Deriving the boot walks and the join's already-mounted set from the additional mounts alone makes `/run/virtiofs` and the set that describes it the same thing. The colliding join then mounts the tag itself, which the guest kernel allows: `virtio_fs_get_tree` resolves each mount of a tag to the device instance's one superblock (`fs/fuse/virtio_fs.c`, `sget_fc` with `virtio_fs_test_super`), so a tag mounts at any number of places.

Closes #860.

## Motivation and Context

The bug needs two containers in one pod and a shared host directory to show up: one booting from it, another mounting it. That is a reasonable thing to arrange, and the failure gives no hint of the cause, since the container that fails is not the one holding the tag.

The underlying confusion is that two different sets were being described by one name. `/run/virtiofs` is where binds come from; the set of tags that need to be there is the additional mounts. Deriving one from the other keeps them from drifting apart.

## Testing

- `swift build` and `make check` clean.
- `swift test`: 603 tests in 83 suites passed.
- Integration suite passes, including the pod tests that exercise hotplug joins.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
