### PR TITLE
fix(relay): apply host Unix socket permissions

### DIFF
--- a/Sources/Containerization/UnixSocketRelay.swift
+++ b/Sources/Containerization/UnixSocketRelay.swift
@@ -90,13 +90,7 @@ extension UnixSocketRelay {
 
     private func setupHostVsockDial() async throws {
         let hostConn = configuration.destination
-
-        let socketType = try UnixType(
-            path: hostConn.path,
-            unlinkExisting: true
-        )
-        let hostSocket = try Socket(type: socketType)
-        try hostSocket.listen()
+        let hostSocket = try Self.makeHostListener(configuration)
 
         log?.info(
             "listening on host UDS",
@@ -121,6 +115,26 @@ extension UnixSocketRelay {
                 }
                 try? FileManager.default.removeItem(at: hostConn)
             }
+        }
+    }
+
+    package static func makeHostListener(
+        _ configuration: UnixSocketConfiguration
+    ) throws -> Socket {
+        let socketType = try UnixType(
+            path: configuration.destination.path,
+            perms: configuration.permissions.map {
+                mode_t($0.rawValue)
+            },
+            unlinkExisting: true
+        )
+        let socket = try Socket(type: socketType)
+        do {
+            try socket.listen()
+            return socket
+        } catch {
+            try? socket.close()
+            throw error
         }
     }
 

--- a/Tests/ContainerizationTests/UnixSocketRelayTests.swift
+++ b/Tests/ContainerizationTests/UnixSocketRelayTests.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import Containerization
+
+@Suite
+struct UnixSocketRelayTests {
+    @Test
+    func outOfRelayAppliesRequestedHostSocketPermissions() throws {
+        let root = URL(fileURLWithPath: "/tmp").appendingPathComponent(
+            "containerization-relay-\(UUID())",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        let socketPath = root.appendingPathComponent("service.sock")
+        let configuration = UnixSocketConfiguration(
+            source: URL(fileURLWithPath: "/run/service.sock"),
+            destination: socketPath,
+            permissions: .init(rawValue: 0o600),
+            direction: .outOf
+        )
+
+        let listener = try UnixSocketRelay.makeHostListener(configuration)
+        defer { try? listener.close() }
+        let permissions = try #require(
+            FileManager.default.attributesOfItem(atPath: socketPath.path)[
+                .posixPermissions
+            ] as? NSNumber
+        )
+        #expect(permissions.uint16Value == 0o600)
+    }
+}


### PR DESCRIPTION
## Summary

Apply `UnixSocketConfiguration.permissions` when an `.outOf` `UnixSocketRelay` creates its host-side listener.

The `.into` path already forwards the configured mode to `UnixType`, but `.outOf` omitted it and therefore used the process-default socket mode. A caller requesting a private endpoint such as `0600` could receive broader permissions than requested.

Extract the host-listener construction into a package-visible helper so the filesystem contract can be tested without a VM, pass the optional mode through, and close the new socket if `listen()` fails.

## Testing

`swift test --filter UnixSocketRelayTests`

Result: 1 focused regression passed, verifying that an `.outOf` relay configured with `0600` creates a host socket with mode `0600`.

## Compatibility

Callers that omit `permissions` keep the existing default. Callers that provide a mode now receive the documented behavior consistently in both relay directions.
