### PR TITLE
Encode os.version and os.features with OCI spec keys

### DIFF
--- a/Sources/ContainerizationOCI/ImageConfig.swift
+++ b/Sources/ContainerizationOCI/ImageConfig.swift
@@ -124,6 +124,19 @@ public struct History: Codable, Sendable {
 /// Image is the JSON structure which describes some basic information about the image.
 /// This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
 public struct Image: Codable, Sendable {
+    enum CodingKeys: String, CodingKey {
+        case created
+        case author
+        case architecture
+        case os
+        case osVersion = "os.version"
+        case osFeatures = "os.features"
+        case variant
+        case config
+        case rootfs
+        case history
+    }
+
     /// created is the combined date and time at which the image was created, formatted as defined by RFC 3339, section 5.6.
     public let created: String?
 

--- a/Sources/ContainerizationOCI/Platform.swift
+++ b/Sources/ContainerizationOCI/Platform.swift
@@ -297,6 +297,8 @@ extension Platform: Codable {
     enum CodingKeys: String, CodingKey {
         case os = "os"
         case architecture = "architecture"
+        case osVersion = "os.version"
+        case osFeatures = "os.features"
         case variant = "variant"
     }
 
@@ -304,6 +306,8 @@ extension Platform: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(os, forKey: .os)
         try container.encode(architecture, forKey: .architecture)
+        try container.encodeIfPresent(osVersion, forKey: .osVersion)
+        try container.encodeIfPresent(osFeatures, forKey: .osFeatures)
         try container.encodeIfPresent(variant, forKey: .variant)
     }
 
@@ -317,8 +321,10 @@ extension Platform: Codable {
         guard let os else {
             throw ContainerizationError(.invalidArgument, message: "missing OS")
         }
+        let osVersion = try container.decodeIfPresent(String.self, forKey: .osVersion)
+        let osFeatures = try container.decodeIfPresent([String].self, forKey: .osFeatures)
         let variant = try container.decodeIfPresent(String.self, forKey: .variant)
-        self.init(arch: architecture, os: os, variant: variant)
+        self.init(arch: architecture, os: os, osVersion: osVersion, osFeatures: osFeatures, variant: variant)
     }
 }
 

--- a/Tests/ContainerizationOCITests/OCIImageTests.swift
+++ b/Tests/ContainerizationOCITests/OCIImageTests.swift
@@ -38,6 +38,36 @@ struct OCITests {
         #expect(image.rootfs.type == "foo")
     }
 
+    @Test func platformDecodesAndEncodesSpecOSKeys() throws {
+        let json = """
+                {"architecture":"amd64","os":"windows","os.version":"10.0.17763.1234","os.features":["win32k"]}
+            """
+        let decoded = try JSONDecoder().decode(ContainerizationOCI.Platform.self, from: json.data(using: .utf8)!)
+        #expect(decoded.osVersion == "10.0.17763.1234")
+        #expect(decoded.osFeatures == ["win32k"])
+
+        let encoded = String(decoding: try JSONEncoder().encode(decoded), as: UTF8.self)
+        #expect(encoded.contains("\"os.version\":\"10.0.17763.1234\""))
+        #expect(encoded.contains("\"os.features\":[\"win32k\"]"))
+        #expect(!encoded.contains("osVersion"))
+        #expect(!encoded.contains("osFeatures"))
+    }
+
+    @Test func imageConfigDecodesAndEncodesSpecOSKeys() throws {
+        let json = """
+                {"architecture":"amd64","os":"windows","os.version":"10.0.17763.1234","os.features":["win32k"],"rootfs":{"type":"layers","diff_ids":[]}}
+            """
+        let decoded = try JSONDecoder().decode(ContainerizationOCI.Image.self, from: json.data(using: .utf8)!)
+        #expect(decoded.osVersion == "10.0.17763.1234")
+        #expect(decoded.osFeatures == ["win32k"])
+
+        let encoded = String(decoding: try JSONEncoder().encode(decoded), as: UTF8.self)
+        #expect(encoded.contains("\"os.version\":\"10.0.17763.1234\""))
+        #expect(encoded.contains("\"os.features\":[\"win32k\"]"))
+        #expect(!encoded.contains("osVersion"))
+        #expect(!encoded.contains("osFeatures"))
+    }
+
     @Test func descriptor() {
         let platform = ContainerizationOCI.Platform(arch: "arm64", os: "linux")
         let descriptor = ContainerizationOCI.Descriptor(mediaType: MediaTypes.descriptor, digest: "123", size: 0, platform: platform)


### PR DESCRIPTION
`Platform` declares `osVersion` and `osFeatures`, but its `CodingKeys` only lists `os`, `architecture` and `variant`, so both fields are dropped on decode and never encoded. `Image` declares the same two fields with no `CodingKeys` at all, so it decodes nothing for them and writes them out as `osVersion` and `osFeatures`. The OCI image spec names these keys `os.version` and `os.features`: specs-go/v1/descriptor.go tags `OSVersion` with `json:"os.version,omitempty"` and `OSFeatures` with `json:"os.features,omitempty"`, and config.go embeds `Platform` in `Image`, so the config uses the same two keys. Any image that sets them loses that metadata the moment it is parsed. ImageStore+Import.swift:246 builds a `Platform` from `config.osFeatures` and always gets nil, and an index re-encoded on export or push comes back missing `os.version`, which is what containerd and docker match manifests on.

This adds the two spec keys to `Platform.CodingKeys` with the matching encode and decode calls, gives `Image` an explicit `CodingKeys`, and leaves the Swift property names, equality and hashing unchanged. Two round-trip tests in OCIImageTests decode JSON containing `os.version` and `os.features` for `Platform` and `Image`, assert the values, then re-encode and assert the spec key names appear. Reverting the two source files makes both fail on the decoded values being nil; with the fix in place `swift test --filter OCITests` passes all 127 tests.

One compatibility note: `Image` had no `CodingKeys` before, so JSON written by earlier versions of this package with `osVersion` or `osFeatures` set will now read those two fields as nil, which is what the spec-keyed fields already read as before this change. No such JSON is produced in this repo's tests, and registries and containerd only ever emit the spec keys.
