### PR TITLE
Add logic to cctl to enable NBD mounts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -95,6 +95,14 @@ let package = Package(
             ]
         ),
         .testTarget(
+            name: "cctlTests",
+            dependencies: [
+                "cctl",
+                "Containerization",
+            ],
+            path: "Tests/cctlTests"
+        ),
+        .testTarget(
             name: "ContainerizationUnitTests",
             dependencies: ["Containerization", "CloudHypervisor"],
             path: "Tests/ContainerizationTests",

--- a/Sources/Integration/PodVolumeTests.swift
+++ b/Sources/Integration/PodVolumeTests.swift
@@ -19,6 +19,7 @@ import ContainerizationArchive
 import ContainerizationEXT4
 import ContainerizationError
 import ContainerizationOCI
+import ContainerizationOS
 import Foundation
 import Logging
 import SystemPackage
@@ -76,6 +77,63 @@ extension IntegrationSuite {
         guard output.contains("/dev/vd") else {
             throw IntegrationError.assert(msg: "expected virtio block device (/dev/vd*) for \(path), got: \(output)")
         }
+    }
+
+    /// Run `bin/cctl run` to completion and return its combined stdout+stderr.
+    ///
+    /// This exercises the `cctl` CLI rather than the
+    /// library directly, so it validates the `--block` option wiring end to end:
+    /// argument parsing, `Mount` construction, VZ attachment, and the guest
+    /// mount. `bin/cctl` is built and codesigned with the virtualization
+    /// entitlement.
+    private func runCctl(arguments: [String]) throws -> (output: String, exitCode: Int32) {
+        let cctl = Self.binPath(name: "cctl")
+        guard FileManager.default.isExecutableFile(atPath: cctl.path) else {
+            throw IntegrationError.assert(msg: "bin/cctl not built or not executable at \(cctl.path); run `make containerization`")
+        }
+
+        let (parent, child) = try Terminal.create()
+
+        let process = Process()
+        process.executableURL = cctl
+        process.arguments = arguments
+        // `cctl run` resolves relative paths (kernel, bin/) against the cwd.
+        process.currentDirectoryURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        process.standardInput = child.handle
+        process.standardOutput = child.handle
+        process.standardError = child.handle
+
+        try process.run()
+        // Drop our copy of the child fd. While any process here holds it open
+        // the parent side never reports EOF and the drain below never returns.
+        try child.close()
+
+        // Drain before waiting: the pty buffer is far smaller than a pipe's, so
+        // a chatty container blocks quickly.
+        var data = Data()
+        var buf = [UInt8](repeating: 0, count: 4096)
+        let parentFD = parent.handle.fileDescriptor
+        while true {
+            let n = read(parentFD, &buf, buf.count)
+            if n > 0 {
+                data.append(contentsOf: buf[0..<n])
+                continue
+            }
+            // n == 0 is EOF. n < 0 with EIO is how Darwin reports "last child
+            // fd closed" on a pty parent, which is EOF for us too. Retry EINTR.
+            if n < 0 && errno == EINTR {
+                continue
+            }
+            break
+        }
+        process.waitUntilExit()
+        try? parent.close()
+
+        // The pty applies ONLCR until cctl switches it to raw mode, so the
+        // output is a mix of "\r\n" and "\n". Normalize for callers' matching.
+        let output = (String(data: data, encoding: .utf8) ?? "")
+            .replacingOccurrences(of: "\r\n", with: "\n")
+        return (output, process.terminationStatus)
     }
 
     func testContainerNBDMount() async throws {
@@ -944,6 +1002,178 @@ extension IntegrationSuite {
         guard readerOut.contains("tmpfs /shared-tmpfs tmpfs") else {
             throw IntegrationError.assert(msg: "reader mount /shared-tmpfs is not backed by tmpfs: \(readerOut)")
         }
+    }
+
+    /// `cctl run --block` in filesystem mode: the ext4 on the NBD export is
+    /// mounted at dst, and a write from the container lands on the backing file.
+    func testCctlBlockNBDMount() async throws {
+        let id = "test-cctl-block-nbd-mount"
+        let (server, diskURL) = try createNBDServer(testID: id, name: "cctl-vol")
+        defer { server.stop() }
+
+        let (output, exitCode) = try runCctl(arguments: [
+            "run",
+            "--kernel", self.kernel,
+            "--id", id,
+            "--block", "src=\(server.url),dst=/data,fmt=ext4",
+            "/bin/sh", "-c",
+            "grep /data /proc/mounts; printf 'cctl-block-works' > /data/hello.txt",
+        ])
+
+        guard exitCode == 0 else {
+            throw IntegrationError.assert(msg: "cctl run exited with \(exitCode): \(output)")
+        }
+
+        // The mount must be backed by a virtio block device, not a virtiofs share.
+        try assertVirtioBlockMount(output, path: "/data")
+
+        // Read the file back off the NBD backing file to prove the write
+        // traversed guest -> virtio-blk -> NBD -> host.
+        let content = try readFileFromDiskImage(diskURL, path: "/hello.txt")
+        guard content == "cctl-block-works" else {
+            throw IntegrationError.assert(msg: "NBD backing file: expected 'cctl-block-works', got '\(content)'")
+        }
+    }
+
+    /// `cctl run --block ...,raw`: the device node is bind mounted rather than
+    /// mounted as a filesystem, so an unformatted export is usable directly.
+    func testCctlBlockNBDRaw() async throws {
+        let id = "test-cctl-block-nbd-raw"
+
+        // No filesystem — a bare sparse file, to prove `raw` never reads a superblock.
+        let diskURL = Self.testDir.appending(component: "\(id)-raw.img")
+        try? FileManager.default.removeItem(at: diskURL)
+        FileManager.default.createFile(atPath: diskURL.path, contents: nil)
+        let fh = try FileHandle(forWritingTo: diskURL)
+        try fh.truncate(atOffset: 64.mib())
+        try fh.close()
+
+        let shortID = String(id.hashValue, radix: 36, uppercase: false)
+        let socketPath = "/tmp/nbd-\(shortID)-cctl-raw.sock"
+        let server = try NBDServer(filePath: diskURL.path, socketPath: socketPath)
+        defer { server.stop() }
+
+        let (output, exitCode) = try runCctl(arguments: [
+            "run",
+            "--kernel", self.kernel,
+            "--id", id,
+            "--block", "src=\(server.url),dst=/dev/my-disk,raw",
+            "/bin/sh", "-c",
+            "test -b /dev/my-disk && printf 'raw-via-cctl' | dd of=/dev/my-disk bs=512 count=1 conv=sync 2>/dev/null && dd if=/dev/my-disk bs=1 count=12 2>/dev/null",
+        ])
+
+        guard exitCode == 0 else {
+            throw IntegrationError.assert(msg: "cctl run exited with \(exitCode): \(output)")
+        }
+
+        guard output.contains("raw-via-cctl") else {
+            throw IntegrationError.assert(msg: "expected 'raw-via-cctl' in output, got '\(output)'")
+        }
+    }
+
+    /// A malformed `--block` value must fail as a usage error before any VM boots.
+    func testCctlBlockRejectsInvalidSpec() async throws {
+        let (output, exitCode) = try runCctl(arguments: [
+            "run",
+            "--kernel", self.kernel,
+            "--id", "test-cctl-block-invalid",
+            "--block", "dst=/data",
+            "/bin/true",
+        ])
+
+        guard exitCode != 0 else {
+            throw IntegrationError.assert(msg: "expected non-zero exit for malformed --block, got 0: \(output)")
+        }
+        guard output.contains("requires src=") else {
+            throw IntegrationError.assert(msg: "expected a src= usage error, got: \(output)")
+        }
+    }
+
+    /// Format an unformatted NBD export from inside the container, then prove
+    /// the filesystem survives the container exiting.
+    ///
+    /// Two sequential `cctl run` invocations against one long-lived NBD
+    /// server, each a separate VM:
+    ///   1. assert the export has no filesystem, then `mkfs` it
+    ///   2. fresh container — read the same filesystem UUID back
+    ///
+    /// Uses `raw` mode (a bind mounted device node) rather than a filesystem
+    /// mount
+    func testCctlBlockNBDFormatAndPersist() async throws {
+        let id = "test-cctl-block-nbd-format-persist"
+
+        // A bare sparse file — deliberately NOT formatted by the host, so the
+        // filesystem observed in run 2 can only have come from run 1.
+        let diskURL = Self.testDir.appending(component: "\(id).img")
+        try? FileManager.default.removeItem(at: diskURL)
+        FileManager.default.createFile(atPath: diskURL.path, contents: nil)
+        let fh = try FileHandle(forWritingTo: diskURL)
+        try fh.truncate(atOffset: 64.mib())
+        try fh.close()
+
+        let shortID = String(id.hashValue, radix: 36, uppercase: false)
+        let socketPath = "/tmp/nbd-\(shortID)-persist.sock"
+        // One server for all runs: each container reconnects to the same export.
+        let server = try NBDServer(filePath: diskURL.path, socketPath: socketPath)
+        defer { server.stop() }
+
+        let blockSpec = "src=\(server.url),dst=/dev/vol,raw"
+
+        // Run 1: verify unformatted, then format.
+        let (out1, code1) = try runCctl(arguments: [
+            "run", "--kernel", self.kernel, "--id", "\(id)-1",
+            "--block", blockSpec,
+            "/bin/sh", "-c",
+            """
+            if [ -n "$(blkid /dev/vol 2>/dev/null)" ]; then echo UNEXPECTED_FS; else echo no-fs-yet; fi
+            mkfs.vfat /dev/vol >/dev/null 2>&1 && echo mkfs-ok || echo mkfs-failed
+            blkid /dev/vol
+            """,
+        ])
+
+        guard code1 == 0 else {
+            throw IntegrationError.assert(msg: "run 1 exited with \(code1): \(out1)")
+        }
+        // The export must have started with no filesystem, or the test proves nothing.
+        // Note: busybox `blkid` exits 0 with empty output on an unformatted
+        // device, so the guest script tests output emptiness, not exit status.
+        guard out1.contains("no-fs-yet"), !out1.contains("UNEXPECTED_FS") else {
+            throw IntegrationError.assert(msg: "run 1: export already had a filesystem: \(out1)")
+        }
+        guard out1.contains("mkfs-ok") else {
+            throw IntegrationError.assert(msg: "run 1: mkfs failed: \(out1)")
+        }
+        guard let uuid = Self.parseBlkidUUID(out1) else {
+            throw IntegrationError.assert(msg: "run 1: no filesystem UUID after mkfs: \(out1)")
+        }
+
+        // Run 2: a brand new VM and container against the same export.
+        let (out2, code2) = try runCctl(arguments: [
+            "run", "--kernel", self.kernel, "--id", "\(id)-2",
+            "--block", blockSpec,
+            "/bin/sh", "-c",
+            "blkid /dev/vol",
+        ])
+
+        guard code2 == 0 else {
+            throw IntegrationError.assert(msg: "run 2 exited with \(code2): \(out2)")
+        }
+        // Same UUID => the very filesystem run 1 created, not a coincidental reformat.
+        guard let uuid2 = Self.parseBlkidUUID(out2), uuid2 == uuid else {
+            throw IntegrationError.assert(msg: "run 2: expected filesystem UUID \(uuid), got: \(out2)")
+        }
+    }
+
+    /// Extract the `UUID="..."` value from `blkid` output, if present.
+    private static func parseBlkidUUID(_ output: String) -> String? {
+        guard let range = output.range(of: "UUID=\"") else {
+            return nil
+        }
+        let rest = output[range.upperBound...]
+        guard let end = rest.firstIndex(of: "\"") else {
+            return nil
+        }
+        return String(rest[..<end])
     }
 }
 #endif

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -621,6 +621,12 @@ struct IntegrationSuite: AsyncParsableCommand {
                 Test("pod filesystem operation", testPodFilesystemOperation),
                 Test("pod shared disk image volume", testPodSharedDiskImageVolume),
                 Test("pod shared tmpfs volume", testPodSharedTmpfsVolume),
+
+                // cctl --block CLI wiring (spawns bin/cctl; skips if unbuilt)
+                Test("cctl block NBD mount", testCctlBlockNBDMount),
+                Test("cctl block NBD raw", testCctlBlockNBDRaw),
+                Test("cctl block NBD format and persist", testCctlBlockNBDFormatAndPersist),
+                Test("cctl block rejects invalid spec", testCctlBlockRejectsInvalidSpec),
             ] + macOS26Tests()
         let tests: [Test] = crossPlatformTests + macOSOnlyTests
         #else

--- a/Sources/cctl/RunCommand.swift
+++ b/Sources/cctl/RunCommand.swift
@@ -51,8 +51,34 @@ extension Application {
         @Option(name: .customLong("mount"), help: "Directory to share into the container (Example: /foo:/bar)")
         var mounts: [String] = []
 
+        @Option(
+            name: .customLong("block"),
+            help: """
+                Block device to attach, as comma separated fields \
+                (Example: src=nbd://127.0.0.1:10809,dst=/data,fmt=ext4). \
+                src= is a disk-image path or NBD URL, dst= the guest mount point. \
+                Optional: fmt=<type> (default ext4), timeout=<seconds>, ro, \
+                raw (bind mount the device node instead of a filesystem). \
+                The source must already be formatted.
+                """,
+            transform: Containerization.Mount.parseBlockArgument
+        )
+        var blocks: [Containerization.Mount] = []
+
         @Option(name: .customLong("ns"), help: "Nameserver addresses")
         var nameservers: [String] = []
+
+        @Option(
+            name: .customLong("cap-add"),
+            help: """
+                Linux capability to grant the container process, repeatable \
+                (Example: --cap-add CAP_SYS_ADMIN, or --cap-add sys_admin). \
+                Added on top of the default OCI capability set. Needed by \
+                tools that issue privileged ioctls, e.g. mkfs.xfs
+                """,
+            transform: { try CapabilityName(rawValue: $0) }
+        )
+        var capAdd: [CapabilityName] = []
 
         @Option(name: .long, help: "Path to OCI runtime to use for spawning the container")
         var ociRuntimePath: String?
@@ -157,6 +183,20 @@ extension Application {
                     config.mounts = LinuxContainer.defaultOCIMounts()
                 }
 
+                // Appended after the OCI reset above, which replaces
+                // config.mounts wholesale.
+                config.mounts.append(contentsOf: self.blocks)
+
+                if !self.capAdd.isEmpty {
+                    var caps = LinuxCapabilities.defaultOCICapabilities
+                    for cap in self.capAdd {
+                        caps.bounding.append(cap)
+                        caps.effective.append(cap)
+                        caps.permitted.append(cap)
+                    }
+                    config.process.capabilities = caps
+                }
+
                 config.useInit = self.`init`
             }
 
@@ -170,17 +210,31 @@ extension Application {
             // Resize the containers pty to the current terminal window.
             try? await container.resize(to: try current.size)
 
-            try await withThrowingTaskGroup(of: Void.self) { group in
+            let exit = try await withThrowingTaskGroup(
+                of: Void.self,
+                returning: ExitStatus.self
+            ) { group in
                 group.addTask {
                     for await _ in sigwinchStream.signals {
                         try await container.resize(to: try current.size)
                     }
                 }
 
-                try await container.wait()
+                let result = try await container.wait()
                 group.cancelAll()
 
                 try await container.stop()
+                return result
+            }
+
+            // Surface the workload's exit code, as the Linux path below does.
+            // Without this `cctl run` always succeeds and callers cannot tell a
+            // failed container from a successful one.
+            if exit.exitCode != 0 {
+                // Reset the terminal before exiting: ExitCode unwinds past the
+                // `defer` that would otherwise restore it.
+                current.tryReset()
+                throw ExitCode(exit.exitCode)
             }
         }
 
@@ -227,6 +281,21 @@ extension Application {
 
         @Option(name: .customLong("mount"), help: "Directory to share into the container (Example: /foo:/bar)")
         var mounts: [String] = []
+
+        @Option(
+            name: .customLong("block"),
+            help: """
+                Block device to attach, as comma separated fields \
+                (Example: src=/tmp/disk.ext4,dst=/data,fmt=ext4). \
+                src= is a disk-image path, dst= the guest mount point. \
+                Optional: fmt=<type> (default ext4), ro, \
+                raw (bind mount the device node instead of a filesystem). \
+                The source must already be formatted. NBD URLs are macOS-only; \
+                cloud-hypervisor treats src= as a file path.
+                """,
+            transform: Containerization.Mount.parseBlockArgument
+        )
+        var blocks: [Containerization.Mount] = []
 
         @Option(name: .long, help: "Path to OCI runtime to use for spawning the container")
         var ociRuntimePath: String?
@@ -287,6 +356,19 @@ extension Application {
 
         @Option(name: .customLong("ns"), help: "Nameserver addresses (default: read host /etc/resolv.conf)")
         var nameservers: [String] = []
+
+        @Option(
+            name: .customLong("cap-add"),
+            help: """
+                Linux capability to grant the container process, repeatable \
+                (Example: --cap-add CAP_SYS_ADMIN, or --cap-add sys_admin). \
+                Added on top of the default OCI capability set. Needed by \
+                tools that issue privileged ioctls — mkfs.xfs, for instance, \
+                calls BLKBSZSET and fails without CAP_SYS_ADMIN.
+                """,
+            transform: { try CapabilityName(rawValue: $0) }
+        )
+        var capAdd: [CapabilityName] = []
 
         @Option(
             name: .customLong("ch-binary"),
@@ -444,6 +526,8 @@ extension Application {
             let networkInterfaces = interfaces
             let useInit = self.`init`
             let extraMounts = self.mounts
+            let extraBlocks = self.blocks
+            let extraCaps = self.capAdd
             let runtimePath = self.ociRuntimePath
             let dns = dnsConfig
             let hosts = hostsConfig
@@ -478,6 +562,20 @@ extension Application {
                 if let runtimePath {
                     config.ociRuntimePath = runtimePath
                     config.mounts = LinuxContainer.defaultOCIMounts()
+                }
+
+                // Appended after the OCI reset above, which replaces
+                // config.mounts wholesale.
+                config.mounts.append(contentsOf: extraBlocks)
+
+                if !extraCaps.isEmpty {
+                    var caps = LinuxCapabilities.defaultOCICapabilities
+                    for cap in extraCaps {
+                        caps.bounding.append(cap)
+                        caps.effective.append(cap)
+                        caps.permitted.append(cap)
+                    }
+                    config.process.capabilities = caps
                 }
             }
 

--- a/Sources/cctl/cctl+Utils.swift
+++ b/Sources/cctl/cctl+Utils.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ArgumentParser
 import Containerization
 import ContainerizationError
 import ContainerizationOCI
@@ -43,6 +44,83 @@ extension Application {
             parsedLabels[key] = val
         }
         return parsedLabels
+    }
+}
+
+extension Containerization.Mount {
+    /// `transform` for `cctl run --block`: parse a block-device specification
+    /// into a virtio-block `Mount`.
+    ///
+    /// The value is a comma separated field list rather than the colon
+    /// separated `host:guest` form used by `--mount`, because an NBD source is
+    /// a URL which contains a colon (`nbd://host:10809`)
+    ///
+    /// Fields:
+    /// - `src=<path|url>` (required): a host disk-image path, or an NBD URL
+    ///   (`nbd://`, `nbds://`, `nbd+unix://`, `nbds+unix://`). NBD sources are
+    ///   attachable on Apple Silicon only
+    /// - `dst=<path>` (required): where the device is mounted in the container.
+    /// - `fmt=<type>`: filesystem passed to `mount(2)` in the guest, default
+    ///   `ext4`. Ignored when `raw` is set. It must already hold this filesystem
+    ///   or the guest mount fails.
+    /// - `timeout=<seconds>`: NBD connection timeout
+    /// - `ro`: attach and mount read-only.
+    /// - `raw`: bind mount the block device node itself rather than mounting a
+    ///   filesystem from it, exposing the raw device to the workload.
+    static func parseBlockArgument(_ spec: String) throws -> Containerization.Mount {
+        var source: String?
+        var destination: String?
+        var format = "ext4"
+        var readOnly = false
+        var raw = false
+        var runtimeOptions: [String] = []
+
+        for field in spec.split(separator: ",", omittingEmptySubsequences: true) {
+            let parts = field.split(separator: "=", maxSplits: 1)
+            let key = String(parts[0])
+            let value = parts.count == 2 ? String(parts[1]) : nil
+
+            switch (key, value) {
+            case ("src", .some(let value)):
+                source = value
+            case ("dst", .some(let value)):
+                destination = value
+            case ("fmt", .some(let value)):
+                format = value
+            case ("timeout", .some(let value)):
+                guard Double(value) != nil else {
+                    throw ValidationError("--block timeout must be a number of seconds, got \"\(value)\"")
+                }
+                runtimeOptions.append("vzTimeout=\(value)")
+            case ("ro", .none):
+                readOnly = true
+            case ("raw", .none):
+                raw = true
+            default:
+                throw ValidationError("unknown --block field \"\(field)\" in \"\(spec)\"")
+            }
+        }
+
+        guard let source, !source.isEmpty else {
+            throw ValidationError("--block requires src=<path|url>, got \"\(spec)\"")
+        }
+        guard let destination, !destination.isEmpty else {
+            throw ValidationError("--block requires dst=<path>, got \"\(spec)\"")
+        }
+
+        // A raw attachment bind mounts the device node, so file system type is meaningless
+        var options: [String] = raw ? ["bind"] : []
+        if readOnly {
+            options.append("ro")
+        }
+
+        return .block(
+            format: raw ? "none" : format,
+            source: source,
+            destination: destination,
+            options: options,
+            runtimeOptions: runtimeOptions
+        )
     }
 }
 

--- a/Tests/cctlTests/BlockArgumentTests.swift
+++ b/Tests/cctlTests/BlockArgumentTests.swift
@@ -1,0 +1,150 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Containerization
+import Foundation
+import Testing
+
+@testable import cctl
+
+@Suite("cctl run --block argument parsing")
+struct BlockArgumentTests {
+
+    @Test func nbdSourcePreservesURLColons() throws {
+        let mount = try Containerization.Mount.parseBlockArgument(
+            "src=nbd://127.0.0.1:10809,dst=/data,fmt=ext4"
+        )
+
+        #expect(mount.source == "nbd://127.0.0.1:10809")
+        #expect(mount.destination == "/data")
+        #expect(mount.type == "ext4")
+        #expect(mount.isBlock)
+        #expect(mount.options.isEmpty)
+    }
+
+    @Test func nbdUnixSocketURLSurvivesParsing() throws {
+        let mount = try Containerization.Mount.parseBlockArgument(
+            "src=nbd+unix:///?socket=/tmp/nbd.sock,dst=/data"
+        )
+
+        #expect(mount.source == "nbd+unix:///?socket=/tmp/nbd.sock")
+        #expect(mount.destination == "/data")
+    }
+
+    @Test func formatDefaultsToExt4() throws {
+        let mount = try Containerization.Mount.parseBlockArgument("src=/tmp/disk.ext4,dst=/mnt")
+
+        #expect(mount.type == "ext4")
+    }
+
+    @Test func formatIsPassedThroughVerbatim() throws {
+        let mount = try Containerization.Mount.parseBlockArgument("src=/tmp/disk.img,dst=/mnt,fmt=xfs")
+
+        #expect(mount.type == "xfs")
+    }
+
+    @Test func readOnlySetsMountOption() throws {
+        let mount = try Containerization.Mount.parseBlockArgument("src=/tmp/disk.ext4,dst=/mnt,ro")
+
+        #expect(mount.options == ["ro"])
+    }
+
+    @Test func rawUsesBindMountAndDiscardsFormat() throws {
+        // A raw attachment bind mounts the device node, so no filesystem type
+        // is interpreted even when fmt= is supplied.
+        let mount = try Containerization.Mount.parseBlockArgument(
+            "src=nbd://host:10809,dst=/dev/my-disk,fmt=ext4,raw"
+        )
+
+        #expect(mount.type == "none")
+        #expect(mount.options == ["bind"])
+        #expect(mount.isBlock)
+    }
+
+    @Test func rawReadOnlyEmitsBothOptions() throws {
+        // MS_RDONLY is ignored on the initial bind, so ContainerizationOS
+        // needs both options present to trigger its remount pass.
+        let mount = try Containerization.Mount.parseBlockArgument("src=/tmp/disk.img,dst=/dev/d,raw,ro")
+
+        #expect(mount.options == ["bind", "ro"])
+    }
+
+    @Test func timeoutBecomesVZRuntimeOption() throws {
+        let mount = try Containerization.Mount.parseBlockArgument(
+            "src=nbd://host:10809,dst=/data,timeout=30"
+        )
+
+        if case .virtioblk(let opts) = mount.runtimeOptions {
+            #expect(opts == ["vzTimeout=30"])
+        } else {
+            Issue.record("Expected virtioblk runtime options")
+        }
+    }
+
+    @Test func noTimeoutLeavesRuntimeOptionsEmpty() throws {
+        let mount = try Containerization.Mount.parseBlockArgument("src=/tmp/disk.ext4,dst=/mnt")
+
+        if case .virtioblk(let opts) = mount.runtimeOptions {
+            #expect(opts.isEmpty)
+        } else {
+            Issue.record("Expected virtioblk runtime options")
+        }
+    }
+
+    @Test func missingSourceThrows() {
+        #expect(throws: (any Error).self) {
+            try Containerization.Mount.parseBlockArgument("dst=/data")
+        }
+    }
+
+    @Test func missingDestinationThrows() {
+        #expect(throws: (any Error).self) {
+            try Containerization.Mount.parseBlockArgument("src=/tmp/disk.ext4")
+        }
+    }
+
+    @Test func emptySourceValueThrows() {
+        #expect(throws: (any Error).self) {
+            try Containerization.Mount.parseBlockArgument("src=,dst=/data")
+        }
+    }
+
+    @Test func unknownFieldThrows() {
+        #expect(throws: (any Error).self) {
+            try Containerization.Mount.parseBlockArgument("src=/tmp/d.img,dst=/mnt,bogus=1")
+        }
+    }
+
+    @Test func nonNumericTimeoutThrows() {
+        #expect(throws: (any Error).self) {
+            try Containerization.Mount.parseBlockArgument("src=/tmp/d.img,dst=/mnt,timeout=abc")
+        }
+    }
+
+    @Test func valuelessFieldRequiringValueThrows() {
+        // `src` without `=value` is a flag-shaped field and must not silently
+        // parse as an empty source.
+        #expect(throws: (any Error).self) {
+            try Containerization.Mount.parseBlockArgument("src,dst=/mnt")
+        }
+    }
+
+    @Test func flagFieldWithValueThrows() {
+        #expect(throws: (any Error).self) {
+            try Containerization.Mount.parseBlockArgument("src=/tmp/d.img,dst=/mnt,ro=true")
+        }
+    }
+}


### PR DESCRIPTION
This enables cctl to handle NBD mounts for formatted and unformatted NBD mounts into Linux containers.