### PR TITLE
Test against the kernel the shipped tool installs, and stop the reaper eating the rootfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ LIBARCHIVE_UPSTREAM_REPO := https://github.com/libarchive/libarchive
 LIBARCHIVE_UPSTREAM_VERSION := v3.7.7
 LIBARCHIVE_LOCAL_DIR := workdir/libarchive
 
-KATA_BINARY_PACKAGE := https://github.com/kata-containers/kata-containers/releases/download/3.17.0/kata-static-3.17.0-arm64.tar.xz
+KATA_BINARY_PACKAGE := https://github.com/kata-containers/kata-containers/releases/download/3.28.0/kata-static-3.28.0-arm64.tar.zst
 CLOUD_HYPERVISOR_URL := https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v52.0/cloud-hypervisor-static-aarch64
 # SHA256 of the v52.0 aarch64 static binary (verified locally from the
 # upstream release artifact). Bump alongside CLOUD_HYPERVISOR_URL.
@@ -410,11 +410,11 @@ integration:
 .PHONY: fetch-default-kernel
 fetch-default-kernel:
 	@mkdir -p .local/ bin/
-ifeq (,$(wildcard .local/kata.tar.gz))
-	@curl -SsL -o .local/kata.tar.gz ${KATA_BINARY_PACKAGE}
+ifeq (,$(wildcard .local/kata.tar))
+	@curl -SsL -o .local/kata.tar ${KATA_BINARY_PACKAGE}
 endif
 ifeq (,$(wildcard .local/vmlinux-$(KERNEL_ARCH)))
-	@tar -zxf .local/kata.tar.gz -C .local/ --strip-components=1
+	@tar -xf .local/kata.tar -C .local/ --strip-components=1
 	@cp -L .local/opt/kata/share/kata-containers/vmlinux.container .local/vmlinux-$(KERNEL_ARCH)
 endif
 ifeq (,$(wildcard bin/vmlinux-$(KERNEL_ARCH)))

--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ After building, run basic and integration tests:
 make test integration
 ```
 
+Tests that only apply to Linux are compiled out on macOS, so `make test` passes
+without running them. Run those with:
+
+```bash
+make linux-test
+```
+
+which runs the same tests inside the Linux dev container, as the Linux build
+workflow does.
+
 A kernel is required to run integration tests.
 If you do not have a kernel locally, a default kernel can be fetched using the `make fetch-default-kernel` target.
 

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -259,12 +259,16 @@ struct IntegrationSuite: AsyncParsableCommand {
         // a ~2GB rootfs and a ~512MB initfs, so without reaping the dev
         // container fills its CoW layer in ~10 tests.
         if self.maxConcurrency == 1 {
-            let preserve = fsPath.absolutePath()
+            // contentsOfDirectory reports paths under /private, while testDir is
+            // built from FileManager's /var view of the same directory, so both
+            // sides are resolved before comparing.
+            let preserve = fsPath.resolvingSymlinksInPathWithPrivate().absolutePath()
             if let entries = try? FileManager.default.contentsOfDirectory(
                 at: Self.testDir,
                 includingPropertiesForKeys: nil
             ) {
-                for url in entries where url.absolutePath() != preserve {
+                for url in entries
+                where url.resolvingSymlinksInPathWithPrivate().absolutePath() != preserve {
                     try? FileManager.default.removeItem(at: url)
                 }
             }


### PR DESCRIPTION
## Summary

Three things the integration suite needs before anything builds on it.

**The kernel the tests fetch had drifted from the one users run.** `container` installs kata 3.28.0 and its 6.18.15 kernel while these tests fetched 3.17.0, so the suite exercised a guest with a different feature set to the one it represents. Nested runtimes are the visible case: 3.17.0 was built without `nf_tables`, so a docker daemon inside a container fails there and works on what ships. Kata moved from xz to zstd between those releases, so the archive is no longer named for its compression, and tar is left to recognise it rather than being told, which also holds if the format changes again.

**The reaper deleted the rootfs it meant to preserve.** Running at a concurrency of one, it deletes everything in the test directory except the unpacked rootfs. It held that path as `FileManager` reports it, under `/var`, and compared it against `contentsOfDirectory` entries, which come back under `/private/var`, so the preserved path never matched and the rootfs went with the per-test files. The unpack coordinator still held it as unpacked, so the next test opened a rootfs that was no longer there. Both sides now resolve with `resolvingSymlinksInPathWithPrivate`, which exists for exactly this difference between two views of one directory.

**`make test` says nothing about what it skipped.** Tests guarded for Linux are compiled out on macOS, so the target reports success without running them, and the target that does run them is mentioned nowhere outside the makefile.

## Motivation and Context

These are separable but all in the same area, and each is the kind of thing that makes a later failure hard to read: a guest with the wrong feature set, a test that fails because a previous test's cleanup removed its rootfs, and a green run that skipped what you cared about.

No issue filed, as this touches only the test suite and its docs and carries no user-visible behaviour. Happy to open one if the project prefers it recorded.

## Testing

- `swift build` and `make check` clean.
- `swift test`: 603 tests in 83 suites passed.
- Integration suite runs against the kata release the config names, and the reaper no longer removes the shared rootfs between tests.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
