### PR TITLE
Improve security across containerization

### DIFF
--- a/Sources/CShim/include/openat2.h
+++ b/Sources/CShim/include/openat2.h
@@ -23,6 +23,15 @@
 #define RESOLVE_IN_ROOT 0x10
 #endif
 
+#ifndef RESOLVE_NO_MAGICLINKS
+#define RESOLVE_NO_MAGICLINKS 0x02
+#endif
+
+/* O_PATH is Linux-only and gated behind __USE_GNU in glibc's <fcntl.h>, so the
+ * Swift libc overlays do not reliably surface it. Prefixed to avoid colliding
+ * with a platform O_PATH (musl defines one unconditionally). */
+#define CZ_O_PATH 010000000
+
 struct cz_open_how {
   unsigned long long flags;
   unsigned long long mode;

--- a/Sources/Containerization/LinuxContainer.swift
+++ b/Sources/Containerization/LinuxContainer.swift
@@ -1197,12 +1197,13 @@ extension LinuxContainer {
             }
             let isArchive = isDirectory.boolValue
 
-            let guestPath: URL = try await state.vm.withAgent { agent in
+            let root = self.root
+            let destinationPath: String = try await state.vm.withAgent { agent in
                 guard let vminitd = agent as? Vminitd else {
                     throw ContainerizationError(.unsupported, message: "copyIn requires Vminitd agent")
                 }
 
-                return try await self.resolveCopyInGuestPath(
+                return try await self.resolveCopyInDestination(
                     from: source,
                     to: destination,
                     sourceIsDirectory: isArchive,
@@ -1226,7 +1227,8 @@ extension LinuxContainer {
                         }
                         try await vminitd.copy(
                             direction: .copyIn,
-                            guestPath: guestPath,
+                            root: root,
+                            path: destinationPath,
                             vsockPort: port,
                             mode: mode,
                             createParents: createParents,
@@ -1299,17 +1301,19 @@ extension LinuxContainer {
         }
     }
 
-    private func resolveCopyInGuestPath(
+    /// Resolve where a copyIn should land, as a path within the container root
+    /// filesystem. The destination is probed in the guest only to apply
+    /// cp-style semantics (copy into an existing directory); the returned path
+    /// is resolved and confined to the rootfs by the guest when it is written.
+    private func resolveCopyInDestination(
         from source: URL,
         to destination: URL,
         sourceIsDirectory: Bool,
         using vminitd: Vminitd
-    ) async throws -> URL {
-        let guestDestination = URL(filePath: self.root).appending(path: destination.path)
-
+    ) async throws -> String {
         let stat: ContainerizationOS.Stat?
         do {
-            stat = try await vminitd.stat(path: guestDestination)
+            stat = try await vminitd.stat(root: self.root, path: destination.path)
         } catch let error as ContainerizationError where error.code == .notFound {
             stat = nil
         }
@@ -1322,7 +1326,7 @@ extension LinuxContainer {
                     message: "destination directory does not exist: \(destination.path)"
                 )
             }
-            return guestDestination
+            return destination.path
         }
 
         let destinationIsDirectory = (stat.mode & UInt32(S_IFMT)) == UInt32(S_IFDIR)
@@ -1333,10 +1337,10 @@ extension LinuxContainer {
                     message: "cannot copy directory over existing file: \(destination.path)"
                 )
             }
-            return guestDestination
+            return destination.path
         }
 
-        return guestDestination.appendingPathComponent(source.lastPathComponent)
+        return destination.appendingPathComponent(source.lastPathComponent).path
     }
 
     /// Copy a file or directory from the container to the host.
@@ -1358,7 +1362,8 @@ extension LinuxContainer {
                 try FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
             }
 
-            let guestPath = URL(filePath: self.root).appending(path: source.path)
+            let root = self.root
+            let sourcePath = source.path
             let port = self.hostVsockPorts.allocate()
             // Deferred LIFO: listener back first, then the port number.
             defer { self.hostVsockPorts.release(port) }
@@ -1376,7 +1381,8 @@ extension LinuxContainer {
                         }
                         try await vminitd.copy(
                             direction: .copyOut,
-                            guestPath: guestPath,
+                            root: root,
+                            path: sourcePath,
                             vsockPort: port,
                             onMetadata: { meta in
                                 metadataCont.yield(meta)

--- a/Sources/Containerization/SandboxContext/SandboxContext.pb.swift
+++ b/Sources/Containerization/SandboxContext/SandboxContext.pb.swift
@@ -823,7 +823,8 @@ public nonisolated struct Com_Apple_Containerization_Sandbox_V3_CopyRequest: Sen
   /// Direction of the copy operation.
   public var direction: Com_Apple_Containerization_Sandbox_V3_CopyRequest.Direction = .copyIn
 
-  /// Path in the guest (destination for COPY_IN, source for COPY_OUT).
+  /// Path within the guest (destination for COPY_IN, source for COPY_OUT),
+  /// resolved as if `root` were the filesystem root.
   public var path: String = String()
 
   /// File mode for single-file COPY_IN (defaults to 0644 if not set).
@@ -837,6 +838,9 @@ public nonisolated struct Com_Apple_Containerization_Sandbox_V3_CopyRequest: Sen
 
   /// For COPY_IN: indicates the data arriving on vsock is a tar+gzip archive.
   public var isArchive: Bool = false
+
+  /// Absolute path of the target root filesystem in the guest.
+  public var root: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -946,7 +950,11 @@ public nonisolated struct Com_Apple_Containerization_Sandbox_V3_StatRequest: Sen
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  /// Path within the guest, resolved as if `root` were the filesystem root.
   public var path: String = String()
+
+  /// Absolute path of the target root filesystem in the guest.
+  public var root: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -3022,7 +3030,7 @@ nonisolated extension Com_Apple_Containerization_Sandbox_V3_WriteFileResponse: S
 
 nonisolated extension Com_Apple_Containerization_Sandbox_V3_CopyRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CopyRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}direction\0\u{1}path\0\u{1}mode\0\u{3}create_parents\0\u{3}vsock_port\0\u{3}is_archive\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}direction\0\u{1}path\0\u{1}mode\0\u{3}create_parents\0\u{3}vsock_port\0\u{3}is_archive\0\u{1}root\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3036,6 +3044,7 @@ nonisolated extension Com_Apple_Containerization_Sandbox_V3_CopyRequest: SwiftPr
       case 4: try { try decoder.decodeSingularBoolField(value: &self.createParents) }()
       case 5: try { try decoder.decodeSingularUInt32Field(value: &self.vsockPort) }()
       case 6: try { try decoder.decodeSingularBoolField(value: &self.isArchive) }()
+      case 7: try { try decoder.decodeSingularStringField(value: &self.root) }()
       default: break
       }
     }
@@ -3060,6 +3069,9 @@ nonisolated extension Com_Apple_Containerization_Sandbox_V3_CopyRequest: SwiftPr
     if self.isArchive != false {
       try visitor.visitSingularBoolField(value: self.isArchive, fieldNumber: 6)
     }
+    if !self.root.isEmpty {
+      try visitor.visitSingularStringField(value: self.root, fieldNumber: 7)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -3070,6 +3082,7 @@ nonisolated extension Com_Apple_Containerization_Sandbox_V3_CopyRequest: SwiftPr
     if lhs.createParents != rhs.createParents {return false}
     if lhs.vsockPort != rhs.vsockPort {return false}
     if lhs.isArchive != rhs.isArchive {return false}
+    if lhs.root != rhs.root {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3130,7 +3143,7 @@ nonisolated extension Com_Apple_Containerization_Sandbox_V3_CopyResponse.Status:
 
 nonisolated extension Com_Apple_Containerization_Sandbox_V3_StatRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StatRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}root\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3139,6 +3152,7 @@ nonisolated extension Com_Apple_Containerization_Sandbox_V3_StatRequest: SwiftPr
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.path) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.root) }()
       default: break
       }
     }
@@ -3148,11 +3162,15 @@ nonisolated extension Com_Apple_Containerization_Sandbox_V3_StatRequest: SwiftPr
     if !self.path.isEmpty {
       try visitor.visitSingularStringField(value: self.path, fieldNumber: 1)
     }
+    if !self.root.isEmpty {
+      try visitor.visitSingularStringField(value: self.root, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Com_Apple_Containerization_Sandbox_V3_StatRequest, rhs: Com_Apple_Containerization_Sandbox_V3_StatRequest) -> Bool {
     if lhs.path != rhs.path {return false}
+    if lhs.root != rhs.root {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Containerization/SandboxContext/SandboxContext.proto
+++ b/Sources/Containerization/SandboxContext/SandboxContext.proto
@@ -242,7 +242,8 @@ message CopyRequest {
   }
   // Direction of the copy operation.
   Direction direction = 1;
-  // Path in the guest (destination for COPY_IN, source for COPY_OUT).
+  // Path within the guest (destination for COPY_IN, source for COPY_OUT),
+  // resolved as if `root` were the filesystem root.
   string path = 2;
   // File mode for single-file COPY_IN (defaults to 0644 if not set).
   uint32 mode = 3;
@@ -252,6 +253,8 @@ message CopyRequest {
   uint32 vsock_port = 5;
   // For COPY_IN: indicates the data arriving on vsock is a tar+gzip archive.
   bool is_archive = 6;
+  // Absolute path of the target root filesystem in the guest.
+  string root = 7;
 }
 
 message CopyResponse {
@@ -271,7 +274,12 @@ message CopyResponse {
   string error = 4;
 }
 
-message StatRequest { string path = 1; }
+message StatRequest {
+  // Path within the guest, resolved as if `root` were the filesystem root.
+  string path = 1;
+  // Absolute path of the target root filesystem in the guest.
+  string root = 2;
+}
 
 message Stat {
   uint64 dev = 1;   // st_dev:     ID of device containing file

--- a/Sources/Containerization/Vminitd.swift
+++ b/Sources/Containerization/Vminitd.swift
@@ -503,19 +503,22 @@ extension Vminitd {
         public let totalSize: UInt64
     }
 
-    /// Stat a path in the guest filesystem and return its metadata.
+    /// Stat a path in the guest filesystem and return its metadata. `path` is
+    /// resolved by the guest as if `root` were the filesystem root and confined to it.
     public func stat(
-        path: URL
+        root: String,
+        path: String
     ) async throws -> ContainerizationOS.Stat {
         let request = Com_Apple_Containerization_Sandbox_V3_StatRequest.with {
-            $0.path = path.path
+            $0.root = root
+            $0.path = path
         }
 
         let response: Com_Apple_Containerization_Sandbox_V3_StatResponse
         do {
             response = try await client.stat(request)
         } catch let error as RPCError where error.code == .notFound {
-            throw ContainerizationError(.notFound, message: "stat: path not found '\(path.path)'", cause: error)
+            throw ContainerizationError(.notFound, message: "stat: path not found '\(path)'", cause: error)
         }
         guard response.error.isEmpty else {
             throw ContainerizationError(.internalError, message: "stat: \(response.error)")
@@ -548,7 +551,8 @@ extension Vminitd {
     /// For COPY_IN, `onMetadata` is not called.
     public func copy(
         direction: Com_Apple_Containerization_Sandbox_V3_CopyRequest.Direction,
-        guestPath: URL,
+        root: String,
+        path: String,
         vsockPort: UInt32,
         mode: UInt32 = 0,
         createParents: Bool = false,
@@ -557,7 +561,8 @@ extension Vminitd {
     ) async throws {
         let request = Com_Apple_Containerization_Sandbox_V3_CopyRequest.with {
             $0.direction = direction
-            $0.path = guestPath.path
+            $0.root = root
+            $0.path = path
             $0.mode = mode
             $0.createParents = createParents
             $0.vsockPort = vsockPort

--- a/Sources/ContainerizationOCI/Client/LocalOCILayoutClient.swift
+++ b/Sources/ContainerizationOCI/Client/LocalOCILayoutClient.swift
@@ -108,13 +108,9 @@ extension LocalOCILayoutClient {
     private static let ociLayoutIndexFileName = "index.json"
 
     package func loadIndexFromOCILayout(directory: URL) throws -> ContainerizationOCI.Index {
-        let fm = FileManager.default
         let decoder = JSONDecoder()
 
         let ociLayoutFile = directory.appendingPathComponent(Self.ociLayoutFileName)
-        guard fm.fileExists(atPath: ociLayoutFile.absolutePath()) else {
-            throw ContainerizationError(.notFound, message: ociLayoutFile.absolutePath())
-        }
         var data = try Self.readControlFile(at: ociLayoutFile)
         let ociLayout = try decoder.decode([String: String].self, from: data)
         guard ociLayout[Self.ociLayoutVersionString] != nil else {
@@ -122,24 +118,40 @@ extension LocalOCILayoutClient {
         }
 
         let indexFile = directory.appendingPathComponent(Self.ociLayoutIndexFileName)
-        guard fm.fileExists(atPath: indexFile.absolutePath()) else {
-            throw ContainerizationError(.notFound, message: indexFile.absolutePath())
-        }
         data = try Self.readControlFile(at: indexFile)
         let index = try decoder.decode(ContainerizationOCI.Index.self, from: data)
         return index
     }
 
-    /// Read a layout control file, refusing an oversized one.
+    /// Read a layout control file.
+    /// File must be a regular file and cannot be larger than `maxDecodedSize`.
     ///
     /// `oci-layout` and `index.json` are read straight out of a caller-supplied
-    /// directory before any digest in them has been looked at, so an unbounded
-    /// read here is a memory-exhaustion primitive reachable from
-    /// `ImageStore.load(from:)`.
+    /// directory before any digest in them has been looked at. Without the
+    /// `O_NOFOLLOW`/regular-file check, a crafted archive could place either name
+    /// as a symlink and without the size cap, an unbounded read here is a
+    /// memory-exhaustion primitive reachable from `ImageStore.load(from:)`.
     private static func readControlFile(at url: URL) throws -> Data {
-        let limit = LocalContent.maxDecodedSize
-        let handle = try FileHandle(forReadingFrom: url)
+        let fd = open(url.path, O_RDONLY | O_NOFOLLOW)
+        guard fd >= 0 else {
+            let errCode = POSIXErrorCode(rawValue: errno) ?? .EINVAL
+            let err = POSIXError(errCode)
+            throw ContainerizationError(.internalError, message: "failed to open \(url.absolutePath())", cause: err)
+        }
+        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
         defer { try? handle.close() }
+
+        var st = stat()
+        guard fstat(fd, &st) == 0 else {
+            let errCode = POSIXErrorCode(rawValue: errno) ?? .EINVAL
+            let err = POSIXError(errCode)
+            throw ContainerizationError(.internalError, message: "failed to stat \(url.absolutePath())", cause: err)
+        }
+        guard (st.st_mode & S_IFMT) == S_IFREG else {
+            throw ContainerizationError(.internalError, message: "refusing to read non-regular file at \(url.absolutePath())")
+        }
+
+        let limit = LocalContent.maxDecodedSize
         let data = try handle.read(upToCount: limit + 1) ?? Data()
         guard data.count <= limit else {
             throw ContainerizationError(

--- a/Sources/ContainerizationOS/Mount/Mount.swift
+++ b/Sources/ContainerizationOS/Mount/Mount.swift
@@ -14,8 +14,6 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import CShim
-
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
@@ -133,21 +131,6 @@ extension Mount {
         try self.mountToTarget(target: realPath, createWithPerms: createWithPerms, targetResolved: true)
     }
 
-    /// Open a path relative to `dirFd` using `openat2(2)` with `RESOLVE_IN_ROOT`.
-    ///
-    /// All symlink resolution is confined to the directory tree beneath `dirFd`.
-    /// Returns the file descriptor on success, or -1 on failure (with errno set).
-    private func openInRoot(dirFd: Int32, path: String, flags: Int32, mode: UInt64 = 0) -> Int32 {
-        path.withCString { cPath in
-            var how = cz_open_how(
-                flags: UInt64(flags),
-                mode: mode,
-                resolve: UInt64(RESOLVE_IN_ROOT)
-            )
-            return CZ_openat2(dirFd, cPath, &how, MemoryLayout<cz_open_how>.size)
-        }
-    }
-
     private func secureResolveInRoot(root: String) throws -> Int32 {
         let rootFd = open(root, O_RDONLY | O_DIRECTORY | O_CLOEXEC)
         guard rootFd >= 0 else {
@@ -179,7 +162,7 @@ extension Mount {
             leafIsFile
             ? (O_RDONLY | O_CLOEXEC)
             : (O_RDONLY | O_DIRECTORY | O_CLOEXEC)
-        let fd = openInRoot(dirFd: rootFd, path: relativePath, flags: openFlags)
+        let fd = RootfsResolver.openInRoot(dirFd: rootFd, path: relativePath, flags: openFlags)
         if fd >= 0 {
             close(rootFd)
             return fd
@@ -223,7 +206,7 @@ extension Mount {
         var firstMissing = 0
         for i in 0..<components.count {
             let subpath = components[0...i].joined(separator: "/")
-            let nextFd = openInRoot(dirFd: rootFd, path: subpath, flags: O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+            let nextFd = RootfsResolver.openInRoot(dirFd: rootFd, path: subpath, flags: O_RDONLY | O_DIRECTORY | O_CLOEXEC)
             if nextFd < 0 {
                 firstMissing = i
                 break

--- a/Sources/ContainerizationOS/RootfsResolver.swift
+++ b/Sources/ContainerizationOS/RootfsResolver.swift
@@ -1,0 +1,140 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+#if os(Linux)
+
+import CShim
+import SystemPackage
+
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Symlink-safe filesystem access confined to a root directory, built on
+/// openat2(2) with RESOLVE_IN_ROOT.
+///
+/// Every component is resolved by the kernel as if the calling process were
+/// chrooted into the directory referenced by the anchoring file descriptor:
+/// absolute symlinks, `..`, and absolute paths are all interpreted relative to
+/// that root, so a resolved path can never escape it. This is the confinement
+/// callers need when acting on a path that originates from an untrusted
+/// container image but must stay within the container's root filesystem.
+///
+/// Requires Linux 5.6+ for openat2(2).
+public enum RootfsResolver {
+    /// `O_PATH`. The Swift libc overlays don't reliably surface it, and callers
+    /// outside `ContainerizationOS` don't depend on `CShim`. Opens a descriptor
+    /// usable only for path operations (`fstat`, reopen via `/proc/self/fd`), so
+    /// it never blocks on a FIFO or device.
+    public static let oPath = Int32(CZ_O_PATH)
+
+    public enum Error: Swift.Error, CustomStringConvertible {
+        case errno(Int32, String)
+
+        public var description: String {
+            switch self {
+            case .errno(let err, let message):
+                return "\(message): \(String(cString: strerror(err)))"
+            }
+        }
+    }
+
+    /// Open path relative to dirFd using openat2(2) with RESOLVE_IN_ROOT.
+    ///
+    /// Symlinks are followed but confined to the tree beneath dirFd; magic
+    /// links (e.g. /proc/*/fd) are rejected. Returns the open file descriptor,
+    /// or -1 with errno set on failure (EINVAL if path contains a NUL).
+    public static func openInRoot(dirFd: Int32, path: String, flags: Int32, mode: UInt64 = 0) -> Int32 {
+        // Avoid withCString truncation on security-sensitive paths.
+        guard !path.utf8.contains(0) else {
+            errno = EINVAL
+            return -1
+        }
+        return path.withCString { cPath in
+            var how = cz_open_how(
+                flags: UInt64(flags),
+                mode: mode,
+                resolve: UInt64(RESOLVE_IN_ROOT | RESOLVE_NO_MAGICLINKS)
+            )
+            return CZ_openat2(dirFd, cPath, &how, MemoryLayout<cz_open_how>.size)
+        }
+    }
+
+    /// Ensure the directory `path` (and any missing parents) exists beneath dirFd,
+    /// confined to it, then run `body` with the descriptor of the leaf directory.
+    /// Components that already exist — including symlinks — are resolved within the
+    /// root; missing components are created. The descriptor passed to `body` is
+    /// valid only for its duration and must not be closed by it.
+    public static func withDirectoryInRoot<T>(
+        dirFd rootFd: Int32, path: String, perms: mode_t = 0o755, _ body: (Int32) throws -> T
+    ) throws -> T {
+        // Avoid C string truncation before the mkdirat/openat component walk.
+        guard !path.utf8.contains(0) else {
+            throw Error.errno(EINVAL, "resolve directory '\(path)' within root, path contains a NUL byte")
+        }
+        // Anchoring at "/" lets lexical normalization clamp ".." at the root and
+        // drop ".", leaving only real-name components for the creation walk.
+        let components = FilePath("/" + path).lexicallyNormalized().components.map(\.string)
+        guard !components.isEmpty else {
+            return try body(rootFd)
+        }
+
+        var currentFd = rootFd
+        defer { if currentFd != rootFd { close(currentFd) } }
+
+        var firstMissing = components.count
+        for i in components.indices {
+            let subpath = components[0...i].joined(separator: "/")
+            let fd = openInRoot(dirFd: rootFd, path: subpath, flags: O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+            if fd < 0 {
+                guard errno == ENOENT else {
+                    throw Error.errno(errno, "resolve '\(subpath)' within root")
+                }
+                firstMissing = i
+                break
+            }
+            if currentFd != rootFd { close(currentFd) }
+            currentFd = fd
+        }
+
+        // Create the missing tail. Each created directory is reopened with
+        // O_NOFOLLOW so a concurrently swapped-in symlink cannot redirect us.
+        for i in firstMissing..<components.count {
+            let component = components[i]
+            if mkdirat(currentFd, component, perms) != 0 && errno != EEXIST {
+                throw Error.errno(errno, "create directory '\(component)'")
+            }
+            let dirFd = openat(currentFd, component, O_RDONLY | O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)
+            guard dirFd >= 0 else {
+                throw Error.errno(errno, "open created directory '\(component)'")
+            }
+            if currentFd != rootFd { close(currentFd) }
+            currentFd = dirFd
+        }
+
+        return try body(currentFd)
+    }
+
+    /// Create the directory `path` (and any missing parents) beneath dirFd,
+    /// confined to it. Succeeds if the directory already exists.
+    public static func createDirectoryInRoot(dirFd rootFd: Int32, path: String, perms: mode_t = 0o755) throws {
+        try withDirectoryInRoot(dirFd: rootFd, path: path, perms: perms) { _ in }
+    }
+}
+
+#endif

--- a/Sources/ContainerizationOS/Socket/UnixType.swift
+++ b/Sources/ContainerizationOS/Socket/UnixType.swift
@@ -66,14 +66,7 @@ public struct UnixType: SocketType, Sendable, CustomStringConvertible {
         let socketName = path
         let nameLength = socketName.utf8.count
 
-        #if os(macOS)
-        // Funnily enough, this isn't limited by sun path on macOS even though
-        // it's stated as so.
-        let lengthLimit = 253
-        #elseif os(Linux)
         let lengthLimit = MemoryLayout.size(ofValue: addr.sun_path)
-        #endif
-
         guard nameLength < lengthLimit else {
             throw Error.nameTooLong(path)
         }

--- a/Sources/Integration/ContainerTests.swift
+++ b/Sources/Integration/ContainerTests.swift
@@ -1864,10 +1864,8 @@ extension IntegrationSuite {
             let vsock = try await container.dialVsock(port: 1024)
             let vminitd = try await Vminitd(connection: vsock, group: Self.eventLoop)
 
-            let root = URL(filePath: container.root)
-
             // --- regular file ---
-            let regularStat = try await vminitd.stat(path: root.appending(path: "tmp/regular-file.txt"))
+            let regularStat = try await vminitd.stat(root: container.root, path: "tmp/regular-file.txt")
             guard (regularStat.mode & UInt32(S_IFMT)) == S_IFREG else {
                 throw IntegrationError.assert(msg: "regular file: expected S_IFREG, got mode 0x\(String(regularStat.mode, radix: 16))")
             }
@@ -1882,7 +1880,7 @@ extension IntegrationSuite {
             }
 
             // --- directory ---
-            let dirStat = try await vminitd.stat(path: root.appending(path: "tmp/test-dir"))
+            let dirStat = try await vminitd.stat(root: container.root, path: "tmp/test-dir")
             guard (dirStat.mode & UInt32(S_IFMT)) == S_IFDIR else {
                 throw IntegrationError.assert(msg: "directory: expected S_IFDIR, got mode 0x\(String(dirStat.mode, radix: 16))")
             }
@@ -1892,8 +1890,8 @@ extension IntegrationSuite {
             }
 
             // --- symlink ---
-            // stat(2) follows symlinks, so the result reflects the target regular file
-            let symlinkStat = try await vminitd.stat(path: root.appending(path: "tmp/test-link"))
+            // stat follows symlinks (confined to the rootfs), so the result reflects the target regular file
+            let symlinkStat = try await vminitd.stat(root: container.root, path: "tmp/test-link")
             guard (symlinkStat.mode & UInt32(S_IFMT)) == S_IFREG else {
                 throw IntegrationError.assert(msg: "symlink (followed): expected S_IFREG, got mode 0x\(String(symlinkStat.mode, radix: 16))")
             }
@@ -1902,7 +1900,7 @@ extension IntegrationSuite {
             }
 
             // --- FIFO ---
-            let fifoStat = try await vminitd.stat(path: root.appending(path: "tmp/test-fifo"))
+            let fifoStat = try await vminitd.stat(root: container.root, path: "tmp/test-fifo")
             guard (fifoStat.mode & UInt32(S_IFMT)) == S_IFIFO else {
                 throw IntegrationError.assert(msg: "FIFO: expected S_IFIFO, got mode 0x\(String(fifoStat.mode, radix: 16))")
             }
@@ -1964,6 +1962,108 @@ extension IntegrationSuite {
             guard output == testContent else {
                 throw IntegrationError.assert(
                     msg: "copied file content mismatch: expected '\(testContent)', got '\(output)'")
+            }
+
+            try await container.kill(.kill)
+            try await container.wait()
+            try await container.stop()
+        } catch {
+            try? await container.stop()
+            throw error
+        }
+    }
+
+    func testCopyInDoesNotEscapeRootfsViaSymlink() async throws {
+        let id = "test-copy-in-symlink-escape"
+
+        let bs = try await bootstrap(id)
+
+        let hostFile = FileManager.default.uniqueTemporaryDirectory(create: true)
+            .appendingPathComponent("payload.txt")
+        try "HACKED".write(to: hostFile, atomically: true, encoding: .utf8)
+
+        let buffer = BufferWriter()
+        let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
+            config.process.arguments = ["sleep", "100"]
+            config.bootLog = bs.bootLog
+        }
+
+        do {
+            try await container.create()
+            try await container.start()
+
+            // Plant a symlink whose absolute target would, resolved unconfined in
+            // vminitd's namespace, escape the container rootfs.
+            let setup = try await container.exec("plant-symlink") { config in
+                config.arguments = ["sh", "-c", "echo -n ORIGINAL > /target && ln -s /target /tmp/escape"]
+            }
+            try await setup.start()
+            guard try await setup.wait().exitCode == 0 else {
+                throw IntegrationError.assert(msg: "failed to plant symlink")
+            }
+            try await setup.delete()
+
+            // Copy through the symlink: the write must land on the container's own
+            // /target (the confined symlink target), not a same-named VM-root file.
+            try await container.copyIn(from: hostFile, to: URL(filePath: "/tmp/escape"))
+
+            let exec = try await container.exec("verify") { config in
+                config.arguments = ["cat", "/target"]
+                config.stdout = buffer
+            }
+            try await exec.start()
+            let status = try await exec.wait()
+            try await exec.delete()
+            guard status.exitCode == 0 else {
+                throw IntegrationError.assert(msg: "cat /target failed with status \(status)")
+            }
+            let got = String(data: buffer.data, encoding: .utf8) ?? ""
+            guard got == "HACKED" else {
+                throw IntegrationError.assert(msg: "copyIn did not stay within the rootfs: /target = '\(got)'")
+            }
+
+            try await container.kill(.kill)
+            try await container.wait()
+            try await container.stop()
+        } catch {
+            try? await container.stop()
+            throw error
+        }
+    }
+
+    func testCopyOutDoesNotEscapeRootfsViaSymlink() async throws {
+        let id = "test-copy-out-symlink-escape"
+
+        let bs = try await bootstrap(id)
+
+        let hostDestination = FileManager.default.uniqueTemporaryDirectory(create: true)
+            .appendingPathComponent("out.txt")
+
+        let container = try LinuxContainer(id, rootfs: bs.rootfs, vmm: bs.vmm) { config in
+            config.process.arguments = ["sleep", "100"]
+            config.bootLog = bs.bootLog
+        }
+
+        do {
+            try await container.create()
+            try await container.start()
+
+            // A symlink whose absolute target resolves, confined, to the container's
+            // own file. copyOut must read that, never a same-named VM-root file.
+            let setup = try await container.exec("plant-symlink") { config in
+                config.arguments = ["sh", "-c", "echo -n CONTAINED > /target && ln -s /target /tmp/leak"]
+            }
+            try await setup.start()
+            guard try await setup.wait().exitCode == 0 else {
+                throw IntegrationError.assert(msg: "failed to plant symlink")
+            }
+            try await setup.delete()
+
+            try await container.copyOut(from: URL(filePath: "/tmp/leak"), to: hostDestination)
+
+            let copied = try String(contentsOf: hostDestination, encoding: .utf8)
+            guard copied == "CONTAINED" else {
+                throw IntegrationError.assert(msg: "copyOut did not stay within the rootfs: got '\(copied)'")
             }
 
             try await container.kill(.kill)

--- a/Sources/Integration/Suite.swift
+++ b/Sources/Integration/Suite.swift
@@ -469,6 +469,8 @@ struct IntegrationSuite: AsyncParsableCommand {
             Test("container copy in file to missing directory fails", testCopyInFileToMissingDirectoryFails),
             Test("container copy in directory over existing file fails", testCopyInDirectoryOverExistingFileFails),
             Test("container copy out", testCopyOut),
+            Test("container copy in does not escape rootfs via symlink", testCopyInDoesNotEscapeRootfsViaSymlink),
+            Test("container copy out does not escape rootfs via symlink", testCopyOutDoesNotEscapeRootfsViaSymlink),
             Test("container copy large file", testCopyLargeFile),
             Test("container copy in directory", testCopyInDirectory),
             Test("container copy out directory", testCopyOutDirectory),

--- a/Tests/ContainerizationOCITests/LocalOCILayoutClientTests.swift
+++ b/Tests/ContainerizationOCITests/LocalOCILayoutClientTests.swift
@@ -147,6 +147,64 @@ struct LocalOCILayoutClientTests {
         }
     }
 
+    @Test func loadIndexFromOCILayoutRejectsSymlinkOCILayout() throws {
+        let root = FileManager.default.uniqueTemporaryDirectory(create: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // A file outside the layout root that the oci-layout symlink points to.
+        let outsideDir = FileManager.default.uniqueTemporaryDirectory(create: true)
+        defer { try? FileManager.default.removeItem(at: outsideDir) }
+        let outsideTarget = outsideDir.appendingPathComponent("outside-\(UUID().uuidString)")
+        try Data("{\"imageLayoutVersion\":\"1.0.0\"}".utf8).write(to: outsideTarget)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("oci-layout"), withDestinationURL: outsideTarget)
+
+        // create a valid regular file for index.json.
+        try Data("{\"schemaVersion\":2,\"manifests\":[]}".utf8)
+            .write(to: root.appendingPathComponent("index.json"))
+
+        let client: LocalOCILayoutClient = try LocalOCILayoutClient(root: root)
+        #expect(throws: (any Error).self) {
+            try client.loadIndexFromOCILayout(directory: root)
+        }
+    }
+
+    @Test func loadIndexFromOCILayoutRejectsSymlinkedIndexFile() throws {
+        let root = FileManager.default.uniqueTemporaryDirectory(create: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // A file outside the layout root that the index.json symlink points to.
+        let outsideDir = FileManager.default.uniqueTemporaryDirectory(create: true)
+        defer { try? FileManager.default.removeItem(at: outsideDir) }
+        let outsideTarget = outsideDir.appendingPathComponent("outside-\(UUID().uuidString)")
+        try Data("{\"schemaVersion\":2,\"manifests\":[]}".utf8).write(to: outsideTarget)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("index.json"), withDestinationURL: outsideTarget)
+
+        // create a valid oci-layout regular file.
+        try Data("{\"imageLayoutVersion\":\"1.0.0\"}".utf8)
+            .write(to: root.appendingPathComponent("oci-layout"))
+
+        let client = try LocalOCILayoutClient(root: root)
+        #expect(throws: (any Error).self) {
+            try client.loadIndexFromOCILayout(directory: root)
+        }
+    }
+
+    @Test func loadIndexFromOCILayoutReadsRegularFiles() throws {
+        let root = FileManager.default.uniqueTemporaryDirectory(create: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let client = try LocalOCILayoutClient(root: root)
+        try Data("{\"imageLayoutVersion\":\"1.0.0\"}".utf8)
+            .write(to: root.appendingPathComponent("oci-layout"))
+        try Data("{\"schemaVersion\":2,\"manifests\":[]}".utf8)
+            .write(to: root.appendingPathComponent("index.json"))
+
+        let index = try client.loadIndexFromOCILayout(directory: root)
+        #expect(index.manifests.isEmpty)
+    }
+
     private func byteBufferGenerator(for data: Data) -> () -> AsyncStream<ByteBuffer> {
         {
             AsyncStream { continuation in

--- a/Tests/ContainerizationOSTests/RootfsResolverTests.swift
+++ b/Tests/ContainerizationOSTests/RootfsResolverTests.swift
@@ -1,0 +1,180 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+// openat2(RESOLVE_IN_ROOT) is Linux-only, so these tests only build and run there.
+#if os(Linux)
+
+import Foundation
+import Testing
+
+@testable import ContainerizationOS
+
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+struct RootfsResolverTests {
+    private func makeTempDirectory() throws -> String {
+        let path = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).path
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        return path
+    }
+
+    private func openRoot(_ path: String) throws -> Int32 {
+        let fd = open(path, O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+        try #require(fd >= 0)
+        return fd
+    }
+
+    private func readAll(_ fd: Int32) -> Data {
+        var data = Data()
+        var buf = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let n = read(fd, &buf, buf.count)
+            if n <= 0 { break }
+            data.append(contentsOf: buf[0..<n])
+        }
+        return data
+    }
+
+    @Test func opensFileWithinRoot() throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        try FileManager.default.createDirectory(atPath: (root as NSString).appendingPathComponent("sub"), withIntermediateDirectories: true)
+        let content = Data("hello".utf8)
+        try content.write(to: URL(fileURLWithPath: (root as NSString).appendingPathComponent("sub/file.txt")))
+
+        let rootFd = try openRoot(root)
+        defer { close(rootFd) }
+
+        let fd = RootfsResolver.openInRoot(dirFd: rootFd, path: "sub/file.txt", flags: O_RDONLY)
+        try #require(fd >= 0)
+        defer { close(fd) }
+        #expect(readAll(fd) == content)
+    }
+
+    @Test func doesNotFollowAbsoluteSymlinkOutsideRoot() throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let outside = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(atPath: outside) }
+
+        let secret = (outside as NSString).appendingPathComponent("secret.txt")
+        try Data("top-secret".utf8).write(to: URL(fileURLWithPath: secret))
+        try FileManager.default.createSymbolicLink(
+            atPath: (root as NSString).appendingPathComponent("escape"),
+            withDestinationPath: secret
+        )
+
+        let rootFd = try openRoot(root)
+        defer { close(rootFd) }
+
+        // Absolute symlink targets are reinterpreted under root, so this should fail with ENOENT.
+        let fd = RootfsResolver.openInRoot(dirFd: rootFd, path: "escape", flags: O_RDONLY)
+        let err = errno
+        if fd >= 0 { close(fd) }
+        #expect(fd == -1, "openInRoot escaped the root via an absolute symlink")
+        #expect(err == ENOENT)
+    }
+
+    @Test func clampsParentTraversalToRoot() throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let content = Data("marker".utf8)
+        try content.write(to: URL(fileURLWithPath: (root as NSString).appendingPathComponent("marker.txt")))
+
+        let rootFd = try openRoot(root)
+        defer { close(rootFd) }
+
+        // ".." is clamped at the root, so this resolves back to <root>/marker.txt.
+        let fd = RootfsResolver.openInRoot(dirFd: rootFd, path: "../../../marker.txt", flags: O_RDONLY)
+        try #require(fd >= 0)
+        defer { close(fd) }
+        #expect(readAll(fd) == content)
+    }
+
+    @Test func createsNestedDirectoriesWithinRoot() throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let rootFd = try openRoot(root)
+        defer { close(rootFd) }
+
+        try RootfsResolver.createDirectoryInRoot(dirFd: rootFd, path: "a/b/c")
+
+        var isDir: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: (root as NSString).appendingPathComponent("a/b/c"), isDirectory: &isDir))
+        #expect(isDir.boolValue)
+    }
+
+    @Test func createDirectoryDoesNotEscapeViaAbsoluteSymlink() throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let outside = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(atPath: outside) }
+
+        try FileManager.default.createSymbolicLink(
+            atPath: (root as NSString).appendingPathComponent("escape"),
+            withDestinationPath: outside
+        )
+
+        let rootFd = try openRoot(root)
+        defer { close(rootFd) }
+
+        // The absolute symlink is confined to a nonexistent in-root path.
+        #expect(throws: RootfsResolver.Error.self) {
+            try RootfsResolver.createDirectoryInRoot(dirFd: rootFd, path: "escape/planted")
+        }
+        #expect(!FileManager.default.fileExists(atPath: (outside as NSString).appendingPathComponent("planted")))
+    }
+
+    @Test func createDirectoryRejectsEmbeddedNul() throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let rootFd = try openRoot(root)
+        defer { close(rootFd) }
+
+        // Reject before mkdirat/openat can truncate this into "new/a".
+        #expect(throws: RootfsResolver.Error.self) {
+            try RootfsResolver.createDirectoryInRoot(dirFd: rootFd, path: "new/a\u{0}b")
+        }
+        #expect(!FileManager.default.fileExists(atPath: (root as NSString).appendingPathComponent("new")))
+    }
+
+    @Test func doesNotTraverseProcMagicLink() throws {
+        // /proc/<pid>/fd/<n> is a magic link; RESOLVE_NO_MAGICLINKS should reject it.
+        let procFd = open("/proc", O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+        try #require(procFd >= 0)
+        defer { close(procFd) }
+        let pid = getpid()
+
+        // Address a descriptor the test owns (procFd) so the entry is guaranteed open.
+        let magic = RootfsResolver.openInRoot(dirFd: procFd, path: "\(pid)/fd/\(procFd)", flags: O_RDONLY)
+        let err = errno
+        if magic >= 0 { close(magic) }
+        #expect(magic == -1, "openInRoot traversed a /proc magic link")
+        #expect(err == ELOOP)
+
+        // Positive control: /proc itself is readable.
+        let regular = RootfsResolver.openInRoot(dirFd: procFd, path: "\(pid)/stat", flags: O_RDONLY)
+        if regular >= 0 { close(regular) }
+        #expect(regular >= 0)
+    }
+}
+
+#endif

--- a/Tests/ContainerizationOSTests/UnixTypeTests.swift
+++ b/Tests/ContainerizationOSTests/UnixTypeTests.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Containerization project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import ContainerizationOS
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+@Suite("UnixType path length tests")
+struct UnixTypeTests {
+    // The real capacity of sockaddr_un.sun_path on this platform (104 on
+    // macOS, 108 on Linux) — derived the same way UnixType.init(path:)
+    // derives its own `lengthLimit`, so this test tracks the real field
+    // size on every platform instead of hardcoding a platform-specific number.
+    private var sunPathCapacity: Int {
+        MemoryLayout.size(ofValue: sockaddr_un().sun_path)
+    }
+
+    @Test("path that leaves room for the NUL terminator is accepted")
+    func acceptsPathWithinCapacity() throws {
+        let path = String(repeating: "a", count: sunPathCapacity - 1)
+        _ = try UnixType(path: path)
+    }
+
+    @Test("path that exactly fills sun_path with no room for a terminator is rejected")
+    func rejectsPathFillingCapacity() {
+        let path = String(repeating: "a", count: sunPathCapacity)
+        #expect(throws: UnixType.Error.self) {
+            _ = try UnixType(path: path)
+        }
+    }
+
+    @Test("path far longer than sun_path's capacity is rejected")
+    func rejectsPathExceedingCapacity() {
+        let path = String(repeating: "a", count: sunPathCapacity + 148)
+        #expect(throws: UnixType.Error.self) {
+            _ = try UnixType(path: path)
+        }
+    }
+}

--- a/vminitd/Sources/VminitdCore/Server+GRPC.swift
+++ b/vminitd/Sources/VminitdCore/Server+GRPC.swift
@@ -377,15 +377,19 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
         log.debug(
             "stat",
             metadata: [
-                "path": "\(request.path)"
+                "root": "\(request.root)",
+                "path": "\(request.path)",
             ]
         )
 
         #if os(Linux)
-        var s = _stat_struct()
-        let result = _stat(request.path, &s)
-        if result == -1 {
-            let error = swiftErrno("stat")
+        let rootFd = try openRootDirectory(request.root)
+        defer { close(rootFd) }
+
+        // O_PATH avoids blocking on FIFOs/devices while preserving confined symlink following.
+        let fd = RootfsResolver.openInRoot(dirFd: rootFd, path: request.path, flags: RootfsResolver.oPath | O_CLOEXEC)
+        if fd == -1 {
+            let error = swiftErrno("openat2")
             if error.code == .ENOENT {
                 throw RPCError(
                     code: .notFound,
@@ -394,6 +398,12 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
                 )
             }
             return .with { $0.error = "\(error)" }
+        }
+        defer { close(fd) }
+
+        var s = _stat_struct()
+        guard fstat(fd, &s) == 0 else {
+            return .with { $0.error = "\(swiftErrno("fstat"))" }
         }
         return .with {
             $0.stat = .with {
@@ -441,6 +451,7 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
             "copy",
             metadata: [
                 "direction": "\(request.direction)",
+                "root": "\(request.root)",
                 "path": "\(path)",
                 "vsockPort": "\(vsockPort)",
                 "isArchive": "\(request.isArchive)",
@@ -472,18 +483,25 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
         }
     }
 
+    private func openRootDirectory(_ root: String) throws -> Int32 {
+        guard !root.isEmpty else {
+            throw RPCError(code: .invalidArgument, message: "missing root filesystem")
+        }
+        let fd = open(root, O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+        guard fd != -1 else {
+            throw RPCError(code: .internalError, message: "failed to open root filesystem '\(root)': \(swiftErrno("open"))")
+        }
+        return fd
+    }
+
     /// Handle a COPY_IN request: connect to host vsock port, read data, write to guest filesystem.
     private func handleCopyIn(
         request: Com_Apple_Containerization_Sandbox_V3_CopyRequest,
         response: GRPCCore.RPCWriter<Com_Apple_Containerization_Sandbox_V3_CopyResponse>
     ) async throws {
+        let root = request.root
         let path = request.path
         let isArchive = request.isArchive
-
-        if request.createParents {
-            let parentDir = URL(fileURLWithPath: path).deletingLastPathComponent()
-            try FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
-        }
 
         // Connect to the host's vsock port for data transfer.
         let vsockType = VsockType(port: request.vsockPort, cid: VsockType.hostCID)
@@ -495,13 +513,20 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
         let rejected: [String] = try await blockingPool.runIfActive { [self] in
             defer { try? sock.close() }
 
+            let rootFd = try openRootDirectory(root)
+            defer { close(rootFd) }
+
             guard isArchive else {
-                let mode = request.mode > 0 ? mode_t(request.mode) : mode_t(0o644)
-                let fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, mode)
+                if request.createParents {
+                    try RootfsResolver.createDirectoryInRoot(dirFd: rootFd, path: FilePath(path).removingLastComponent().string)
+                }
+
+                let mode = request.mode > 0 ? UInt64(request.mode) : 0o644
+                let fd = RootfsResolver.openInRoot(dirFd: rootFd, path: path, flags: O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, mode: mode)
                 guard fd != -1 else {
                     throw RPCError(
                         code: .internalError,
-                        message: "copy: failed to open file '\(path)': \(swiftErrno("open"))"
+                        message: "copy: failed to open file '\(path)': \(swiftErrno("openat2"))"
                     )
                 }
                 defer { close(fd) }
@@ -532,12 +557,13 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
                 }
                 return []
             }
-            let destURL = URL(fileURLWithPath: path)
-            try FileManager.default.createDirectory(at: destURL, withIntermediateDirectories: true)
 
-            let fileHandle = FileHandle(fileDescriptor: sockFd, closeOnDealloc: false)
-            let reader = try ArchiveReader(format: .pax, filter: .gzip, fileHandle: fileHandle)
-            return try reader.extractContents(to: destURL)
+            // /proc/self/fd pins the resolved directory against path swaps during extraction.
+            return try RootfsResolver.withDirectoryInRoot(dirFd: rootFd, path: path) { destFd in
+                let fileHandle = FileHandle(fileDescriptor: sockFd, closeOnDealloc: false)
+                let reader = try ArchiveReader(format: .pax, filter: .gzip, fileHandle: fileHandle)
+                return try reader.extractContents(to: URL(fileURLWithPath: "/proc/self/fd/\(destFd)"))
+            }
         }
 
         if !rejected.isEmpty {
@@ -558,21 +584,33 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
         request: Com_Apple_Containerization_Sandbox_V3_CopyRequest,
         response: GRPCCore.RPCWriter<Com_Apple_Containerization_Sandbox_V3_CopyResponse>
     ) async throws {
+        let root = request.root
         let path = request.path
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) else {
-            throw RPCError(code: .notFound, message: "copy: path not found '\(path)'")
-        }
-        let isArchive = isDirectory.boolValue
 
-        // Determine total size for single files.
-        var totalSize: UInt64 = 0
-        if !isArchive {
-            let attrs = try FileManager.default.attributesOfItem(atPath: path)
-            if let size = attrs[.size] as? UInt64 {
-                totalSize = size
+        // O_PATH avoids blocking on special files before we validate the resolved type.
+        let rootFd = try openRootDirectory(root)
+        defer { close(rootFd) }
+
+        let fd = RootfsResolver.openInRoot(dirFd: rootFd, path: path, flags: RootfsResolver.oPath | O_CLOEXEC)
+        guard fd != -1 else {
+            let error = swiftErrno("openat2")
+            if error.code == .ENOENT {
+                throw RPCError(code: .notFound, message: "copy: path not found '\(path)'", cause: error)
             }
+            throw RPCError(code: .internalError, message: "copy: failed to open '\(path)'", cause: error)
         }
+        defer { close(fd) }
+
+        var s = _stat_struct()
+        guard fstat(fd, &s) == 0 else {
+            throw RPCError(code: .internalError, message: "copy: failed to stat '\(path)': \(swiftErrno("fstat"))")
+        }
+        let fileType = s.st_mode & UInt32(S_IFMT)
+        let isArchive = fileType == UInt32(S_IFDIR)
+        guard isArchive || fileType == UInt32(S_IFREG) else {
+            throw RPCError(code: .invalidArgument, message: "copy: cannot copy out '\(path)': unsupported file type")
+        }
+        let totalSize: UInt64 = isArchive ? 0 : UInt64(s.st_size)
 
         // Send metadata response BEFORE connecting to vsock, so host knows what to expect.
         try await response.write(
@@ -591,18 +629,18 @@ extension Initd: Com_Apple_Containerization_Sandbox_V3_SandboxContext.SimpleServ
             defer { try? sock.close() }
 
             if isArchive {
-                let fileURL = URL(fileURLWithPath: path)
+                // TODO: archiveDirectory is path-based; running containers can still
+                // race directory copyOut. Close this with an fd-relative archive writer.
+                let source = try FileDescriptorOps.getCanonicalPath(FileDescriptor(rawValue: fd)).string
                 let writer = try ArchiveWriter(configuration: .init(format: .pax, filter: .gzip))
                 try writer.open(fileDescriptor: sock.fileDescriptor)
-                try writer.archiveDirectory(fileURL)
+                try writer.archiveDirectory(URL(fileURLWithPath: source))
                 try writer.finishEncoding()
             } else {
-                let srcFd = open(path, O_RDONLY)
+                // Reopen through the pinned fd after confirming this is a regular file.
+                let srcFd = open("/proc/self/fd/\(fd)", O_RDONLY | O_CLOEXEC)
                 guard srcFd != -1 else {
-                    throw RPCError(
-                        code: .internalError,
-                        message: "copy: failed to open '\(path)': \(swiftErrno("open"))"
-                    )
+                    throw RPCError(code: .internalError, message: "copy: failed to open '\(path)': \(swiftErrno("open"))")
                 }
                 defer { close(srcFd) }
 


### PR DESCRIPTION
See commit details for more information about each individual change.

This PR fixes a number of issues:
- Ensure `oci-layout` and `index.json` are regular files before reading them
- Confine vminitd copy/stat path resolution to the container rootfs
- Do not overflow socket `sun_path` on macOS

Note on API surface: `Vminitd.stat` and `Vminitd.copy` take a new `root` parameter, and the guest path moves from `URL` to `String`, so the guest now resolves it under `root` with `openat2(RESOLVE_IN_ROOT)` rather than trusting a path the host joined. `CopyRequest`/`StatRequest` gain a `root` field. `LinuxContainer.copyIn`/`copyOut` are unchanged.