### PR TITLE
Fetch zlib from its own releases

### DIFF
--- a/scripts/build-musl-x86_64-deps.sh
+++ b/scripts/build-musl-x86_64-deps.sh
@@ -78,7 +78,7 @@ fi
 # zlib — provides libz.a. Its configure does not take --host, so the
 # CC env var is what selects the cross compiler.
 ZLIB_VERSION=1.3.1
-fetch_extract "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz" zlib.tar.gz
+fetch_extract "https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz" zlib.tar.gz
 (
     cd "zlib-${ZLIB_VERSION}"
     if ! ./configure --static --prefix="${PREFIX}"; then


### PR DESCRIPTION
## Summary

Every dependency this script fetches comes from a GitHub release page except zlib, which came from `zlib.net`, and a build dies whenever that one host does. zlib publishes the same release tarballs on its own GitHub repository, so the fetch joins the others on infrastructure that answers.

## Motivation and Context

The x86_64 dependency build has one host in it that the others do not depend on, and it fails often enough to notice. The tarballs are the same artifacts published by the same project, so this is a change of mirror rather than of source.

## Testing

- `make dist-x86_64`'s dependency step fetches and builds zlib from the new location.
- No change to the built artifacts: same release, same tarball contents.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
