### PR TITLE
Ask for continuous discard where the runtime makes an ext4

### DIFF
--- a/Sources/Containerization/ContainerManager.swift
+++ b/Sources/Containerization/ContainerManager.swift
@@ -350,7 +350,7 @@ public struct ContainerManager: Sendable {
                     format: "ext4",
                     source: destination.absolutePath(),
                     destination: "/",
-                    options: []
+                    options: ["discard"]
                 )
             }
             throw err
@@ -364,11 +364,14 @@ public struct ContainerManager: Sendable {
         }
         let filesystem = try EXT4.Formatter(FilePath(path), minDiskSize: size)
         try filesystem.close()
+        // The filesystem lives in a sparse file that only gives freed blocks
+        // back to the host when the guest discards them, so the mount asks
+        // for continuous discard from birth.
         return .block(
             format: "ext4",
             source: path,
             destination: "/",
-            options: []
+            options: ["discard"]
         )
     }
 }

--- a/Sources/Containerization/Image/Unpacker/EXT4Unpacker.swift
+++ b/Sources/Containerization/Image/Unpacker/EXT4Unpacker.swift
@@ -139,11 +139,15 @@ public struct EXT4Unpacker: Unpacker {
             try await filesystem.unpack(reader: reader, progress: progress)
         }
 
+        // The filesystem lives in a sparse file that only gives freed blocks
+        // back to the host when the guest discards them, so the mount asks for
+        // continuous discard from birth. A read-only mount of it parses the
+        // option and leaves it idle.
         return .block(
             format: "ext4",
             source: cleanedPath,
             destination: "/",
-            options: []
+            options: ["discard"]
         )
     }
 


### PR DESCRIPTION
## Summary

A container's root filesystem and writable layer are sparse files, and the guest never returns the blocks it frees: deleting inside the guest frees guest blocks, the host file keeps every block it has ever touched, so its real size is the high water mark of everything ever written rather than what is live.

The filesystem hands freed blocks back the moment they are freed when its mount asks for discard, and the runtime forwards those discards to hole punches in the backing file. The ask belongs to the file: every ext4 the runtime creates is such a sparse file, so its mount options carry `discard` from the moment the mount exists, and every place the file is later mounted, container or pod, lower layer or writable, inherits the ask with the rest of the options. A read-only mount parses the option and leaves it idle.

## Motivation and Context

This is the continuous counterpart to an explicit trim: rather than reclaiming in a sweep after the fact, the filesystem returns each block as it is freed, and the backing file stops growing to its high water mark.

Putting the option on the mount where the file is created, rather than at each place it is mounted, means a caller cannot forget it, and the two do not drift apart as more mount sites appear.

## Relationship to #859

#859 adds an explicit trim that returns blocks on demand and reports how many. The two are complementary: continuous discard keeps a live filesystem from growing, while a trim reclaims what a filesystem that has been running without it already holds. Neither depends on the other, and they touch different files.

## Testing

- `swift build` and `make check` clean.
- `swift test`: 595 tests in 82 suites passed.
- Integration: the swap and reclaim tests watch the backing file's allocated blocks while a workload fills and frees, which is where a filesystem that keeps its high water mark shows up.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
