### PR TITLE
Prefer the in-repo kernel for make integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,16 @@ SWIFT_CONFIGURATION := $(if $(filter-out false,$(WARNINGS_AS_ERRORS)),-Xswiftc -
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 KERNEL_ARCH := $(if $(filter $(UNAME_M),aarch64 arm64),arm64,$(UNAME_M))
-# Candidate kernel filenames in bin/ (compiled vmlinuz first, kata-fetched vmlinux fallback).
+# Candidate kernels for `make integration`, in preference order: the in-repo
+# kernel built by `make -C kernel` first, then the kata-fetched kernel under
+# bin/ as a fallback. The in-repo kernel is built from the config this repo
+# carries, so a configuration change made here is the one integration boots
+# wherever that kernel exists; a checkout without one still runs on the
+# fetched default.
 ifeq ($(KERNEL_ARCH),x86_64)
-KERNEL_CANDIDATES := bin/vmlinuz-x86_64 bin/vmlinux-x86_64
+KERNEL_CANDIDATES := kernel/vmlinuz-x86_64 bin/vmlinuz-x86_64 bin/vmlinux-x86_64
 else
-KERNEL_CANDIDATES := bin/vmlinux-$(KERNEL_ARCH)
+KERNEL_CANDIDATES := kernel/vmlinux-$(KERNEL_ARCH) bin/vmlinux-$(KERNEL_ARCH)
 endif
 # In-repo KVM-capable kernel built by `make -C kernel` (vmlinuz for x86_64 bzImage,
 # vmlinux for arm64 Image). linux-integration requires this; the kata-fetched


### PR DESCRIPTION
## Summary

The integration suite booted whichever kernel sat under `bin/`, so a kernel configured and built in the repo with `make -C kernel` took effect only if the fetched default was deleted by hand: a configuration change could be built, pass a rebuild, and never be the kernel a test ran against.

The guest kernel is a variable of every integration result, so the one built from the repo's own configuration is preferred wherever it exists, with the kata-fetched kernel remaining the fallback for a checkout that never built one. This is the preference `LINUX_INTEGRATION_KERNEL` already expresses; `make integration` now expresses the same one.

## Motivation and Context

The failure mode is a silent wrong answer rather than an error: you change the kernel configuration, build it, run the suite, and read results produced by a different kernel. Nothing in the output says which one booted.

Taking the preference that already exists for the Linux integration target, rather than inventing one, keeps the two from disagreeing.

## Testing

- With no in-repo kernel, `make integration` uses the fetched default exactly as before.
- With `make -C kernel` having produced one, the suite boots it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
